### PR TITLE
Document id strings can only contain text characters.

### DIFF
--- a/documentation/documents.html
+++ b/documentation/documents.html
@@ -30,6 +30,8 @@ read more in <a href="content/buckets.html">buckets</a> and <a href="elastic-ves
 <p>
 The document identifiers are URIs, represented by a string,
 which must conform to a defined URI scheme for document identifiers.
+The document identifier string may only contain <i>text characters</i>, as defined by <code>isTextCharacter</code> in
+<a href="https://github.com/vespa-engine/vespa/blob/master/vespajlib/src/main/java/com/yahoo/text/Text.java">com.yahoo.text.Text</a>
 Schemes have two parts:
 <table class="table">
   <thead></thead><tbody>


### PR DESCRIPTION
@baldersheim or @jobergum please review