### PR TITLE
Cut less relevant docs from sidebar

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -44,9 +44,9 @@ docs:
         url: /documentation/jdisc/processing.html
       - page: Developing web service applications
         url: /documentation/developing-web-services.html
-      - page: Components for the JDisc Container
+      - page: Components for the Container
         url: /documentation/jdisc/container-components.html
-      - page: Component Types in the JDisc Container
+      - page: Component Types in the Container
         url: /documentation/component-types.html
       - page: HTTP API Use Case Tutorial
         url: /documentation/handler-tutorial.html
@@ -137,7 +137,7 @@ docs:
     documents:
       - page: Linguistics in Vespa
         url: /documentation/linguistics.html
-      - page: Introduction to Stemming
+      - page: Stemming
         url: /documentation/stemming.html
 
   - title: CONFIGURATION
@@ -146,15 +146,11 @@ docs:
         url: /documentation/cloudconfig/config-introduction.html
       - page: Using the Cloud Config API
         url: /documentation/cloudconfig/configapi-dev.html
-      - page: Java
-        url: /documentation/cloudconfig/configapi-dev-java.html
-      - page: C++
-        url: /documentation/cloudconfig/configapi-dev-cpp.html
       - page: Developing Cloud Config Model Plugins
         url: /documentation/cloudconfig/cloudconfig-model-plugins.html
-      - page: REST API for getting config
+      - page: API for getting config
         url: /documentation/cloudconfig/config-rest-api-v2.html
-      - page: REST API for deploying application packages
+      - page: API for deploying application packages
         url: /documentation/cloudconfig/deploy-rest-api-v2.html
 
   - title: PERFORMANCE
@@ -165,7 +161,7 @@ docs:
         url: /documentation/performance/sizing-search.html
       - page: Benchmarking
         url: /documentation/performance/vespa-benchmarking.html
-      - page: JDisc Container tuning
+      - page: Container tuning
         url: /documentation/performance/container-tuning.html
       - page: Profiling the Search Container
         url: /documentation/performance/profiling-search-container.html
@@ -180,7 +176,7 @@ docs:
         url: /documentation/elastic-vespa.html
       - page: Cluster and node states
         url: /documentation/content/admin-states.html
-      - page: REST API for State
+      - page: API for State
         url: /documentation/content/api-state-rest-api.html
       - page: Consistency model
         url: /documentation/content/consistency.html
@@ -209,27 +205,6 @@ docs:
         url: /documentation/log-events.html
       - page: Files, processes and ports
         url: /documentation/reference/files-processes-and-ports.html
-        subdocuments:
-          - page: Config Server
-            url: /documentation/cloudconfig/configuration-server.html
-          - page: Config Proxy
-            url: /documentation/reference/config-proxy.html
-          - page: Config Sentinel
-            url: /documentation/config-sentinel.html
-          - page: File distribution
-            url: /documentation/cloudconfig/file-distribution.html
-          - page: Service Location Broker
-            url: /documentation/slobrok.html
-          - page: Log Daemon
-            url: /documentation/reference/logs.html#logd
-          - page: Log Server
-            url: /documentation/reference/logs.html#logd
-          - page: Distributor
-            url: /documentation/distributor.html
-          - page: Cluster controller
-            url: /documentation/clustercontroller.html
-          - page: Proton
-            url: /documentation/proton.html
       
   - title: REFERENCE
     documents:
@@ -242,23 +217,6 @@ docs:
         url: /documentation/reference/advanced-indexing-language.html
       - page: services.xml
         url: /documentation/reference/services.html
-        subdocuments:
-          - page: admin
-            url: /documentation/reference/services-admin.html
-          - page: container
-            url: /documentation/reference/services-container.html
-          - page: content
-            url: /documentation/reference/services-content.html
-          - page: document processing
-            url: /documentation/reference/services-docproc.html
-          - page: HTTP
-            url: /documentation/reference/services-http.html
-          - page: processing
-            url: /documentation/reference/services-processing.html
-          - page: routing
-            url: /documentation/reference/services-routing.html
-          - page: search
-            url: /documentation/reference/services-search.html
       
   - title: CONFIGURATION
     documents:


### PR DESCRIPTION
- these are linked from elsewhere
- makes the sidebar more focused

@bratseth please merge

side note: given http://docs.vespa.ai/documentation/api.html I consider removing some of the API links from the sidebar, these docs are not much used (State API, Config API) - agree?