### PR TITLE
Refactor Document JSON put format doc

### DIFF
--- a/documentation/reference/document-json-put-format.html
+++ b/documentation/reference/document-json-put-format.html
@@ -201,6 +201,7 @@ is done by specifying the cells of the tensor as follows:
 document tensordoctype1 {
   field tensorfield type tensor(x{},y{}) {
     indexing: attribute | summary
+    attribute: tensor(x{},y{})
   }
 }
 </pre>
@@ -227,6 +228,7 @@ representing a 2x2 matrix.
 document tensordoctype2 {
   field tensorfield type tensor(x[2],y[2]) {
     indexing: attribute | summary
+    attribute: tensor(x[2],y[2])
   }
 }
 </pre>

--- a/documentation/reference/document-json-put-format.html
+++ b/documentation/reference/document-json-put-format.html
@@ -76,7 +76,8 @@ document arraydoctype {
 
 <h3 id="map-values">Map values</h3>
 <p>
-Maps are represented as JSON dictionaries. The key has to be a string.
+Maps are represented as JSON dictionaries. The JSON dictionary key must be a string, even
+if the map key type in the search definition is not a string (see below for an example of this).
 </p>
 <pre>
 document mapdoctype {

--- a/documentation/reference/document-json-put-format.html
+++ b/documentation/reference/document-json-put-format.html
@@ -6,37 +6,65 @@ title: "Document JSON format - Put"
 <p>
 The <code>put</code> object is used to add new or changed documents to Vespa.
 Also see <a href="document-json-format.html#conditional-updates-test-and-set">conditional puts</a>.
+</p>
+<p>
+Each JSON example is shown with an excerpt of the <a href="../../documentation/search-definitions.html">search definition</a>
+file for the document type.
+</p>
+<pre>
+document music {
+  field songs type string {
+    indexing: summary
+  }
+  field title type string {
+    indexing: summary
+  }
+  field url type string {
+    indexing: summary
+  }
+}
+</pre>
 <pre>
 {
-    "put": "id:music:music::http://music.yahoo.com/bobdylan/BestOf",
+    "put": "id:mynamespace:music::http://music.example.com/bobdylan/BestOf",
     "fields": {
         "songs": "Knockin on Heaven's Door; Mr. Tambourine Man",
         "title": "Best of Bob Dylan",
-        "url": "http://music.yahoo.com/bobdylan/BestOf"
+        "url": "http://music.example.com/bobdylan/BestOf"
     }
 }
 </pre>
+<p>
 The value of the <em>put</em> field is the document id which uniquely identifies the
 document and at the same time specifies the document type (matching one in the deployed application).
 Values for the document fields may be set using elements as shown above in the <em>fields</em> object.
 In this example, <em>songs</em> and <em>title</em> are fields specified in the document type.
 </p>
 
-
 <h3 id="array-values">Array values</h3>
 <p>
-Arrays are represented by using JSON arrays:
+Arrays are represented by JSON arrays.
 </p>
 <pre>
+document arraydoctype {
+  field int_array_field type array&lt;int&gt; {
+    indexing: summary
+  }
+  field string_array_field type array&lt;string&gt; {
+    indexing: summary
+  }
+}
+</pre>
+<pre>
 {
-    "put": "id:arraydoctype:arraydoctype::example1",
+    "put": "id:mynamespace:arraydoctype::example1",
     "fields": {
-        "intarrayfield": [
+        "int_array_field": [
             123,
             456,
             789
         ],
-        "stringarrayfield": [
+        "string_array_field": [
             "item 1",
             "item 2",
             "item 3"
@@ -49,19 +77,27 @@ Arrays are represented by using JSON arrays:
 <h3 id="map-values">Map values</h3>
 <p>
 Maps are represented as JSON dictionaries. The key has to be a string.
+</p>
+<pre>
+document mapdoctype {
+  field int_to_string_map type map&lt;int, string&gt; {
+    indexing: summary
+  }
+}
+</pre>
 <pre>
 {
-    "put": "id:mapdoctype:mapdoctype::example1",
+    "put": "id:mynamespace:mapdoctype::example1",
     "fields": {
-        "inttostringmap":
-            {
-                "123": "foo",
-                "456": "bar",
-                "789": "foobar"
-            }
+        "int_to_string_map": {
+            "123": "foo",
+            "456": "bar",
+            "789": "foobar"
+        }
     }
 }
 </pre>
+<p>
 Refer to the reference for <a href="search-definitions-reference.html#type:map">
 indexing restrictions using maps and structs</a>.
 </p>
@@ -70,9 +106,21 @@ indexing restrictions using maps and structs</a>.
 <h3 id="struct-values">Struct values</h3>
 <p>
 Structs are more or less directly represented as JSON objects, declared by their field name.
+</p>
+<pre>
+document structdoctype {
+  struct my_struct_type {
+    field intfield type int {}
+    field stringfield type string {}
+  }
+  field mystruct type my_struct_type {
+    indexing: summary
+  }
+}
+</pre>
 <pre>
 {
-    "put": "id:structdoctype:structdoctype::example1",
+    "put": "id:mynamespace:structdoctype::example1",
     "fields": {
         "mystruct": {
             "intfield": 123,
@@ -81,6 +129,7 @@ Structs are more or less directly represented as JSON objects, declared by their
     }
 }
 </pre>
+<p>
 Refer to the reference for <a href="search-definitions-reference.html#type:map">
 indexing  restrictions using maps and structs</a>.
 </p>
@@ -91,16 +140,27 @@ indexing  restrictions using maps and structs</a>.
 Weighted sets are represented as maps where the value is the weight.
 Note, even if the key is not a string as such,
 it will be represented as a string in the JSON format.
-Default weight is 1.</p>
+Default weight is 1.
+</p>
+<pre>
+document weightedsetdoctype {
+  field int_weighed_set type weightedset&lt;int&gt; {
+    indexing: summary
+  }
+  field string_weighted_set type weightedset&lt;string&gt; {
+    indexing: summary
+  }
+}
+</pre>
 <pre>
 {
-    "put": "id:weightedsetdoctype:weightedsetdoctype::example1",
+    "put": "id:mynamespace:weightedsetdoctype::example1",
     "fields": {
-        "intweightedsetfield": {
+        "int_weighted_set": {
             "123": 2,
             "456": 78
         },
-        "stringweightedsetfield": {
+        "string_weighted_set": {
             "item 1": 143,
             "item 2": 6
         }
@@ -112,10 +172,18 @@ Default weight is 1.</p>
 <h3 id="base64">base64 encoded values</h3>
 <p>
 Feeding <a href="search-definitions-reference.html#type:raw">raw</a> fields
-are done by feeding the input data as a base64-encoded string.</p>
+are done by feeding the input data as a base64-encoded string.
+</p>
+<pre>
+document rawdoctype {
+  field rawfield type raw {
+    indexing: summary
+  }
+}
+</pre>
 <pre>
 {
-    "put": "id:rawdoctype:rawdoctype::example1",
+    "put": "id:mynamespace:rawdoctype::example1",
     "fields": {
         "rawfield": "VW5rbm93biBhcnRpc3QgZnJvbSB0aGUgbW9vbg=="
     }
@@ -127,9 +195,17 @@ are done by feeding the input data as a base64-encoded string.</p>
 <p>
 Feeding a <a href="search-definitions-reference.html#type:tensor">tensor</a> field
 is done by specifying the cells of the tensor as follows:
+</p>
+<pre>
+document tensordoctype1 {
+  field tensorfield type tensor(x{},y{}) {
+    indexing: attribute | summary
+  }
+}
+</pre>
 <pre>
 {
-    "put": "id:tensordoctype:tensordoctype::example1",
+    "put": "id:mynamespace:tensordoctype1::example",
     "fields": {
         "tensorfield": {
             "cells": [
@@ -140,14 +216,22 @@ is done by specifying the cells of the tensor as follows:
     }
 }
 </pre>
-In this case we have a tensor with two mapped dimensions <em>x</em> and <em>y</em>
-where the tensor type as specfied in the sd-file is <em>tensor(x{},y{})</em>.
+<p>
+In this case we have a tensor with two mapped dimensions <em>x</em> and <em>y</em>.
 </p><p>
 In the next example we have a tensor with two indexed dimensions <em>x</em> and <em>y</em>
-representing a 2x2 matrix. The tensor type in this case is <em>tensor(x[2],y[2])</em>.</p>
+representing a 2x2 matrix.
+</p>
+<pre>
+document tensordoctype2 {
+  field tensorfield type tensor(x[2],y[2]) {
+    indexing: attribute | summary
+  }
+}
+</pre>
 <pre>
 {
-    "put": "id:tensordoctype:tensordoctype::example2",
+    "put": "id:mynamespace:tensordoctype2::example",
     "fields": {
         "tensorfield": {
             "cells": [

--- a/documentation/reference/document-json-update-format.html
+++ b/documentation/reference/document-json-update-format.html
@@ -72,6 +72,7 @@ field title type string {
 <pre>
 field tensorfield type tensor(x{},y{}) {
   indexing: attribute | summary
+  attribute: tensor(x{},y{})
 }
 </pre>
 <pre>


### PR DESCRIPTION
@geirst @kkraune please review

Add SD example for each documented type and disambiguate namespace vs
doctype in document IDs.