### PR TITLE
Revert "Adding execution of all sample apps."

### DIFF
--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -2,10 +2,4 @@
 
 urls:
     - "http://docs.vespa.ai/documentation/vespa-quick-start.html"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/basic-search-java/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/basic-search-tensor/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/blog-search/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/blog-recommendation/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/boolean-search/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/http-api-using-searcher/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/http-api-using-request-handlers-and-processors/README.md"
+


### PR DESCRIPTION
Reverts vespa-engine/documentation#195

Problems with missing maven. Takes forever to test on PRs, so need to revert this until a solution is found.

@jobergum 