### PR TITLE
Make copy and paste behavoir for commands in quick start easier

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -245,6 +245,13 @@ h3,
     padding-top: 0;
 }
 
+.force-select {  
+  -webkit-user-select: all;  /* Chrome 49+ */
+  -moz-user-select: all;     /* Firefox 43+ */
+  -ms-user-select: all;      /* No support yet */
+  user-select: all;          /* Likely future */   
+}
+
 /*
 * Footer
 */

--- a/documentation/vespa-quick-start-centos.html
+++ b/documentation/vespa-quick-start-centos.html
@@ -18,48 +18,48 @@ Also try the <a href="vespa-quick-start.html">Docker</a> guide.
 <ol>
 <li><p><strong>Clone sample-apps repository</strong></p>
 <pre>
-$ git clone https://github.com/vespa-engine/sample-apps.git
+$ <span class="force-select">git clone https://github.com/vespa-engine/sample-apps.git</span> 
 </pre>
 </li>
 
 <li><p><strong>Start CentOS VM using Vagrant and Virtualbox</strong></p>
 Navigate into the cloned repository and start the CentOS VM using Vagrant. This may take a couple of minutes.
 <pre>
-$ cd sample-apps
-$ vagrant up
+$ <span class="force-select">cd sample-apps</span>
+$ <span class="force-select">vagrant up</span>
 </pre>
 See the <samp>Vagrantfile</samp> in the <samp>sample-apps</samp> directory for exact configuration of the CentOS based VM.
 </li>
 
 <li>
 <p><strong>SSH into the VM</strong>
-<pre>$ vagrant ssh</pre>
+<pre>$ <span class="force-select">vagrant ssh</span></pre>
 </li>
 
 <li>
 <p><strong>Start the vespa configuration server</strong>
-<pre>$ sudo service vespa-configserver start</pre>
+<pre>$ <span class="force-select">sudo service vespa-configserver start</span></pre>
 </li>
 
 <li>
     <strong>Ensure the configuration server is active:</strong><br>
     Wait for a <samp>200 OK</samp> response from:
 <pre>
-$ curl -s --head http://localhost:19071/ApplicationStatus 
+$ <span class="force-select">curl -s --head http://localhost:19071/ApplicationStatus</span> 
 </pre>
 </li>
 
 <li><p><strong>Deploy a sample application:</strong></p>
 	The sample apps are located at <samp>/vespa-sample-apps</samp> inside the VM.
 <pre>
-$ cd /vespa-sample-apps/basic-search
-$ vespa-deploy prepare src/main/application &amp;&amp; vespa-deploy activate
+$ <span class="force-select">cd /vespa-sample-apps/basic-search</span>
+$ <span class="force-select">vespa-deploy prepare src/main/application &amp;&amp; vespa-deploy activate</span>
 </pre>
 </li>
 
 <li><p><strong>Start Vespa:</strong></p>
 <pre>
-$ sudo service vespa start
+$ <span class="force-select">sudo service vespa start</span>
 </pre>
 </li>
 
@@ -67,7 +67,7 @@ $ sudo service vespa start
     <strong>Ensure the application is active:</strong><br>
     Wait for a <samp>200 OK</samp> response from:
 <pre>
-$ curl -s --head http://localhost:8080/ApplicationStatus 
+$ <span class="force-select">curl -s --head http://localhost:8080/ApplicationStatus</span>
 </pre>
 </li>
 
@@ -75,11 +75,11 @@ $ curl -s --head http://localhost:8080/ApplicationStatus
     <p>
     <strong>Feed documents:</strong>
 <pre>
-$ curl -s -X POST --data-binary @/vespa-sample-apps/basic-search/music-data-1.json \
-    http://localhost:8080/document/v1/music/music/docid/1 | python -m json.tool
+$ <span class="force-select">curl -s -X POST --data-binary @/vespa-sample-apps/basic-search/music-data-1.json \
+    http://localhost:8080/document/v1/music/music/docid/1 | python -m json.tool</span>
 
-$ curl -s -X POST --data-binary @/vespa-sample-apps/basic-search/music-data-2.json \
-    http://localhost:8080/document/v1/music/music/docid/2 | python -m json.tool
+$ <span class="force-select">curl -s -X POST --data-binary @/vespa-sample-apps/basic-search/music-data-2.json \
+    http://localhost:8080/document/v1/music/music/docid/2 | python -m json.tool</span>
 </pre>
     <p>
     This uses the single <a href="document-api.html">document API</a>.
@@ -90,8 +90,8 @@ $ curl -s -X POST --data-binary @/vespa-sample-apps/basic-search/music-data-2.js
     <p>
     <strong>Run a query and a document get request :</strong>
 <pre>
-$ curl -s http://localhost:8080/search/?query=bad | python -m json.tool 
-$ curl -s http://localhost:8080/document/v1/music/music/docid/2 | python -m json.tool
+$ <span class="force-select">curl -s http://localhost:8080/search/?query=bad | python -m json.tool</span> 
+$ <span class="force-select">curl -s http://localhost:8080/document/v1/music/music/docid/2 | python -m json.tool</span>
 </pre>
     <p>
     You can also view the results in a browser at


### PR DESCRIPTION
An alternative method would be to make the $ sign unselectable