### PR TITLE
Freshen up the config intro

### DIFF
--- a/documentation/cloudconfig/config-introduction.html
+++ b/documentation/cloudconfig/config-introduction.html
@@ -1,198 +1,195 @@
 ---
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "The Cloud Configuration System"
+title: "Cloud Configuration"
 ---
 
 <p>
-This document gives an overview of the Cloud Config System (CCS), which is an integral
-part of Vespa. Reading this document is not necessary in order to use Vespa or to develop
-Java components for the Vespa container. For this purpose, please refer to
-<a href="../configuring-components.html">Configuring components</a> instead.
-</p>
-<p>
-The problem of configuring cloud nodes can be divided into three
-parts, each addressed by different solutions:
-</p>
+The Cloud Config System (CCS) is an integral part of Vespa.
+To use it, it suffices to read about <a href="application-packages.html">application packages</a> -
+this article details the inner workings of Cloud Configuration.
+The problem of configuring cloud nodes can be divided into three parts,
+each addressed by different solutions:
 <ul>
   <li><strong>Node system level configuration:</strong> Configure OS
-  level settings such as time zone as well as user privileges on the
-  node.</li>
+  level settings such as time zone as well as user privileges on the node.</li>
   <li><strong>Package management</strong>: Ensure that the correct
-  set of software packages is installed on the nodes. This
-  functionality is provided by three tools working together.</li>
+  set of software packages is installed on the nodes.
+  This functionality is provided by three tools working together.</li>
   <li><strong>Cloud configuration:</strong> Starts the configured
   set of processes on each node with their configured startup
-  parameters and provides dynamic configuration to the modules run by
-  these services.<em>Configuration</em> here is any data which
-    <ul>
-       <li> Can not be fixed at compile time.</li>
-       <li> Is static most of the time.</li>
-    </ul>
+  parameters and provides dynamic configuration to the modules run by these services.
+  <em>Configuration</em> here is any data which:
+  <ul>
+    <li>can not be fixed at compile time</li>
+    <li>is static most of the time</li>
+  </ul>
   </li>
 </ul>
-<p>
-Note that by these definitions we may allow all the cloud nodes to
-have the same software packages (disregarding version differences,
-discussed later) because variations in what services are run on each
-node and in their behavior can be achieved entirely by using CCS. This
-allows us to manage the complexity of node variations completely
-within the cloud configuration system rather than across multiple
-systems.
-</p>
-<p>
-CCS makes the following assumptions about the nodes using it:
-</p>
+Note that by these definitions, we may allow all the cloud nodes to
+have the same software packages (disregarding version differences, discussed later),
+because variations in what services are run on each node and in their behavior
+can be achieved entirely by using CCS.
+This allows us to manage the complexity of node variations completely
+within the cloud configuration system, rather than across multiple systems.
+</p><p>
+Configuring a system can be divided into:
 <ul>
-   <li> Each node has the software packages needed to run the
-   configuration system and any services which will be configured to
-   run on the node. This usually means that all nodes have the same
-   software, although this is not a requirement.</li>
-   <li> Each node has set <a href="../setting-vespa-variables.html">VESPA_CONFIGSERVERS</a>
-     listing the active configuration servers.</li>
-   <li>Each node knows its fully qualified domain name.</li>
-</ul>
-
-
-
-<h1 id="configuration">Cloud Configuration</h1>
-<p>
-The responsibility of configuring a system can be divided into two largely
-independent parts
-</p>
-<ul>
-   <li> <strong>Configuration delivery:</strong> Definition of
-   individual configurations, API's for requesting and accessing
-   configuration, and the mechanism for delivering configurations from
-   their source to the receiving components.</li>
-   <li> <strong>Configuration assembly:</strong> Assembly of a complete
-   set of configurations for delivery from the inputs provided by the
-   parties involved in configuring the system. </li>
+  <li> <strong>Configuration assembly:</strong> Assembly of a complete
+  set of configurations for delivery from the inputs provided by the
+  parties involved in configuring the system</li>
+  <li> <strong>Configuration delivery:</strong> Definition of
+  individual configurations, API's for requesting and accessing
+  configuration, and the mechanism for delivering configurations from
+  their source to the receiving components</li>
  </ul>
