### PR TITLE
Replace 'boolean search' by 'predicate field'

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -64,8 +64,8 @@ docs:
         url: /documentation/attributes.html
       - page: Special Tokens
         url: /documentation/text-processing.html
-      - page: Boolean Search
-        url: /documentation/boolean-search.html
+      - page: Predicate fields
+        url: /documentation/predicate-fields.html
       - page: Geo search
         url: /documentation/geo-search.html
 

--- a/documentation/api.html
+++ b/documentation/api.html
@@ -33,7 +33,7 @@ title: "Vespa API and interfaces"
   <li><a href="reference/search-api-reference.html">HTTP search API reference</a></li>
   <li><a href="query-language.html">YQL Query Language</a>,
     <a href="reference/simple-query-language-reference.html">Simple Query Language reference</a>,
-    <a href="boolean-search.html">Boolean Search</a></li>
+    <a href="predicate-fields.html">Predicate fields</a></li>
   <li><a href="query-profiles.html">Vespa Query Profiles </a></li>
   <li><a href="grouping.html">Grouping API</a>,
     <a href="reference/grouping-syntax.html">Grouping API reference</a></li>

--- a/documentation/boolean-library.html
+++ b/documentation/boolean-library.html
@@ -1,14 +1,14 @@
 ---
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "Boolean Search Java Library"
+title: "Predicate Search Java Library"
 ---
 
 <p>
-The rationale for Boolean Search is described in the document
-<a href="boolean-search.html">Using Boolean Search with Vespa</a>.
-Vespa also has a standalone Java library for boolean search,
+The rationale for predicate fields is described in the
+<a href="predicate-fields.html">predicate fields document</a>.
+Vespa also has a standalone Java library for searching predicate fields,
 for boolean matching tightly integrated with a Java program, e.g. running on a grid.
-The performance is similar to Vespa boolean search.
+The performance is similar to predicate search in Vespa.
 Find API documentation in the
 <a href="http://javadoc.io/doc/com.yahoo.vespa/predicate-search">javadoc</a>.
 Get started - add a dependency in <em>pom.xml</em>:
@@ -25,7 +25,7 @@ Get started - add a dependency in <em>pom.xml</em>:
 
 <h3>Indexing documents</h3>
 <p>
-Unlike Vespa boolean search, which has dynamic indexes,
+Unlike Vespa predicate fields, which have dynamic indexes,
 the Java library requires the entire index to be built before any searches are run.
 Once built, the index cannot be changed.
 Build an index using an instance of <code>PredicateIndexBuilder</code>.
@@ -43,7 +43,7 @@ The expressions uses the <a href="boolean-search.html#predicates">Vespa predicat
 
 <h3>Index configuration</h3>
 <p>
-Just as with Vespa boolean search, specify the <a href="boolean-search.html#index_size">arity</a> and
+Just as with Vespa predicatre fields, specify the <a href="predicate-fields.html#index_size">arity</a> and
 <a href="boolean-search.html#upper_lower_bound">upper- and lower bounds</a> for the index,
 to make the index more efficient and trade index size for query performance.
 This is set when creating a <code>PredicateIndexBuilder</code> object,

--- a/documentation/predicate-fields.html
+++ b/documentation/predicate-fields.html
@@ -1,15 +1,15 @@
 ---
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "Boolean Search"
+title: "Predicate fields"
 ---
 
 <p>
-Boolean Search is a way to match queries to a set of <em>boolean
-constraints</em>. The typical use case for Boolean Search is to have a
+<i>Predicate fields</i>i> provides a way to match queries to a set of <em>boolean
+constraints</em> given in the document. The typical use case is to have a
 set of boolean constraints representing advertisements, specifying
 their target groups. Then we query the system with a set of
 impressions, i.e. specific values for a given user, to find out which
-ads can be shown to this user. When configuring boolean search there
+ads can be shown to this user. When configuring predicate fields there
 are some trade-offs between index size and query performance.
 </p>
 
