### PR TITLE
Kkraune/doc distribution

### DIFF
--- a/documentation/content/data-placement.html
+++ b/documentation/content/data-placement.html
@@ -4,28 +4,13 @@ title: "Document distribution"
 ---
 
 <p>
-Documents can be uniformly distributed, in groups, or documents can be global.
+Documents can be uniformly distributed or in groups.
 Read <a href="../elastic-vespa.html">elastic Vespa</a> before this article.
 </p>
 
 
-<h3 id="global-documents">Global documents</h3>
-<p>
-Global documents exist on all nodes in a content cluster.
-Use the <a href="../reference/services-content.html#document">global</a> attribute in
-<em>services.xml</em> to enable global documents.
-</p><p>
-Fields in global documents can be imported into documents to implement joins -
-read more in <a href="../search-definitions.html#document-references">
-document references</a>.
-</p>
 
-<p> <strong>Note:</strong> The global documents feature is under development. It is currently
-only available for setups where all documents are already inherently on all nodes, i.e. <em>N</em>
-groups each containing a single node.</p>
-
-
-<h3 id="grouped-documents">Grouped documents</h3>
+<h2 id="grouped-documents">Grouped documents</h2>
 <p>
 The <a href="../reference/services-content.html#group">group</a> element is used to distribute
 documents - use cases:

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -2492,7 +2492,7 @@ i.e. a foreign key. The reference is the <a href="../documents.html">document id
 of the document-type instance, hence a string.
 References are used to join documents in a
 <a href="../search-definitions.html#document-references">parent-child relationship</a>.
-A reference can only be made to <a href="../content/data-placement.html#global-documents">global documents</a>.
+A reference can only be made to <a href="services-content.html#document">global</a> documents.
 <table class="table">
   <thead></thead><tbody>
     <tr>

--- a/documentation/reference/services-content.html
+++ b/documentation/reference/services-content.html
@@ -199,7 +199,9 @@ The document type to be routed to this content cluster. Attributes:
       <td>false</td>
       <td>
         Set to <em>true</em> to distribute documents of this type to all nodes.
-        Details in <a href="../content/data-placement.html">data placement</a>.
+        Fields in global documents can be imported into documents to implement joins -
+        read more in <a href="../search-definitions.html#document-references">
+        document references</a>.
         Note: <em>global</em> is only supported for <em>mode="index"</em>.
       </td></tr>
   </tbody>

--- a/documentation/reference/services-content.html
+++ b/documentation/reference/services-content.html
@@ -274,8 +274,6 @@ Configure this cluster and chain as the indexing chain in the content cluster - 
 
 
 
-
-
 <h2 id="redundancy">redundancy</h2>
 <p>
 Contained in <code><a href="#content">content</a></code>.
@@ -764,54 +762,45 @@ A mid-level dispatcher will also be located on the host of the content/search no
 <h2 id="bucket-splitting">bucket-splitting</h2>
 <p>Contained in <a href="#tuning"><code>tuning</code></a>.
 The <a href="../content/buckets.html">bucket</a> is the fundamental unit of distribution
-and management in a content cluster. To ensure that each bucket is of a size that can
-be processed with reasonable resource usage, the system will automatically
-split oversized buckets once they hit configured thresholds.
-</p>
-<p>
-The default settings have been chosen to be a good fit for most practical applications.
-If you are using streaming search you might want to experiment with changing split limits
-to get buckets down to a size that can be processed fully within a desired latency window.
-</p>
-<p>
-If you change the bucket splitting parameters, you should be aware of the following caveats:
-</p>
-<ul>
-  <li>Smaller buckets are faster to reconcile and to move across nodes.</li>
-  <li>Smaller buckets means that there are <em>more</em> buckets, so the total amount
-      of buckets to reconcile and move across nodes goes up proportionally.</li>
-  <li>Larger buckets reduce the amount of metadata the content cluster must keep track of.</li>
-  <li>Certain operations have a time and space complexity that is linear in the document count
-      and/or the size of the bucket.
-      Streaming search over a bucket is one example of such an operation.</li>
-  <li>A very large number of buckets (more than 1 million per node) may cause non-trivial
-      metadata processing overhead when node availability changes happen in the cluster
-      (such as when a node goes down).</li>
-  <li>Never choose a maximum bucket size that is too large to comfortably be kept in memory
-      and sent across the network (i.e. prefer sizes in tens of megabytes, not in hundreds
-      of megabytes or above).</li>
-</ul>
-<p>
-Attributes:
-<ul>
-  <li><strong>max-documents (optional)</strong>:
-    Maximum number of documents per content bucket.
-    Buckets are split in two if they have more documents than this. Default is 1024.
-    You should keep this value below 16K.
-  </li>
-  <li><strong>max-size (optional)</strong>:
-    Maximum size (in bytes) of a bucket. This is the sum of the serialized size of all documents kept in the bucket.
-    Buckets are split in two if they have a larger size than this. Default is 32MiB.
-    You should keep this value below 100MiB.
-  </li>
-  <li><strong>minimum-bits (optional)</strong>:
-    Override the ideal distribution bit count configured for this cluster.
-    Prefer to use the <a href="#distribution_type">distribution type</a>
-    setting instead if the default distribution bit count does not fit the cluster.
-    This variable is intended for testing and to work around possible distribution bit issues.
-    Most users should not need this option.
-  </li>
-</ul>
+and management in a content cluster.
+Buckets are auto-split, no need to configure for most applications.
+<a href="../streaming-search.html">Streaming search</a> latency is linear with bucket size. Attributes:
+<table class="table">
+  <thead>
+    <tr><th>Name</th><th>Required</th><th>Value</th><th>Default</th><th>Description</th></tr>
+  </thead><tbody>
+    <tr><th id="max-documents">max-documents</th>
+      <td>optional</td>
+      <td>integer</td>
+      <td>1024</td>
+      <td>
+        Maximum number of documents per content bucket.
+        Buckets are split in two if they have more documents than this.
+        Keep this value below 16K.
+      </td></tr>
+    <tr><th id="max-size">max-size</th>
+      <td>optional</td>
+      <td>integer</td>
+      <td>32MiB</td>
+      <td>
+        Maximum size (in bytes) of a bucket.
+        This is the sum of the serialized size of all documents kept in the bucket.
+        Buckets are split in two if they have a larger size than this.
+        Keep this value below 100MiB.
+      </td></tr>
+    <tr><th id="minimum-bits">minimum-bits</th>
+      <td>optional</td>
+      <td>integer</td>
+      <td></td>
+      <td>
+        Override the ideal distribution bit count configured for this cluster.
+        Prefer to use the <a href="#distribution_type">distribution type</a>
+        setting instead if the default distribution bit count does not fit the cluster.
+        This variable is intended for testing and to work around possible distribution bit issues.
+        Most users should not need this option.
+      </td></tr>
+  </tbody>
+</table>
 </p>
 
 

--- a/documentation/search-definitions.html
+++ b/documentation/search-definitions.html
@@ -150,7 +150,7 @@ Read more in the <a href="ranking.html">ranking</a> documentation.
 <p>
 Documents can refer to other documents using
 <a href="reference/search-definitions-reference.html#type:reference">references</a>
-to <a href="content/data-placement.html#global-documents">global documents</a>.
+to <a href="/documentation/reference/services-content.html#document">global documents</a>.
 Using a reference, fields can be
 <a href="reference/search-definitions-reference.html#import-field">imported</a>
 from parent types into the child's search definition and used for matching, ranking, grouping and sorting.


### PR DESCRIPTION
keep global docs in reference docs, to not confuse users. less bucket split details, use table for readability

@hmusum please merge