### PR TITLE
Fix javadoc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,10 @@ Example:
 &lt;h2 id=&quot;my-nice-heading&quot;&gt;My nice Heading&lt;/h2&gt;
 If this algorithmic transformation is followed it is possible to link to this section using &lt;a href=&quot;doc.html#my-nice-heading&quot;&gt; without having to consult the html source of the page to find the right id.
 
+### Link to Javadoc
+
+* Link to javadoc for an artifact: http://javadoc.io/doc/com.yahoo.vespa/container-search
+* Link to javadoc for a package: http://javadoc.io/page/com.yahoo.vespa/container-search/latest/com/yahoo/search/federation/vespa/package-summary.html
+* Link to javadoc for a class: http://javadoc.io/page/com.yahoo.vespa/vespa-http-client/latest/com/yahoo/vespa/http/client/config/ConnectionParams.Builder.html
+
 *By Jon Bratseth in June 2016*

--- a/documentation/boolean-library.html
+++ b/documentation/boolean-library.html
@@ -48,8 +48,8 @@ Just as with Vespa boolean search, specify the <a href="boolean-search.html#inde
 to make the index more efficient and trade index size for query performance.
 This is set when creating a <code>PredicateIndexBuilder</code> object,
 and cannot be changed without creating a new <code>PredicateIndexBuilder</code>.
-Consult the <a href="/javadoc/">javadoc</a> for the <code>Config</code> class
-for more information on other configuration parameters.
+Check the <code><a href="http://javadoc.io/page/com.yahoo.vespa/predicate-search/latest/com/yahoo/search/predicate/Config.html">Config</a></code>
+class for more information on other configuration parameters.
 </p>
 
 <h3>Serializing the index</h3>

--- a/documentation/cloudconfig/configapi-dev-java.html
+++ b/documentation/cloudconfig/configapi-dev-java.html
@@ -69,17 +69,15 @@ In many cases one will do this from a thread which loops the
 <code>nextConfig()</code> call, and reconfigures your application if
 <code>isChanged()</code> is true.
 </p><p>
-The meaning of <code>motdserver2/0</code>, the second parameter to
-<code>subscribe()</code>, config id, is explained in the
-<a href="configapi-dev.html">main config API doc</a>.
-</p><p>
-The <a href="http://javadoc.io/doc/com.yahoo.vespa/config-lib">javadoc</a>
-for the <code>com.yahoo.config</code> package has all the details of the API.
+The second parameter to <code>subscribe()</code>, <em>"motdserver2/0"</em>,
+is the <a href="configapi-dev.html#config-id">config id</a>.
 </p><p>
 If one <code>ConfigSubscriber</code> subscribes to multiple configs,
 <code>nextConfig()</code> will only return true if the configs are of
-the same generation, i.e. they are "in sync". See the
-<a href="/javadoc/">javadoc</a> for details. Example:
+the same generation, i.e. they are "in sync".
+</p><p>
+See the
+<a href="http://javadoc.io/doc/com.yahoo.vespa/config-lib">com.yahoo.config</a> javadoc for details. Example:
 <pre>
 ConfigSubscriber subscriber = new ConfigSubscriber();
 ConfigHandle&lt;MotdConfig&gt; motdHandle = subscriber.subscribe(MotdConfig.class, "motdserver2/0");
@@ -125,10 +123,11 @@ or otherwise track config changes. If needed, use the generic method above.
 
 
 
+
 <h2 id="unit-testing">Unit testing config</h2>
 <p>
-When instantiating a <code>ConfigSubscriber</code>, one can give it a <code>ConfigSource</code> -
-details in <a href="/javadoc/">javadoc</a>.
+When instantiating a <code><a href="http://javadoc.io/page/com.yahoo.vespa/config/latest/com/yahoo/config/subscription/ConfigSubscriber.html">ConfigSubscriber</a></code>,
+one can give it a <code><a href="http://javadoc.io/page/com.yahoo.vespa/config/latest/com/yahoo/config/subscription/ConfigSource.html">ConfigSource</a></code>.
 One such source is a <code>ConfigSet</code>. It consists of a set of <code>Builder</code>s.
 This is an example of instantiating a subscriber using this -
 it uses 2 types of config, that were generated from files

--- a/documentation/feed-using-hadoop-pig-oozie.html
+++ b/documentation/feed-using-hadoop-pig-oozie.html
@@ -12,13 +12,12 @@ This includes text or JSON files on HDFS, data in Hive or HBase table.
 </p><p>
 <code>vespa-hadoop</code> contains classes and utilities to enable feeding directly to Vespa endpoints.
 It is a minimal layer over the <a href="vespa-http-client.html">Vespa HTTP client</a>. Dependency:
