### PR TITLE
Update docs to use 'package' in custom def files.

### DIFF
--- a/documentation/configuring-components.html
+++ b/documentation/configuring-components.html
@@ -40,7 +40,7 @@ Write a <a href="reference/config-files.html#config-definition-files">config def
 file and place it in the application's <code>src/main/resources/configdefinitions/</code>
 directory. E.g. <code>src/main/resources/configdefinitions/my-component.def</code>:
 <pre>
-namespace=example
+package=com.mydomain.mypackage
 
 myCode     int     default=42
 myMessage  string  default=""
@@ -57,9 +57,9 @@ $ mvn generate-resources
 </pre>
 This generates the config classes in <code>target/generated-sources/vespa-configgen-plugin/</code>.
 </p><p>
-In this example, the config definition file was named <em>my-component.def</em>,
-and the namespace used was <em>example</em> -
-this translates to a java class in <em>com.yahoo.example.MyComponentConfig</em>
+In the above example, the config definition file was named <em>my-component.def</em>,
+and its package declaration is <em>com.mydomain.myypackage</em>.
+Hence, the full name of the generated java class is <em>com.mydomain.mypackage.MyComponentConfig</em>
 </p><p>
 It is a good idea to generate the config classes first,
 <em>then</em> resolve dependencies and compile in the IDE.
@@ -73,7 +73,7 @@ The generated config class is now available for your component through
 <a href="jdisc/injecting-components.html">constructor injection</a>, which means that the
 component can declare the generated class as one of its constructor arguments:
 <pre>
-package com.yahoo.example;
+package com.mydomain.mypackage;
 
 public class MyComponent {
 
@@ -93,8 +93,8 @@ To override the default values of the config,
   values in <code>src/main/application/services.xml</code>. Following the above example:
 <pre>
 &lt;container version="1.0"&gt;
-    &lt;component id="com.yahoo.example.MyComponent"&gt;
-        &lt;config name="example.my-component"&gt;
+    &lt;component id="com.mydomain.mypackage.MyComponent"&gt;
+        &lt;config name="com.mydomain.mypackage.my-component"&gt;
             &lt;myCode&gt;132&lt;/myCode&gt;
             &lt;myMessage&gt;Hello, World!&lt;/myMessage&gt;
         &lt;/config&gt;
@@ -113,7 +113,7 @@ The generated config class provides a builder API that makes it easy to create
 config objects for unit testing. Below is an example that sets up a unit test for the
 <code>MyComponent</code> class from the previous example:
 <pre>
-import static com.yahoo.example.MyComponentConfig.*;
+import static com.mydomain.mypackage.MyComponentConfig.*;
 
 public class MyComponentTest {
 
@@ -152,7 +152,7 @@ config file reference</a> for details about the <code>path</code> config type.
 </p><p>
 Assume this config definition, named <code>my-component.def</code>:
 <pre>
-namespace=example
+package=com.mydomain.mypackage
 
 myFile path
 </pre>
@@ -161,8 +161,8 @@ the application package root) must be given in the component's configuration in
 <code>services.xml</code>:
 <pre>
 &lt;container version="1.0"&gt;
-    &lt;component id="com.yahoo.example.MyComponent"&gt;
-        &lt;config name="example.my-component"&gt;
+    &lt;component id="com.mydomain.mypackage.MyComponent"&gt;
+        &lt;config name="com.mydomain.mypackage.my-component"&gt;
             &lt;myFile&gt;my-files/my-file.txt&lt;/myFile&gt;
         &lt;/config&gt;
     &lt;/component&gt;
@@ -170,7 +170,7 @@ the application package root) must be given in the component's configuration in
 </pre>
 An example component that uses the file:
 <pre>
