### PR TITLE
Add description of the docker image commands to start configserver or…

### DIFF
--- a/documentation/docker-containers-in-production.html
+++ b/documentation/docker-containers-in-production.html
@@ -36,3 +36,20 @@ Make sure that the environment starting the Docker engine is setup in such a way
 For a CentOS/RHEL base host Docker is usually started by <a href="https://www.freedesktop.org/software/systemd/man/systemd.exec.html">systemd</a>. In this case LimitNOFILE, LimitNPROC and LimitCORE should
 be set to meet the minimum requirements in <a href="reference/files-processes-and-ports.html#vespa-system-limits">system limits</a>.
 </p>
+
+<h2 id="controlling-which-services-to-start">Controlling which services to start</h2>
+<p>
+The docker image vespaengine/vespa can take a command that controls which services are started inside the container.
+</p>
+<strong>Starting a configserver container:</strong>
+<pre>
+$ docker run &lt;other arguments&gt; --env VESPA_CONFIGSERVERS=&lt;comma separated list of config servers&gt; vespaengine/vespa configserver
+</pre>
+<strong>Starting a services container (configserver will not be started):</strong>
+<pre>
+$ docker run &lt;other arguments&gt; --env VESPA_CONFIGSERVERS=&lt;comma separated list of config servers&gt; vespaengine/vespa services
+</pre>
+<p>
+Omitting the command will result in both the configserver and services being started. The VESPA_CONFIGSERVERS environment variable will then be set to the local host.
+</p>
+</h2>


### PR DESCRIPTION
… services.

These commands are used in the AWS ECS tutorial:
http://localhost:4000/documentation/vespa-quick-start-multinode-aws-ecs.html

However, I think it is best to describe them in the document in this PR.

Should resolve https://github.com/vespa-engine/vespa/issues/5586.