### PR TITLE
Fix mobile display by adding viewport meta tag

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,5 @@
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{ page.title | escape }}</title>
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 <link rel="stylesheet" href="{{site.github.url}}/css/font-awesome/css/font-awesome.min.css">


### PR DESCRIPTION
On mobile, pages are not displaying according to the media query rules in the CSS. Instead, pages are being scaled down because the viewport isn't set. (I'm seeing this in Google Chrome both on Android and in the device mode in Chrome developer tools. This likely reproduces on iOS as well, though someone else would have to confirm.)

Adding the viewport is recommended in the [Bootstrap docs](http://getbootstrap.com/2.3.2/scaffolding.html#responsive) and is pretty standard:

* [Using the viewport meta tag to control layout on mobile browsers](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) in the MDN Web Docs
* [Configuring the Viewport](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html) in the Safari Web Content Guide

Congrats on open sourcing Vespa! The docs look great.