### PR TITLE
test redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,5 +21,8 @@ search:
     doctype: "open"
     endpoint: "http://doc-search.vespa.ai/vespa_documentation_search_proxy"
 
+plugins:
+  - jekyll-redirect-from
+
 # Build settings
 markdown: kramdown

--- a/documentation/container-intro.html
+++ b/documentation/container-intro.html
@@ -1,6 +1,7 @@
 ---
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 title: "The Vespa Container"
+redirect_from: "/ja/container-intro.html"
 ---
 
 <p>


### PR DESCRIPTION
inspired by https://help.github.com/articles/redirects-on-github-pages/ I suggest we use the _jekyll-redirect-from_ as a simple way to redirect to the English documents for documents that are not translated from say Japanese.

it is not a super scalable way, as each document will have an entry per language - on the other hand, it is not a practical problem short term as it is easy to add such an entry for all documents that are not translated from Japanese yet.

with this, once a document is translated, one must also remember to remove the redirect entry in the English doc (it loops if not, when tested on my laptop).

you like, @frodelu  and @lesters ? please be careful when merging, as I am not sure if the jekyll-redirect-from plugin is active on github, so you should merge, test and roll back if documents do not load (and today is not a good day to break Vespa docs with the Tokyo meetup)

@remoriok FYI we can hopefully fix so there are no dead links in Japanese docs