@@ -17,10 +17,9 @@ are some trade-offs between index size and query performance.
 
 <h2 id="constraints">Boolean Constraints</h2>
 <p>
-A boolean constraint specifies a target area for queries to land
+A boolean constraint (predicate) specifies a target area for queries to land
 in. Its attributes may be simple true/false criteria, subsets of sets
-to match, or ranges of values. In Vespa, boolean constraints are
-specified as predicates.
+to match, or ranges of values.
 </p>
 
 
@@ -79,9 +78,6 @@ The variables in predicates are known as <em>attributes</em>. There are two type
   </ol>
   </li>
 </ul>
-</p><p class="alert alert-success">
-Note: The attribute concept in boolean search is unrelated to
-<a href="attributes.html">attribute document fields in search definitions</a>.
 </p>
 
 
@@ -201,7 +197,7 @@ are reported in two different summary features, one for the lower 32
 bits, named <code>lsb</code>, and one for the upper 32 bits,
 named <code>msb</code>.
 </p><p>
-See the <a href="https://github.com/vespa-engine/sample-apps/tree/master/boolean-search">boolean search sample app</a>
+See the <a href="https://github.com/vespa-engine/sample-apps/tree/master/boolean-search">predicate search sample app</a>
 for how to configure a custom <em>searcher</em>, <em>services.xml</em> and the <em>search definition</em>
 required to retrieve the subquery bitmap of each hit.
 </p>
@@ -258,11 +254,10 @@ one for the lower 32-bit and one for the upper 32-bit of the subquery bitmap.
 <h2 id="configuration">Configuration</h2>
 <p class="alert alert-warning">
 Contact Vespa support for performance tuning.
-Boolean search is complex and tuning the configuration for performance requires
+Using predicate fields is complex and tuning the configuration for performance requires
 insight in the underlying algorithms.
 </p><p>
-Boolean search is specified in the search definition as a field of
-type <code>predicate</code>. A predicate field requires an index definition
+A field of type predicate requires an index definition
 with a mandatory parameter, <code>arity</code>, a value which trades index size
 for query complexity. See <a href="#index_size">Index Size</a> for more
 details. Fields of type predicate also accept three other optional parameters:
@@ -273,7 +268,7 @@ is structured, trading index size for potentially better query performance.
 </p>
 
 
-<h3>Search Definition for Boolean Search</h3>
+<h3>Search Definition</h3>
 <p>
 The following search definition example sets up an attribute predicate field
 including the mandatory arity parameter.

--- a/documentation/query-language.html
+++ b/documentation/query-language.html
@@ -796,7 +796,7 @@ If "foo" contained a searchable term, the query would not have failed.
 <h2 id="predicate">predicate()</h2>
 <p>
 <em>predicate()</em> is used to specify a predicate query -
-see <a href="boolean-search.html">Boolean Search</a>.
+see <a href="predicate-fields.html">predicate fields</a>.
 It takes three arguments: the predicate field to search, a map of attributes, and a map of range attributes:
 <pre class="urlunencode" oncopy="">
 select%20*%20from%20sources%20*%20where%20predicate(predicate_field%2C%7B%22gender%22%3A%22Female%22%7D%2C%7B%22age%22%3A20L%7D)%3B

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1442,15 +1442,14 @@ The data type for the containing field must be <code>predicate</code>.</td>
 </tr>
 <tr><td><a href="#upper-bound">upper-bound</a></td>
 <td>Set the
-<a href="../predicate-fields.html#upper_lower_bound">upper bound value for boolean search</a>.
+<a href="../predicate-fields.html#upper_lower_bound">upper bound value for predicate fields</a>.
 The data type for the containing field must be <code>predicate</code>.</td>
 <td>Zero to one.</td>
 </tr>
 <tr><td><a href="#dense-posting-list-threshold">dense-posting-list-threshold</a></td>
 <td>Set the