-<p> 
 This division allows the problem of reliable configuration delivery in
-large distributed systems to be addressed in configuration delivery
+large distributed systems to be addressed in configuration delivery,
 while the complexities of assembling complete configurations in the
 cloud environment can be treated as a vm-local design problem.
-</p>
-<p>  
-An important feature of CCS is the nature of the interface between the delivery
-and assembly subsystems. The assembly subsystem creates as output a (Java)
-object model of the desired distributed system. The delivery subsystem queries
-this model to obtain concrete configurations of all the components of the
-system. This allows the assembly subsystem to accept higher level and simpler to
-use abstractions as input and automatically derive detailed configurations with
-the correct interdependencies. This division insulates the external interface
-and the components being configured from changes in each other. In addition the
-system model provides the home for logic implementing node/component instance
-variations of configuration.
-</p>
-<p> 
-The next two sections will discuss the delivery and assembly
-subsystems separately.
+</p><p>
+An important feature of CCS is the nature of the interface between the delivery and assembly subsystems.
+The assembly subsystem creates as output a (Java) object model of the distributed system.
+The delivery subsystem queries this model to obtain concrete configurations
+of all the components of the system.
+This allows the assembly subsystem to accept higher level, and simpler to use,
+abstractions as input and automatically derive detailed configurations with the correct interdependencies.
+This division insulates the external interface and the components being configured
+from changes in each other.
+In addition, the system model provides the home for logic
+implementing node/component instance variations of configuration.
 </p>
 
 
 
-<h2 id="delivery">Configuration Delivery</h2>
+<h2 id="configuration-assembly">Configuration assembly</h2>
+<p>
+Config assembly is the process of turning the configuration input sources
+into an object model of the desired system,
+which can respond to queries for configs given a name and config id.
+Config assembly for cloud systems can become complex,
+because it involves merging information owned by multiple parties:
+<ul>
+  <li><strong>Cloud operations</strong>
+    own the machines on the cloud and controls assignment of nodes to services/applications</li>
+  <li><strong>Cloud service providers</strong>
+    own services which hosts multiple applications running on the cloud</li>
+  <li><strong>Cloud applications</strong>
+    define the final applications running on cloud nodes and shared services</li>
+</ul>
+The current config model assembly procedure uses a single source -
+the <a href="application-packages.html">application package</a>.
+The application package is a directory structure containing defined files
+and sub-directories which together completely defines the system -
+including which nodes belong in the system,
+which services they should run and the configuration of these services and their components.
+When the application deployer wants to change the application,
+<a href="application-packages.html#deploy">vespa-deploy prepare</a> is issued to a config server,
+with the application package as argument.
+</p><p>
+At this point the system model is assembled and validated
+and any feedback is issued to the deployer.
+If the deployer decides to make the new configuration active,
+a <a href="application-packages.html#deploy">vespa-deploy activate</a> is then issued,
+causing the config server cluster to switch to the new system model
+and respond with new configs on any active subscriptions
+where the new system model caused the config to change.
+This ensures that subscribers gets new configs timely on changes,
+and that the changes propagated are the minimal set
+such that small changes to an application package
+causes correspondingly small changes to the system.
+</p>
+<img src="img/VespaAssemblySmaller.png" alt="VespaAssemblySmaller.png" />
+<p>
+The config model itself is pluggable, so that cloud service providers may write
+plugins for assembling a particular service.
+The plugins are written in Java, and is installed together with the CCS.
+Service plugins define their own syntax for specifying services
+that may be configured by cloud applications.
+This allows the applications to be specified in an abstract manner,
+decoupled from the configuration that is delivered to the components.
+</p>
+
+
+
+<h2 id="configuration-delivery">Configuration delivery</h2>
 <p>
 Configuration delivery encompasses the following aspects:
-</p>
 <ul>
-  <li> Definition of configurations</li>
-  <li> The component view (API) of configuration</li>
-  <li> Configuration delivery mechanism</li>
+  <li>Definition of configurations</li>
+  <li>The component view (API) of configuration</li>
+  <li>Configuration delivery mechanism</li>
 </ul>
-<p>     
 These aspects work together to realize the following goals:
