### PR TITLE
Correct doc for weighted set assign vs. add updates

### DIFF
--- a/documentation/reference/document-json-update-format.html
+++ b/documentation/reference/document-json-update-format.html
@@ -33,7 +33,7 @@ The following operations are supported:
     </tr><tr>
         <td><strong>Composite types</strong></td>
         <td><ul>
-            <li><code><a href="#add">add</a></code> (works for array. To put into a map or weighted set, see the <a href="#assign">assign</a> section)</li>
+            <li><code><a href="#add">add</a></code> (works for array and weighted set. To put into a map, see the <a href="#assign">assign</a> section)</li>
             <li><code><a href="#remove">remove</a></code></li>
             <li><code><a href="#match">match</a></code> (pick element from collection, then apply given operation to matched element) </li>
             <li><a href="#fieldpath">accessing elements within a composite field using fieldpaths.</a></li>
@@ -263,11 +263,8 @@ Or alternatively:
 
 <h3 id="assign-weighted-set-field">Weighted set field</h3>
 <p>
-You can assign weighted set elements using a JSON key/value syntax,
-where the value is the weight of the element.
-</p>
-<p>
-Assigning a weight to a key that already exists will overwrite the existing weight with the new one.
+Adding new elements to a weighted set can be done using <a href="#add-weighted-set">add</a>, or
+by assigning with <code>field{key}</code> syntax. Example of the latter:
 </p>
 <pre>
 field int_weighted_set type weightedset&lt;int&gt; {
@@ -277,28 +274,6 @@ field string_weighted_set type weightedset&lt;string&gt; {
   indexing: summary
 }
 </pre>
-<pre>
-{
-    "update":"id:weightedsetdoctype:weightedsetdoctype::example1",
-    "fields": {
-        "int_weighted_set":  {
-            "assign": {
-                "123": 123,
-                "456": 100
-            }
-        },
-        "string_weighted_set": {
-            "assign": {
-                "item 1": 144,
-                "item 2": 7
-            }
-        }
-    }
-}
-</pre>
-<p>
-Or alternatively, using the same syntax as map updates:
-</p>
 <pre>
 {
     "update":"id:weightedsetdoctype:weightedsetdoctype::example1",
@@ -319,7 +294,8 @@ Or alternatively, using the same syntax as map updates:
 }
 </pre>
 <p>
-This may not be as efficient as updates using the JSON key/value syntax.
+Note that using the <code>field{key}</code> syntax for weighted sets <em>may</em> be
+less efficient than using <a href="#add-weighted-set">add</a>.
 </p>
 
 <h3 id="assign-clearing-a-field">Clearing a field</h3>
@@ -339,8 +315,11 @@ To clear a field, assign a <code>null</code> value to it.
 
 <h2 id="add">add</h2>
 <p>
-<code>add</code> is used to add entries to arrays. The added entries are appended to
-the end of the array in the order specified.
+<code>add</code> is used to add entries to arrays or weighted sets.
+</p>
+<h3 id="add-array-elements">Adding array elements</h3>
+<p>
+The added entries are appended to the end of the array in the order specified.
 </p>
 <pre>
 field tracks type array&lt;string&gt; {
@@ -356,6 +335,41 @@ field tracks type array&lt;string&gt; {
                 "Lay Lady Lay",
                 "Every Grain of Sand"
             ]
+        }
+    }
+}
+</pre>
+
+<h3 id="add-weighted-set">Adding weighted set entries</h3>
+<p>
+You can add weighted set elements using a JSON key/value syntax, where the value is the weight of the element.
+</p>
+<p>
+Adding a key/weight mapping that already exists will overwrite the existing weight with the new one.
+</p>
+<pre>
+field int_weighted_set type weightedset&lt;int&gt; {
+  indexing: summary
+}
+field string_weighted_set type weightedset&lt;string&gt; {
+  indexing: summary
+}
+</pre>
+<pre>
+{
+    "update":"id:weightedsetdoctype:weightedsetdoctype::example1",
+    "fields": {
+        "int_weighted_set":  {
+            "add": {
+                "123": 123,
+                "456": 100
+            }
+        },
+        "string_weighted_set": {
+            "add": {
+                "item 1": 144,
+                "item 2": 7
+            }
         }
     }
 }


### PR DESCRIPTION
@geirst @kkraune please review. Actual semantics of the thing was a bit different from what I had Assumed™️.

For adding elements rather than replacing the weighted set contents
verbatim, `add` must be used instead of `assign`.