### PR TITLE
Add missing quote in blog search example

### DIFF
--- a/documentation/tutorials/blog-search.md
+++ b/documentation/tutorials/blog-search.md
@@ -476,7 +476,7 @@ This is a query for the two terms "music" and "festival", combined with an
 `AND` operation; it finds documents that match both terms — but not just one of
 them.
 
-    {"yql" : "select * from sources * where sddocname contains \"blog_post\";}
+    {"yql" : "select * from sources * where sddocname contains \"blog_post\";"}
 
 This is a single-term query in the special field `sddocname` for the value
 "blog_post".  This is a common and useful Vespa trick to get the number of


### PR DESCRIPTION
One of the examples is missing a closing quote, which leads to an error when pasting the
snippet in the querybuilder.