-
-<pre class="code">
-        &lt;dependency&gt;
-            &lt;groupId&gt;com.yahoo.vespa&lt;/groupId&gt;
-            &lt;artifactId&gt;vespa-hadoop&lt;/artifactId&gt;
-            &lt;version&gt;...&lt;/version&gt;
-        &lt;/dependency&gt;
+<pre>
+&lt;dependency&gt;
+  &lt;groupId&gt;com.yahoo.vespa&lt;/groupId&gt;
+  &lt;artifactId&gt;vespa-hadoop&lt;/artifactId&gt;
+  &lt;version&gt;...&lt;/version&gt;
+&lt;/dependency&gt;
 </pre>
 
 <p class="alert alert-success">
@@ -293,6 +292,8 @@ Another alternative is to limit number of tasks by
 SET mapreduce.jobtracker.maxtasks.perjob 100
 </pre>
 
+
+
 <h2 id="hadoop-mapreduce">Hadoop MapReduce</h2>
 <p>
 The <code>VespaStorage</code> Pig class builds upon an <code>OutputFormat</code> class that feeds to Vespa.
@@ -381,8 +382,8 @@ For Oozie, specify them as parameters in the configuration section of the action
       <td>Log sent/ok/failed/skipped documents every n records</td></tr>
     <tr id="vespa.feed.connections"><th>vespa.feed.connections</th>
       <td><em>1</em></td>
-      <td>Number of concurrent connections per mapper/reducer.
-        <a href="/javadoc/com/yahoo/vespa/http/client/config/ConnectionParams.Builder.html#setNumPersistentConnectionsPerEndpoint-int-">See javadoc</a></td></tr>
+      <td>Number of concurrent connections per mapper/reducer:
+        <a href="http://javadoc.io/page/com.yahoo.vespa/vespa-http-client/latest/com/yahoo/vespa/http/client/config/ConnectionParams.Builder.html">setNumPersistentConnectionsPerEndpoint</a></td></tr>
     <tr id="vespa.feed.route"><th>vespa.feed.route</th>
       <td><em>default</em></td>
       <td><a href="routing.html">Route</a> to use on endpoint</td></tr>

--- a/documentation/jdisc/developing-request-handlers.html
+++ b/documentation/jdisc/developing-request-handlers.html
@@ -4,8 +4,7 @@ title: "Developing request handlers"
 ---
 
     <p>
-      The <code>com.yahoo.jdisc.service.RequestHandler</code>
-      (<a href="http://javadoc.io/page/com.yahoo.vespa/jdisc_core/latest/com/yahoo/jdisc/handler/RequestHandler.html">javadoc</a>)
+      The <code><a href="http://javadoc.io/page/com.yahoo.vespa/jdisc_core/latest/com/yahoo/jdisc/handler/RequestHandler.html">com.yahoo.jdisc.service.RequestHandler</a></code>
       interface defines a component that is capable of acting as a handler for a
       Request. This document explains how to implement and deploy a custom request
       handler.
@@ -106,15 +105,12 @@ title: "Developing request handlers"
       CompletionHandler)</code> or <code>close(CompletionHandler)</code>, it
       is <u>required</u> that you explicitly call the corresponding completion handler at
       some point in the future.
-    </p><p class="note">
+    </p><p>
       Instead of developing your own <code>ContentChannel</code>, please consider using
       <a href="http://javadoc.io/page/com.yahoo.vespa/jdisc_core/latest/com/yahoo/jdisc/handler/BufferedContentChannel.html"><code>BufferedContentChannel</code></a>
       if you intend to forward the content without blocking or copying, or
       <a href="http://javadoc.io/page/com.yahoo.vespa/jdisc_core/latest/com/yahoo/jdisc/handler/ReadableContentChannel.html"><code>ReadableContentChannel</code></a>
-      if you intend to access the content yourself. Both provide convenient access to
-      the <a href="http://javadoc.io/page/com.yahoo.vespa/jdisc_core/latest/com/yahoo/jdisc/handler/ContentInputStream.html"><code>ContentInputStream</code></a>
-      and <a href="http://javadoc.io/page/com.yahoo.vespa/XXARTIFACTXX/latest/com/yahoo/jdisc/handler/ContentReader.html"><code>ContentReader</code></a>
-      interfaces to safely read their content.
+      if you intend to access the content yourself.
     </p>
 
 
@@ -173,11 +169,6 @@ title: "Developing request handlers"
       Notice that it is <u>required</u> that you explicitly close all content channels --
       regardless of whether some call to it threw an exception
       or <code>failed(Throwable)</code> was invoked on some completion handler.
-    </p><p class="note">
-      Please consider using
-      the <a href="http://javadoc.io/page/com.yahoo.vespa/XXARTIFACTXX/latest/com/yahoo/jdisc/handler/ContentOutputStream.html"><code>ContentOutputStream</code></a>
-      or <a href="http://javadoc.io/page/com.yahoo.vespa/XXARTIFACTXX/latest/com/yahoo/jdisc/handler/ContentWriter.html"><code>ContentWriter</code></a>
-      to safely write to a content channel.
     </p>
 
 

