### PR TITLE
Add link to tensor javadoc

### DIFF
--- a/documentation/tensor-user-guide.html
+++ b/documentation/tensor-user-guide.html
@@ -341,9 +341,7 @@ documention</a> in the search definition documentation.
 
 <h2 id="tensor-java-api">Tensor Java API</h2>
 
-<p>
-Coming soon.
-</p>
+The Tensor API <a href="http://javadoc.io/page/com.yahoo.vespa/vespajlib/latest/com/yahoo/tensor/Tensor.html">javadoc can be found here</a>.
 
 <h2>Common Use Cases</h2>
 In the following section we describe some common use cases that can be solved using tensor operations.


### PR DESCRIPTION
@kkraune Please review and merge.
@bratseth FYI.

I will add a few code examples here ASAP, but this is to remove the misunderstanding about whether the Tensor Java API itself is coming soon.