### PR TITLE
Update streaming doc after recent changes

### DIFF
--- a/documentation/streaming-search.html
+++ b/documentation/streaming-search.html
@@ -139,12 +139,12 @@ This is the memory used to keep documents searchable -
 adding to this is the memory used per search.
 Applications with a low query rate can optimize for static memory use by presetting
 the document meta store ensuring it is never <a href="content/setup-proton-tuning.html#resizing">re-sized</a>
-- example setting 500M documents per node:
+- example setting 5M documents per node:
 <pre>
 &lt;tuning&gt;
   &lt;searchnode&gt;
     &lt;resizing&gt;
-      &lt;initialdocumentcount&gt;500000000&lt;/initialdocumentcount&gt;
+      &lt;initialdocumentcount&gt;5000000&lt;/initialdocumentcount&gt;
 </pre>
 Note: This is a hard limit if the node does not have memory to keep more than one attribute in memory!
 </p>
@@ -166,12 +166,11 @@ Parallelism is configured using <a href="reference/services-content.html#thread"
 
 <h3 id="summary-store-direct-io-and-cache">Summmary store: Direct IO and cache</h3>
 <p>
-For better control of memory usage, use direct IO for reads -
-this makes the OS buffer cache size smaller and proton memory usage larger.
-The summary cache does not apply to streaming search -
-the cache is only used to cache hits for intexed search.
-Set to zero if only streaming search is used:
-ToDo: check this - is this the visit cahce size as well?
+For better control of memory usage, use direct IO for reads when summary cache is enabled -
+this makes the OS buffer cache size smaller and more predictable performance.
+The summary cache will cache recent entries and increase performance for users or groups which does repeated accesses.
+Below setting sets aside 1GB for summary cache. 
+
 <pre>
 &lt;engine&gt;
   &lt;proton&gt;
@@ -184,25 +183,9 @@ ToDo: check this - is this the visit cahce size as well?
           &lt;/io&gt;
           &lt;store&gt;
 <span style="background-color: yellow;">            &lt;cache&gt;
-              &lt;maxsize&gt;0&lt;/maxsize&gt;
+              &lt;maxsize&gt;1073741824&lt;/maxsize&gt;
             &lt;/cache&gt;</span>
 </pre>
-</p>
-
-<h3 id="visit-cache">Visit-cache</h3>
-<p>
-If there us data locality in the queries (e.g. repeated personal queries),
-use the <em>visit cache</em>:
-<pre>
-&lt;content id="mycluster" version="1.0"&gt;
-  &lt;config name="vespa.config.search.core.proton"&gt;
-    &lt;summary&gt;
-<span style="background-color: yellow;">      &lt;cache&gt;
-        &lt;allowvisitcaching&gt;true&lt;/allowvisitcaching&gt;
-      &lt;/cache&gt;</span>
-    &lt;/summary&gt;
-</pre>
-<strong>ToDo:</strong> Add details on cache size
 </p>
 
 


### PR DESCRIPTION
Remove allowvisitcache as default has been flipped, cache is controlled as with indexed search. 

Please review the last parts here about searchable-copies, my understanding is that the default searchable copies is equal to redundancy and better to simply remove searchable-copies entirely from the example.