-</p>
 <ul>
   <li> Eliminate inconsistency between code and configuration.</li>
   <li> Eliminate inconsistency between the desired configuration and
    the state on each node.</li>
   <li> Limit temporal inconsistencies after reconfiguration.</li>
 </ul>
-<p>
-The next three subsections discusses the three aspects above, followed
-by subsections on two special concerns - bootstrapping and system
-upgrades.
+The next three subsections discusses the three aspects above,
+followed by subsections on two special concerns - bootstrapping and system upgrades.
 </p>
 
 
-<h3 id="config-definitions">Configuration Definitions</h3>
+<h3 id="configuration-definitions">Configuration definitions</h3>
 <p>
-A <em>configuration</em> is a set of simple or array key-values with a
-name and a type which can possibly be nested. For example:
-</p>
-   
+A <em>configuration</em> is a set of simple or array key-values
+with a name and a type which can possibly be nested. Example:
 <pre>
-myProperty &quot;myvalue&quot;
+myProperty "myvalue"
 myArray[1]
-myArray[0].key1 &quot;someValue&quot;
+myArray[0].key1 "someValue"
 myArray[0].key2 1337 
 </pre>
-
-<p>   
 The <em>type definition</em> (or class) of a configuration object
 defines and documents the set of fields a configuration may contain
-with their types and default values. It has a name as well as a
-namespace. For example, the above config instance may have this
-definition:
-</p>
-   
+with their types and default values.
+It has a name as well as a namespace.
+For example, the above config instance may have this definition:
 <pre>
 namespace=foo.bar
 
 # Documentation of this key
-myProperty string default=&quot;foo&quot;
+myProperty string default="foo"
 
 # etc.
 myArray[].key1 string
 myArray[].key2 int default=0
 </pre>
-
-<p>
-An individual config typically contains a coherent set of settings
-regarding some topic, such as "logging" or "indexing". A complete
-system consists of many instances of many config types.
+An individual config typically contains a coherent set of settings regarding some topic,
+such as <em>logging</em> or <em>indexing</em>.
+A complete system consists of many instances of many config types.
 </p>
 
 
-<h3 id="component-view">The Component View of Configuration</h3>
+<h3 id="component-view">Component view</h3>
 <p>
 Individual components of a system consumes one or more such configs and
-use their values to influence their behavior.  APIs are needed for
-<em>requesting</em> configs and for <em>accessing</em> the values of
-those configs as they are provided.
-</p>
-<p>
-<strong>Access</strong> to configs happens through a (Java or C++) class
-generated from the config definition file. This ensures that any
-inconsistency between the fields declared in a config type and the
-expectations of the code accessing it are caught at compile time. The
-config definition is best viewed as another class with an alternative
-form of source syntax belonging to the components consuming it. A
-Maven target is provided for generating such classes from config
-definition types.
-</p>
-<p>   
-Components may use two different methods for
-<strong>requesting</strong> configurations (only Java code is shown,
-here see the <a href="configapi-dev-cpp.html">Developing with the C++
-Config API</a> doc for how to do this in C++):
-</p>
+use their values to influence their behavior.
+APIs are needed for <em>requesting</em> configs
+and for <em>accessing</em> the values of those configs as they are provided.
+</p><p>
+<em>Access</em> to configs happens through a (Java or C++) class
+generated from the config definition file.
+This ensures that any inconsistency between the fields declared in a config type and the
+expectations of the code accessing it are caught at compile time.
+The config definition is best viewed as another class with an alternative
+form of source syntax belonging to the components consuming it.
+A Maven target is provided for generating such classes from config definition types.
+</p><p>
+Components may use two different methods for <em>requesting</em> configurations
+(refer to
+<a href="configapi-dev-cpp.html">Config API</a> for C++ code):
 <ul>
   <li>
-    <p>
     <strong>Subscription:</strong> The component sets up
-    <em>ConfigSubscriber</em>, then subscribes to one or more
-    configs. This is the simple approach, there
-    are <a href="configapi-dev-java.html">other ways of</a> getting
-    configs too.
-    </p>
+    <em>ConfigSubscriber</em>, then subscribes to one or more configs.
+    This is the simple approach, there are <a href="configapi-dev-java.html">other ways of</a>
+    getting configs too:
 <pre>
 ConfigSubscriber subscriber = new ConfigSubscriber();
