### PR TITLE
move simple query language out of search-api.html

### DIFF
--- a/documentation/api.html
+++ b/documentation/api.html
@@ -32,7 +32,7 @@ title: "Vespa API and interfaces"
   <li><a href="search-api.html">Searching API</a></li>
   <li><a href="reference/search-api-reference.html">HTTP search API reference</a></li>
   <li><a href="query-language.html">YQL Query Language</a>,
-    <a href="reference/simple-query-language-syntax.html">Simple Query Language reference</a>,
+    <a href="reference/simple-query-language-reference.html">Simple Query Language reference</a>,
     <a href="boolean-search.html">Boolean Search</a></li>
   <li><a href="query-profiles.html">Vespa Query Profiles </a></li>
   <li><a href="grouping.html">Grouping API</a>,

--- a/documentation/reference/rank-features.html
+++ b/documentation/reference/rank-features.html
@@ -986,7 +986,7 @@ They are cheap to compute even if the query is very large.</td></tr>
       </p><p>
       <strong>NOTE:</strong>When the query vector end up being the
       same as your query, it is better to annotate your query terms with weights
-      (see <a href="simple-query-language-syntax.html#term-weight">term weight</a>) and use the nativeDotProduct feature instead.
+      (see <a href="simple-query-language-reference.html#term-weight">term weight</a>) and use the nativeDotProduct feature instead.
       This will run more efficiently and improve the correlation between
       results produced by the WAND operator and the final relevance score.</p>
     </td></tr>

--- a/documentation/reference/search-api-reference.html
+++ b/documentation/reference/search-api-reference.html
@@ -392,7 +392,7 @@ matches than the query.
 <tr><td>Default</td><td><em>Not set</em></td></tr>
 </table>
 <p>
-The <a href="simple-query-language-syntax.html">Simple Vespa Query Language</a> query string
+The <a href="simple-query-language-reference.html">Simple Vespa Query Language</a> query string
 specifying which documents to match in this query.
 </p>
 
@@ -461,7 +461,7 @@ The names of the sources to search, e.g one or more search clusters and/or feder
 <table class="table table-striped">
 <tr><td>Alias</td><td>type</td></tr>
 <tr><td>Values</td><td>web, all, any, phrase, yql, adv (deprecated) -
-  refer to <a href="simple-query-language-syntax.html">simple query language syntax</a></td></tr>
+  refer to <a href="simple-query-language-reference.html">simple query language reference</a></td></tr>
 <tr><td>Default</td><td>all</td></tr>
 </table>
 <p>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -2258,7 +2258,7 @@ Example: In a uri field <code>sourceurl</code>, search for documents from slashd
 query=sourceurl.hostname:slashdot
 </pre>
 URL hostnames also support <em>anchored searching</em>, see
-<a href="../reference/simple-query-language-syntax.html#url_field">search in URL fields</a>.
+<a href="../reference/simple-query-language-reference.html#url_field">search in URL fields</a>.
 </p><p>
 It is not possible to index uri-typed fields into a common index, i.e. it has
 to be indexed separately from other fields. If you need to combine URLs

--- a/documentation/reference/simple-query-language-reference.html
+++ b/documentation/reference/simple-query-language-reference.html
@@ -1,6 +1,6 @@
 ---
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "Simple Query Language Syntax"
+title: "Simple Query Language Reference"
 ---
 
 <p>