--- a/documentation/jdisc/metrics.html
+++ b/documentation/jdisc/metrics.html
@@ -11,16 +11,16 @@ Vespa to report your own custom metrics.</p>
   <li>Add a <em>MetricReceiver</em>
   (<a href="http://javadoc.io/page/com.yahoo.vespa/simplemetrics/latest/com/yahoo/metrics/simple/MetricReceiver.html">
   com.yahoo.metrics.simple.MetricReceiver</a>)
-  instance to the constructor of the component in question - it is injected by the container.</li>
+  instance to the constructor of the component in question - it is injected by the container</li>
 
   <li>Declare the <em>gauges</em> and <em>counters</em> using the <em>declare</em>
   methods on the metric receiver. Optionally set arbitrary metric
   dimensions to default values at declaration time -
-  refer to <a href="/javadoc/">javadoc</a>.</li>
+  refer to the javadoc for details</li>
 
   <li>Each time there is some data to measure, invoke the <em>sample</em> method on
   gauges or the <em>add</em> method on counters. When sampling data, any dimensions
-  can optionally be set.</li>
+  can optionally be set</li>
 </ol>
 <p>
 The gauges and counters declared are inherently thread safe. Example:

--- a/documentation/jdisc/processing.html
+++ b/documentation/jdisc/processing.html
@@ -10,14 +10,14 @@ of creating such applications on top of JDisc, but can also be used independentl
 Processing lets you define application behavior by combining Processors performing simple tasks.
 Processors use a synchronous call model, but the underlying IO may be asynchronous.
 </p><p>
-  Javadoc:<br/>
-  <code><a href="http://javadoc.io/page/com.yahoo.vespa/XXARTIFACTXX/latest/com/yahoo/processing/Processor.html">com.yahoo.processing.Processor</a></code><br/>
-  <code><a href="http://javadoc.io/page/com.yahoo.vespa/XXARTIFACTXX/latest/com/yahoo/processing/rendering/Renderer.html">com.yahoo.processing.rendering.Renderer</a></code>
+Javadoc:<br/>
+<code><a href="http://javadoc.io/page/com.yahoo.vespa/processing/latest/com/yahoo/processing/Processor.html">com.yahoo.processing.Processor</a></code><br/>
+<code><a href="http://javadoc.io/page/com.yahoo.vespa/processing/latest/com/yahoo/processing/rendering/Renderer.html">com.yahoo.processing.rendering.Renderer</a></code>
 </p>
 
 
 
-<h1 id="using_processing">Using processing</h1>
+<h2 id="using_processing">Using processing</h2>
 <p>
 To use processing, add this dependency to your maven pom:
 <pre>
@@ -33,7 +33,7 @@ Or read <a href="developing-applications.html">how to start a deployable project
 
 
 
-<h1 id="processors">Processors</h1>
+<h2 id="processors">Processors</h2>
 <p>
 A <em>processor</em> subclasses Processor and implements a single method:
 <pre>
@@ -70,7 +70,7 @@ multiple processors.
 
 
 
-<h1 id="chaining-processors">Chaining Processors</h1>
+<h2 id="chaining-processors">Chaining Processors</h2>
 <p>
 Processors should carry out a single task and are combined into complete
 applications.  This is achieved using Chains:
@@ -104,7 +104,7 @@ chains can be used to define extensions and variants of chains.
 
 
 
-<h1 id="asynchronous-processing">Asynchronous Results</h1>
+<h2 id="asynchronous-processing">Asynchronous Results</h2>
 <p>
 In some cases it is useful to return a Response before all the data in
 it is available.  This allows returning a partial response to clients
@@ -120,7 +120,7 @@ the processing framework becomes completely non-blocking.
 
 
 
-<h1 id="dependency-injection">Dependency Injection</h1>
+<h2 id="dependency-injection">Dependency Injection</h2>
 <p>
 Processors in real applications will typically depend on some
 configuration and/or other components to run.  Such dependencies
@@ -138,7 +138,7 @@ after construction is completed.
 
 
 
-<h1 id="response-rendering">Response Rendering</h1>
+<h2 id="response-rendering">Response Rendering</h2>
 <p>
 A <em>Renderer</em> is used to serialize the Response for return to a
 client.  Renderers are subclasses of
@@ -161,7 +161,7 @@ to the renderer id.
 
 
 
-<h1 id="subclassing-of-processing">Subclassing of Processing</h1>
+<h2 id="subclassing-of-processing">Subclassing of Processing</h2>
 <p>
 The Processing framework is meant to be generic and minimal. In some
 domains it is useful to employ a richer model of Processors, Requests,