-<a href="../predicatre-fields.html#dense_posting_list_threshold">dense posting list threshold value for boolean search
-The data
-type for the containing field must be <code>predicate</code>.</td>
+<a href="../predicatre-fields.html#dense_posting_list_threshold">dense posting list threshold value for predicate fields</a>.
+The data type for the containing field must be <code>predicate</code>.</td>
 <td>Zero to one.</td>
 </tr>
 </tbody>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1429,29 +1429,27 @@ this index.</td>
 <td>Zero to one</td>
 </tr>
 <tr><td><a href="#arity">arity</a></td>
-<td>Set the arity value for boolean search. See
-<a href="../boolean-search.html#index_size">Using Boolean Search with Vespa</a>. The data
-type for the containing field must be <code>predicate</code>.</td>
-<td>One (mandatory for boolean search), else zero.</td>
+<td>Set the
+<a href="../predicate-fields.html#index_size">arity value for a predicate field</a>. 
+The data type for the containing field must be <code>predicate</code>.</td>
+<td>One (mandatory for predicate fields), else zero.</td>
 </tr>
 <tr><td><a href="#lower-bound">lower-bound</a></td>
-<td>Set the lower bound value for boolean search. See
-<a href="../boolean-search.html#upper_lower_bound">
-Using Boolean Search with Vespa</a>. The data
-type for the containing field must be <code>predicate</code>.</td>
+<td>Set the 
+<a href="../predicate-fields.html#upper_lower_bound">lower bound value for a predicate field</a>.
+The data type for the containing field must be <code>predicate</code>.</td>
 <td>Zero to one.</td>
 </tr>
 <tr><td><a href="#upper-bound">upper-bound</a></td>
-<td>Set the upper bound value for boolean search. See
-<a href="../boolean-search.html#upper_lower_bound">
-Using Boolean Search with Vespa</a>. The data
-type for the containing field must be <code>predicate</code>.</td>
+<td>Set the
+<a href="../predicate-fields.html#upper_lower_bound">upper bound value for boolean search</a>.
+The data type for the containing field must be <code>predicate</code>.</td>
 <td>Zero to one.</td>
 </tr>
 <tr><td><a href="#dense-posting-list-threshold">dense-posting-list-threshold</a></td>
-<td>Set the dense posting list threshold value for boolean search. See
-<a href="../boolean-search.html#dense_posting_list_threshold">
-Using Boolean Search with Vespa</a>. The data
+<td>Set the
+<a href="../predicatre-fields.html#dense_posting_list_threshold">dense posting list threshold value for boolean search
+The data
 type for the containing field must be <code>predicate</code>.</td>
 <td>Zero to one.</td>
 </tr>
@@ -2172,7 +2170,7 @@ Small letter o may be used as a replacement for degrees.
 <tr><th id="type:predicate">predicate</th>
 <td>
 Use to match queries to a set of boolean constraints.
-See <a href="../boolean-search.html#queries">boolean search.</a>
+See <a href="../predicate-fields.html#queries">querying predicate fields.</a>
 <table class="table">
   <thead></thead><tbody>
     <tr>

--- a/documentation/vespatoc.html
+++ b/documentation/vespatoc.html
@@ -82,7 +82,7 @@ title: "Vespa Documentation table of content"
     <a href="query-phrasing.html">Query Phrasing using an FSA</a></li>
   <li><a href="attributes.html">Attributes</a></li>
   <li><a href="text-processing.html">Special Tokens</a></li>
-  <li><a href="boolean-search.html">Boolean Search</a></li>
+  <li><a href="predicate-fields.html">Predicate Fields</a></li>
   <li><a href="geo-search.html">Geo search</a></li>
 </ul>
 


### PR DESCRIPTION
This is to avoid any confusion with 'boolean search' in the
sense of combining search operator with boolean combinators.

@bjorncs please review