-package com.yahoo.example;
+package com.mydomain.mypackage;
 import java.io.File;
 
 public class MyComponent {

--- a/documentation/handler-tutorial.html
+++ b/documentation/handler-tutorial.html
@@ -45,7 +45,7 @@ The searcher uses custom configuration, where the config definition is in
 <a href="https://github.com/vespa-engine/sample-apps/blob/master/http-api-using-searcher/src/main/resources/configdefinitions/demo.def">
 demo.def</a>:
 <pre>
-namespace=demo
+package=com.yahoo.demo
 
 demo[].term string
 </pre>

--- a/documentation/jdisc/http-api-tutorial.html
+++ b/documentation/jdisc/http-api-tutorial.html
@@ -88,7 +88,7 @@ configuration, where the definition is in
 <a href="https://github.com/vespa-engine/sample-apps/blob/master/http-api-using-request-handlers-and-processors/src/main/resources/configdefinitions/demo.def">
   demo.def</a>:
 <pre>
-namespace=demo
+pacakge=com.yahoo.demo
 
 demo[].term string
 </pre>

--- a/documentation/jdisc/server-tutorial.html
+++ b/documentation/jdisc/server-tutorial.html
@@ -153,7 +153,7 @@ management, reconfiguration and so on available as needed. </p>
 The demo server requires a custom configuration class, it is defined in
 <code>components/src/main/resources/configdefinitions/hello-world-server.def</code>:
 <pre>
-namespace=demo
+package=com.mydomain.demo
 
 response string default="No config value given."
 port int
@@ -167,8 +167,8 @@ Notice how hyphens in the file name are converted to camel casing in the generat
 <pre>
 &lt;?xml version="1.0" encoding="utf-8" ?&gt;
 &lt;container version="1.0"&gt;
-    &lt;server id="com.mydomain.vespatest.HelloWorldServer" bundle="hello_world"&gt;
-        &lt;config name="demo.hello-world-server"&gt;
+    &lt;server id="com.mydomain.demo.HelloWorldServer" bundle="hello_world"&gt;
+        &lt;config name="com.mydomain.demo.hello-world-server"&gt;
             &lt;response&gt;Hello, world!
             &lt;/response&gt;
             &lt;port&gt;16889&lt;/port&gt;

--- a/documentation/jdisc/testing-configurable-components.html
+++ b/documentation/jdisc/testing-configurable-components.html
@@ -20,7 +20,7 @@ object, exactly the same as used during deployment.
 <p> Assume the config definition file <code>demo.def</code> containing the
 following schema:</p>
 <pre>
-namespace=demo
+package=com.mydomain.demo
 
 toplevel[].term string
 toplevel[].number int

--- a/documentation/reference/config-files.html
+++ b/documentation/reference/config-files.html
@@ -24,23 +24,17 @@ Vespa's builtin .def files are found in
 </p>
 
 
-<h3 id="namespace">Namespace</h3>
+<h3 id="package">Package</h3>
 <p>
-Namespace is a mandatory statement that is used to define the package for the generated java class.
+Package is a mandatory statement that is used to define the package for the generated java class.
 For <a href="../jdisc/container-components.html">container component</a> developers,
-it is recommended to use a separate namespace for each bundle that needs to export config classes,
+it is recommended to use a separate package for each bundle that needs to export config classes,
 to avoid conflicts between bundles that contain configurable components.
-Namespace must be the first non-comment line, and can only contain lower-case characters and dots:
+Package must be the first non-comment line, and can only contain lower-case characters and dots:
 <pre>
-namespace=myproject.config
+package=com.mydomain.mypacakge
 </pre>
-In this example, the generated class will belong to package <code>com.yahoo.myproject.config</code>.
-The <code>com.yahoo.</code> prefix will automatically be added to the java package name,
-and must not be included in the namespace statement.
-The reason for this is that the config system is a generic system
-that is used for other languages than Java.
 </p>
-
 
 <h3 id="parameter-names">Parameter names</h3>
 <p>
@@ -177,7 +171,7 @@ by setting the same config values in e.g. <em>handler</em> or <em>server</em> el
 </p><p>
 Given the following config definition, let's say its name is <code>example.def</code>:
 <pre>
-namespace=myproject
+package=com.mydomain.example
 
 stringVal string
 myArray[].name string
@@ -192,7 +186,7 @@ myFile path
 To set all the values for this config in <code>services.xml</code>,
 add the following xml at the desired element:
 <pre>
-&lt;config name="myproject.example"&gt;
+&lt;config name="com.mydomain.example"&gt;
   &lt;stringVal&gt;val&lt;/stringVal&gt;
   &lt;myArray&gt;
     &lt;item&gt;

--- a/documentation/reference/statistics-api.html
+++ b/documentation/reference/statistics-api.html
@@ -36,7 +36,7 @@ manager instance is acquired through dependency injection in the container.
 
 <h3>Example searcher</h3>
 <pre>
-package com.yahoo.example;
+package com.mydomain.example;
 
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -267,18 +267,19 @@ Assume a searcher plugin which tracks the number of hits returned each
 logging interval, and optionally tracks the mean (number of hits returned).
 First, one would create config definition as outlined in the documentation for general
 <a href="../jdisc/container-components.html#configurable_components">configurable
-components</a>, the configuration definition might look as follows:</p>
+components</a>. The config definition file could be named <code>hitrates.def</code> and
+might look as follows:
+</p>
 <pre>
-namespace=example
+package=com.mydomain.example
 
 ## Switch to control whether to log mean number of hits per query
 logmean bool default=false
 </pre>
 Then, we need a search which actually does the measurements, and also reads the configuration:
 <pre>
-package com.yahoo.example;
+package com.mydomain.example;
 
-import com.yahoo.example.HitratesConfig;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;


### PR DESCRIPTION
@hmusum, see also https://github.com/vespa-engine/sample-apps/pull/6
FYI: @bratseth, @kkraune 

A natural consequence is that we can and should use `com.mydomain` instead of `com.yahoo` as java package for sample code from now.