@@ -174,7 +174,7 @@ designed to allow such subclassing to built richer frameworks on top.
 
 
 
-<h1 id="testing-processors-with-application">Testing Processors with an Application</h1>
+<h2 id="testing-processors-with-application">Testing Processors with an Application</h2>
 <p>
 A processor can be tested running inside a container.
 We create a JDisc from <em>services.xml</em>:
@@ -228,7 +228,7 @@ assertTrue("No instance of ExampleProcessor found in the default chain", foundEx
 
 
 
-<h1 id="selecting-a-chain">Selecting a Non-default Processor Chain</h1>
+<h2 id="selecting-a-chain">Selecting a Non-default Processor Chain</h2>
 <p>
 A complete application will usually be composed of several processor chains,
 which may or may not invoke each other. To select a chain configured with
@@ -247,22 +247,22 @@ In other words, given a chain named "testbed", as in:
 </pre>
 The chain testbed could be tested from the command line by doing:
 <pre>
-curl http://<em>hostname</em>:<em>port</em>/processing/?chain=testbed
+$ curl http://<em>hostname</em>:<em>port</em>/processing/?chain=testbed
 </pre>
 </p>
 
 
 
-<h1 id="references">References</h1>
+<h2 id="references">References</h2>
 <ul>
   <li><a href="../developing-web-services.html">Developing web services</a>.
-  <li><a href="http://javadoc.io/page/com.yahoo.vespa/XXARTIFACTXX/latest/com/yahoo/processing/package-summary.html">com.yahoo.processing</a> javadoc </li>
+  <li><a href="http://javadoc.io/page/com.yahoo.vespa/processing/latest/com/yahoo/processing/package-summary.html">com.yahoo.processing</a> javadoc </li>
   <li><a href="https://google.github.io/guava/releases/snapshot/api/docs/">Guava Javadoc</a>.</li>
 </ul>
 
 
 
-<h1 id="common-tasks-with-processing">Common tasks with processing</h1>
+<h2 id="common-tasks-with-processing">Common tasks with processing</h2>
 <p>
 This section contains a collection of "how do I" explanations with processing.
 Most of these pertains to the jDisc binding of Processing, but note that Processing is independent of
@@ -270,7 +270,7 @@ jDisc and may be invoked programmatically in any environment.
 </p>
 
 
-<h2 id="accessing-the-http-request-from-processors">Accessing the HTTP request from Processors</h2>
+<h3 id="accessing-the-http-request-from-processors">Accessing the HTTP request from Processors</h3>
 <p>
 Processors which interface with the network layer may need to access the network level
 request to access headers or request data, or to make outgoing calls through jDisc.
@@ -281,7 +281,7 @@ httpRequest = (com.yahoo.container.jdisc.HttpRequest)processingRequest.propertie
 </p>
 
 
-<h2 id="setting-response-headers-from-processors">Setting response headers from Processors</h2>
+<h3 id="setting-response-headers-from-processors">Setting response headers from Processors</h3>
 <p>
 Response headers may be added to any Response by adding instances of
 <code>com.yahoo.processing.handler.ResponseHeaders</code> to the Response
@@ -320,7 +320,7 @@ public class ResponseHeaderSetter extends Processor {
 
 
 
-<h1 id="example-processors">Example Processors</h1>
+<h2 id="example-processors">Example Processors</h2>
 <p>
 This section lists a few example processors which shows some use cases
 for the asynchronous aspects of the API.

--- a/documentation/vespa-versions.html
+++ b/documentation/vespa-versions.html
@@ -14,7 +14,7 @@ and use of deprecated application package constructs will cause a deprecation wa
 Note that Java API's come in two categories:
 <ul>
   <li><em>Public API's</em> carry the compatibility guarantee and are visible from your code
-    as well as in the <a href="/javadoc/">Vespa javadoc</a></li>
+    as well as in the javadoc</li> <!-- ToDo javadoc - link to something here if possible -->
   <li><em>Exported API's</em> are also visible from your code,
    but is not in the public Javadoc and carry no compatibility guarantee</li>
 </ul>

--- a/documentation/vespatoc.html
+++ b/documentation/vespatoc.html
@@ -48,7 +48,7 @@ title: "Vespa Documentation table of content"
   <li><a href="chained-components.html">Chained Components</a></li>
   <li><a href="searcher-development.html">Searcher Development</a></li>
   <li><a href="jdisc/component-versioning.html">Versioning in the Container</a></li>
-  <li><a href="/javadoc/">JavaDoc</a></li>
+  <!-- li><a href="/javadoc/">JavaDoc</a></li --> <!-- ToDo javadoc - link to something here if possible -->
 </ul>
 
 


### PR DESCRIPTION
- also added to readme how to set links
- minor random changes to document's layout, no content changes
- ToDo for how to refer to "Vespa Javadoc"
- no known wrong links in doc now

@tokle please merge