-ConfigHandle&lt;MydConfig&gt; handle = subscriber.subscribe(MyConfig.class, &quot;myId&quot;); 
-if (!subscriber.nextConfig()) throw new RuntimeException(&quot;Config timed out.&quot;);
+ConfigHandle&lt;MydConfig&gt; handle = subscriber.subscribe(MyConfig.class, "myId"); 
+if (!subscriber.nextConfig()) throw new RuntimeException("Config timed out.");
 if (handle.isChanged()) {
   String message = handle.getConfig().myKey();
   # &hellip;consume the rest of this config
@@ -200,15 +197,12 @@ if (handle.isChanged()) {
 </pre>
   </li>
   <li>
-  <p>
   <strong>Dependency injection:</strong> The component declares its
-  config dependencies in the constructor and subscriptions are set up
-  on its behalf. When changed configs are available a new instance of
-  the component is created. The advantage of this method is that
-  configs are immutable throughout the lifetime of the component such
-  that no thread coordination is required. This method is currently
-  only available in Java using the jdisc container.
-  </p>
+  config dependencies in the constructor and subscriptions are set up on its behalf.
+  When changed configs are available a new instance of the component is created.
+  The advantage of this method is that configs are immutable throughout the lifetime of the component
+  such that no thread coordination is required.
+  This method is currently only available in Java using the <a href="../jdisc/index.html">Container</a>.
 <pre>
 public MyComponent(MyConfig config) {
   String myKey = config.myKey();
@@ -217,141 +211,76 @@ public MyComponent(MyConfig config) {
 </pre>
   </li>
 </ul>
-<p>
-For unit testing <a
-href="configapi-dev-java.html#unit-testing">configs can be created
-with Builders</a>, submitted directly to components.
+For unit testing,
+<a href="configapi-dev-java.html#unit-testing">configs can be created with Builders</a>,
+submitted directly to components.
 </p>
 
 
-<h3 id="delivery-mechanism">Config Delivery Mechanism</h3>
+<h3 id="delivery-mechanism">Delivery mechanism</h3>
 <p>
 The config delivery mechanism is responsible for ensuring that a new
-config instance is delivered to each subscribing component in a timely
-fashion each time there is a change to the system model causing that
-config instance to change. A config subscription is identified by two
-parameters, the config definition name and namespace and the config id
-used to identify the particular component instance making the
-subscription. The in-process config library will forward these
-subscription requests to a node local config proxy which provides
-caching and fan-in from processes to node. The proxy in turn issues
-these subscriptions to a node in the configuration server cluster,
-each of which hosts a copy of the system model and resolves config
-requests by querying the system model. To provide config server
-failover the config subscriptions are implemented as long-timeout gets
-which are immediately resent when they time out, but conceptually this
-is best understood as push subscriptions.
+config instance is delivered to subscribing components in a timely fashion,
+each time there is a change to the system model causing that config instance to change.
+A config subscription is identified by two parameters,
+the config definition name and namespace
+and the <a href="configapi-dev.html#config-id">config id</a>
+used to identify the particular component instance making the subscription.
+The in-process config library will forward these subscription requests to a node local
+<a href="../reference/config-proxy.html">config proxy</a>,
+which provides caching and fan-in from processes to node.
+The proxy in turn issues these subscriptions to a node in the configuration server cluster,
+each of which hosts a copy of the system model and resolves config requests by querying the system model.
+To provide config server failover,
+the config subscriptions are implemented as long-timeout gets,
+which are immediately resent when they time out,
+but conceptually this is best understood as push subscriptions.
 </p>
 <img src="img/CloudConfigControlFlowSmaller.png" alt="CloudConfigControlFlowSmaller.png" />
 <p>
-As configs are not stored as files locally on the nodes there is no
-possibility of inconsistencies due to local edits, or of nodes coming
-out of maintenance with a stale configuration.  As configuration
-changes are pushed as soon as the config server cluster allows, time
-inconsistencies during reconfigurations are minimized, although not
-avoided as there is no global transaction.
+As configs are not stored as files locally on the nodes,
+there is no possibility of inconsistencies due to local edits,
+or of nodes coming out of maintenance with a stale configuration.
+As configuration changes are pushed as soon as the config server cluster allows,
+time inconsistencies during reconfigurations are minimized,
+although not avoided as there is no global transaction.
 </p>
 
 
 <h3 id="bootstrapping">Bootstrapping</h3>
 <p>
-Until now we have described systems in their steady state, but how do
-a set of processes, hosting a set of components, each initiating
-subscriptions using their own unique config id's come to be? This is
-the bootstrapping process.
-</p>
-<p>
-At the outset, a single <a href="../config-sentinel.html">config-sentinel</a>
-process is started on all nodes.
-This process gets the config server names from <a href="../setting-vespa-variables.html">
-VESPA_CONFIGSERVERS</a> and issues a subscription
-for a process list config using the host name as the config id. This
-config lists the processes to be started on the node along with the
-config id to assign to each, typically the logical name of that
-service instance. Those processes can then in turn instantiate
-internal components, each assigned the same or another config id, and
-instantiating further components, etc. This cascade of events brings
-the system into steady state from an initial state where all nodes are
-the same and only knows the names of the config servers.
+Each Vespa node runs a <a href="../config-sentinel.html">config-sentinel</a> process
+which start and maintains services run on a node.
 </p>
 
 
 <h3 id="upgrades">System upgrades</h3>
 <p>
-The configuration server will up/downgrade between config versions on
-the fly on minor upgrades which causes discrepancies between the
-config definitions requested from those produced by the
-configuration model. Major upgrades which involve incompatible changes
-to the configuration protocol or the system model, however, requires a
-special procedure. A configured node can be
-<strong>detached</strong> from the configuration system. On detachment,
-the node will stop listening to the config server and instead keep
-serving its current config from its local snapshot. To avoid losing
-the snapshot on restart, the proxy will save the config snapshot on
-disk during detachment.
+The configuration server will up/downgrade between config versions on the fly on minor upgrades
+which causes discrepancies between the config definitions requested
+from those produced by the configuration model.
+Major upgrades, which involve incompatible changes to the configuration protocol or the system model,
+requires a <a href="../reference/config-proxy.html">procedure</a>.
 </p>
+
+
+
+<h2 id="notes">Notes</h2>
 <p>
-With this operation available, the procedure goes as follows: Detach
-all nodes, upgrade the config server and reassemble its
-configuration. Upgrade and reattach the configured nodes one by one.
-</p>
-
-
-
-<h2 id="configuration-assembly">Configuration Assembly</h2>
-<p>
-Config assembly is the process of turning the configuration input
-sources into an object model of the desired system which can respond
-to queries for configs given a name and config id. Config
-assembly for cloud systems can become complex, because it involves
-merging information owned by multiple parties into a coherent whole:
-</p>
+Find more information for using the Cloud config API in the
+<a href="configapi-dev.html">reference doc</a>.
+</p><p>
+CCS makes the following assumptions about the nodes using it:
 <ul>
-   <li> <strong>Cloud operations</strong> own the machines on the
-   cloud and controls assignment of nodes to
-   services/applications.</li>
-   <li> <strong>Cloud service providers</strong> own services which
-   hosts multiple applications running on the cloud.</li>
-   <li> <strong>Cloud applications</strong> define the final
-   applications running on cloud nodes and shared services.</li>
+  <li>All nodes have the software packages needed to run the
+    configuration system and any services which will be configured to run on the node.
+    This usually means that all nodes have the same software,
+    although this is not a requirement</li>
+  <li>All nodes have set <a href="../setting-vespa-variables.html">VESPA_CONFIGSERVERS</a></li>
+  <li>All nodes know its fully qualified domain name</li>
 </ul>
-<p>
-The current config model assembly procedure uses a single source
-- the <strong>application package</strong>. The application package, owned by the
-application, is a directory structure containing some defined files
-and sub-directories which together completely defines the system -
-including which nodes belong in the system, which services they should
-run and the configuration of these services and their components. When
-the application deployer wants to change the application, a <strong>vespa-deploy</strong>
-command is issued to a config server, with the application package as
-argument.
+</p><p>
+Reading this document is not necessary in order to use Vespa or to develop
+Java components for the Vespa container - for this purpose, refer to
+<a href="../configuring-components.html">Configuring components</a> instead.
 </p>
-<p>
-At this point the system model is assembled and validated
-and any feedback is issued to the deployer. If the deployer decides to
-make the new configuration active a <strong>commit</strong> command is then issued,
-causing the config server cluster to switch to the new system model
-and respond with new configs on any active subscriptions where the new
-system model caused the config to change. This ensures that
-subscribers gets new configs timely on changes, and that the changes
-propagated are the minimal set such that small changes to an
-application package causes correspondingly small changes to the
-system.
-</p>
-<img src="img/VespaAssemblySmaller.png" alt="VespaAssemblySmaller.png" />
-<p>
-The config model itself is pluggable, so that cloud service providers may write
-plugins for assembling a particular service. The plugins are written in Java,
-and is installed together with the CCS. Service plugins define their own syntax
-for specifying services that may be configured by cloud applications. This
-allows the applications to be specified in an abstract manner, decoupled from
-the configuration that is delivered to the components.
-</p>
-
-
-<h2 id="reference">Reference</h2>
-<p>
-Further information in the <a href="configapi-dev.html">reference doc</a>
-</p>
-
-

--- a/documentation/config-sentinel.html
+++ b/documentation/config-sentinel.html
@@ -5,12 +5,33 @@ title: "Config sentinel"
 
 <p>
 The config sentinel starts and stops services -
-and restart failed services unless are manually stopped.
+and restart failed services unless are manually stopped - in short:
+<ol>
+  <li>
+    At cluster start, a <em>config-sentinel</em> process is started on all nodes.
+  </li><li>
+    This process reads the config server names from
+    <a href="setting-vespa-variables.html">VESPA_CONFIGSERVERS</a>.
+    It picks a config server and issues a subscription for a process list config,
+    using its hostname as the <a href="cloudconfig/configapi-dev.html#config-id">config id</a>.
+    It will retry using other config servers in case some are down.
+  </li><li>
+    The config for the config-sentinel (the process list)
+    lists the processes to be started on the node,
+    along with the <em>config id</em> to assign to each,
+    typically the logical name of that service instance.
+    The processes are started with the config id as argument -
+    see example output below, like <em>id="search/qrservers/qrserver.0"</em>
+  </li><li>
+    The processes can then in turn instantiate internal components,
+    each assigned the same or another config id, and instantiating further components.
+</ol>
 The config sentinel runs a telnet service which can be used to list,
 start and stop the services supposed to run on that node.
 The port number is 19098 by default,
-use the <a href="reference/vespa-model-inspect.html">Vespa Model Inspector</a> to verify.
-The service name is <code>config-sentinel</code>, and the port is tagged <em>telnet interactive</em>:
+use the <a href="reference/vespa-model-inspect.html">Vespa Model Inspector</a> to verify -
+the service name is <code>config-sentinel</code>, and the port is tagged <em>telnet interactive</em>.
+Open the interface:
 <pre>
 $ telnet localhost 19098
 </pre>

--- a/documentation/reference/config-proxy.html
+++ b/documentation/reference/config-proxy.html
@@ -48,8 +48,29 @@ The config proxy has two modes:
     </tr>
   </tbody>
 </table>
-The mode can be set with:
+</p>
+
+
+
+<h2 id="major-vespa-software-upgrade">Major Vespa software upgrade</h2>
+<p>
+Use the <em>memorycache</em> mode for incompatible major upgrades.
+A configured node can be <em>detached</em> from the configuration system.
+On detachment, the node will stop listening to the config server
+and instead keep serving its current config from its local snapshot:
+<ol>
+  <li>
+    Detach all nodes using
 <pre>
-$ vespa-configproxy-cmd -m setmode &lt;mode&gt;
+$ vespa-configproxy-cmd -m setmode memorycache
 </pre>
+  </li><li>
+    Upgrade the config servers
+  </li><li>
+    Deploy the application package
+  </li><li>
+    Stop, upgrade and start the configured nodes one by one.
+    As the default is using the config servers, there is no need to set the mode again
+  </li>
+</ol>
 </p>


### PR DESCRIPTION
- better linkage to other docs
- move relevant pieces to config-proxy and config-sentinel, link instead
- better format, linkbreaks for easier editing
- reorder - assembly before delivery is better flow
- the text is still a bit heavy, with long sentences - rewrite later

@hmusum please merge