@@ -247,3 +247,64 @@ The URL <code>http://site.com/a)b</code> in this example could be
 quoted as following:
 <pre>(x url:http://site.com/a,b) y</pre>
 </p>
+
+
+
+<h2 id="examples">Examples</h2>
+<p>
+The <em>simple</em> query language syntax accepts any input string and makes the most of it.
+A basic query consists of words separated by spaces (encoded as %20). In addition,
+<ul>
+  <li>
+    A phrase can be searched by enclosing it in quotes, like
+    <code>"match exactly this"</code>
+  </li><li>
+    Phrases and words may be preceded by -, meaning documents <em>must not</em> contain this
+  </li><li>
+    Phrases and words may be preceded by +, meaning documents
+    <em>must</em> contain this, currently only in use for subtype <code>any</code>
+  </li><li>
+    Groups of words and phrases may be grouped using parenthesis, like
+    <code>-(do not match if all of these words matches)</code>
+  </li><li>
+    Each word or phrase may be preceded by an index or attribute name and a colon,
+    like <code>indexname:word</code>, to match in that index.
+    If the index name is omitted the index named <em>default</em> is searched.
+  </li>
+</ul>
+Any <em>noise</em> (characters not in indexes or attributes, and with no query language meaning)
+is ignored, all query strings are valid.
+The exception is queries which have no meaningful interpretation.
+An example is <code>-a</code>, which one would expect to return
+all documents <em>not</em> containing <em>a</em>.
+Vespa, however, will return the error message <em>Null query</em>.
+All the following examples are of type <em>all</em>.
+</p><p>
+Get all documents with the word <em>word</em>,
+having <em>microsoft</em> but not <em>bug</em> in the title:
+<pre>
+word title:microsoft -title:bug
+</pre>
+Search for all documents having the phrase "<em>to be or not not be</em>",
+but excluding those having <em>shakespeare</em> in the title:
+<pre>
+"to be or not to be" -title:shakespeare
+</pre>
+Get all documents with the word <em>Christmas</em> in the title that
+were last modified Christmas Day 2009:
+<pre>
+title:Christmas date:20091225
+</pre>
+Get documents on US Foreign politics, excluding those matching both
+rival presidential candidates:
+<pre>
+"us foreign politics" -(clinton trump)
+</pre>
+Get documents on US Foreign politics, including only those matching at
+least one of the rival presidential candidates:
+<pre>
+"us foreign politics" (clinton trump)
+</pre>
+</p>
+
+

--- a/documentation/search-api.html
+++ b/documentation/search-api.html
@@ -32,71 +32,14 @@ see <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>.
 The most important piece of the query request is the query string.
 The query string contains the specification of which results the search should return,
 typically some words which should be present in matching documents.
-The Vespa Query Language comes in two flavors:
-<ul>
-<li>The <strong>simple</strong> query language is intended to be usable directly
-    by end users. It has four
-    <a href="reference/simple-query-language-syntax.html#simple">subtypes</a>,
-    where <em>all</em> is the default.  Its main purpose
-    is <em>robustness</em> - it makes the most out of any strange piece
-    of text which may be given to a search engine by an end user.
-    This is the default in Vespa.</li>
-<li>The <strong>advanced</strong> query syntax is intended for programmatic
-    use. Queries are formulated in <a href="query-language.html">YQL</a>
-    which should be used when building applications.</li>
-</ul>
-See the <a href="reference/simple-query-language-syntax.html">simple query language reference</a>.
+Queries are formulated in <a href="query-language.html">YQL</a>.</p>
+Note: Also find the legacy
+<a href="reference/simple-query-language-reference.html">simple query language reference</a>.
 </p><p>
 If Vespa cannot determine a valid search expression from the query string,
 it will issue the error message <em>Null query</em>.
 To troubleshoot, add <a href="reference/search-api-reference.html#tracelevel">&amp;tracelevel=2</a>
-to the GET request. A missing query/yql parameter will also lead to this error message.
-</p>
-
-
-<h3 id="simple-query-syntax">Simple Query Syntax</h3>
-<p>
-The <em>simple</em> query language syntax accepts any input string and
-makes the most of it. A basic query consists of words separated by
-spaces (encoded as %20). In addition,
-<ul>
-<li>A phrase can be searched by enclosing it in quotes, like
-    <code>"match exactly this"</code></li>
-<li>Phrases and words may be preceded by -, meaning documents <em>must
-    not</em> contain this</li>
-<li>Phrases and words may be preceded by +, meaning documents
-    <em>must</em> contain this, currently only in use for
-    subtype <code>any</code></li>
-<li>Groups of words and phrases may be grouped using parenthesis, like
-    <code>-(do not match if all of these words matches)</code></li>
-<li>Each word or phrase may be preceded by an index or attribute name
-    and a colon, like <code>indexname:word</code>, to match in that
-    index. If the index name is omitted the index
-    named <em>default</em> is searched.</li>
-</ul>
-Any <em>noise</em> (characters not in indexes or attributes,
-and with no query language meaning) is ignored, all query strings are valid.
-The exception is queries which have no meaningful interpretation.
-An example is <code>-a</code>, which one would expect to return
-all documents <em>not</em> containing <em>a</em>.
-Vespa, however, will return the error message <em>Null query</em>.
-All the following examples are of type <em>all</em>.
-</p><p>
-Get all documents with the word <em>word</em>,
-having <em>microsoft</em> but not <em>bug</em> in the title:
-<pre>word title:microsoft -title:bug</pre>
-Search for all documents having the phrase "<em>to be or not not be</em>",
-but excluding those having <em>shakespeare</em> in the title:
-<pre>"to be or not to be" -title:shakespeare</pre>
-Get all documents with the word <em>Christmas</em> in the title that
-were last modified Christmas Day 2009:
-<pre>title:Christmas date:20091225</pre>
-Get documents on US Foreign politics, excluding those matching both
-rival presidential candidates:
-<pre>"us foreign politics" -(clinton trump)</pre>
-Get documents on US Foreign politics, including only those matching at
-least one of the rival presidential candidates:
-<pre>"us foreign politics" (clinton trump)</pre>
+to the GET request. A missing yql parameter will also lead to this error message.
 </p>
 
 
@@ -118,11 +61,8 @@ It is also possible to use locations for <a href="geo-search.html">Geo search</a
   </tr>
 </thead>
 <tbody>
-<tr><td><code>query</code></td>
+<tr><td><code>yql</code></td>
   <td>the query, described above</td></tr>
-<tr><td><code>type</code></td>
-  <td>the query type (all, web, any, phrase, adv), described
-      above</td></tr>
 <tr><td><code>offset</code></td>
   <td>the (0-base) offset into the results, used for paging through a
       set of hits</td></tr>
@@ -146,10 +86,6 @@ It is also possible to use locations for <a href="geo-search.html">Geo search</a
   <td>A floating point number giving number of seconds to wait for
       this query to finish. This overrides any default values set in query profiles,
       and any provider(backend) timeouts.</td></tr>
-<tr><td><code>select</code></td>
-  <td>specifies a grouping expression to do over the result set, see
-      the <a href="reference/grouping-syntax.html">grouping
-      reference</a>.</td></tr>
 </tbody>
 </table>
 </p>

--- a/documentation/streaming-search.html
+++ b/documentation/streaming-search.html
@@ -48,19 +48,19 @@ which can be specified either at query time or at configuration time:
   <tbody>
     <tr>
       <td>substring</td>
-      <td><a href="reference/simple-query-language-syntax.html#substring-searching">*bla*</a></td>
+      <td><a href="reference/simple-query-language-reference.html#substring-searching">*bla*</a></td>
       <td><a href="reference/search-definitions-reference.html#match">match:substring</a></td>
       <td>/search/?query=*bla*</td>
     </tr>
     <tr>
       <td>prefix</td>
-      <td><a href="reference/simple-query-language-syntax.html#prefix-searching">bla*</a></td>
+      <td><a href="reference/simple-query-language-reference.html#prefix-searching">bla*</a></td>
       <td><a href="reference/search-definitions-reference.html#match">match:prefix</a></td>
       <td>/search/?query=bla*</td>
     </tr>
     <tr>
       <td>suffix</td>
-      <td><a href="reference/simple-query-language-syntax.html#suffix-searching">*bla</a></td>
+      <td><a href="reference/simple-query-language-reference.html#suffix-searching">*bla</a></td>
       <td><a href="reference/search-definitions-reference.html#match">match:suffix</a></td>
       <td>/search/?query=*bla</td>
     </tr>

--- a/documentation/vespatoc.html
+++ b/documentation/vespatoc.html
@@ -223,7 +223,7 @@ title: "Vespa Documentation table of content"
 <h3>Queries and Results</h3>
 <ul>
   <li><a href="reference/search-api-reference.html">Search API reference</a></li>
-  <li><a href="reference/simple-query-language-syntax.html">Simple Query Language Syntax</a></li>
+  <li><a href="reference/simple-query-language-reference.html">Simple Query Language reference</a></li>
   <li><a href="reference/query-profile-reference.html">Query Profile reference</a></li>
   <li><a href="reference/semantic-rules.html">Query Rewriting - Semantic Rules Syntax</a></li>
   <li><a href="reference/advanced-search-operators.html">Advanced Search Operators</a></li>


### PR DESCRIPTION
- it is bad practise to put this in reference docs, but the alternative is creating a new doc
  - and the purpose is just to hide this, so added this as examples in /simple-query-language-reference.html
- /simple-query-language-reference.html renamed from -syntax
- fixed links
- now easier to write a better search-api.html and remove replace query= with yql instead

@bratseth 