### PR TITLE
Small fix on `Rot13DocprocTest` test.

### DIFF
--- a/documentation/docproc-development.html
+++ b/documentation/docproc-development.html
@@ -303,7 +303,8 @@ public class Rot13DocprocTest {
         com.yahoo.docproc.Processing processing;
         DocumentProcessor.Progress progress;
 
-        processing = new com.yahoo.docproc.Processing(doc);
+        processing = new com.yahoo.docproc.Processing();
+        processing.addDocumentOperation(new DocumentPut(doc));
         progress = docProc.process(ComponentSpecification.fromString("myChain"), processing);
         assertThat(progress, sameInstance(DocumentProcessor.Progress.DONE));
         assertThat(doc.getFieldValue("title").toString(), equalTo("Terng Nyohz!"));


### PR DESCRIPTION
Originally used constructor of `Processing` takes a DocumentOperation, and is private.