### PR TITLE
Tiny typo fix

### DIFF
--- a/documentation/content/idealstate.html
+++ b/documentation/content/idealstate.html
@@ -241,7 +241,7 @@ Distribute the buckets to all the units. Assume the size of all units are identi
 Assume the unit with the most units assigned to it is at 100% capacity.
 The wasted space is the percentage of unused capacity compared to the used capacity.
 </p><p>
-This definition seems useful as a cluster is considered at full capacity ones
+This definition seems useful as a cluster is considered at full capacity once
 one of its partitions is at full capacity.
 Having one node with more buckets than the rest is thus very damaging,
 while having one node with less buckets than the rest is just fine.


### PR DESCRIPTION
Fixing a small typo in "The Content Layer/Distribution Algorithm" section. 

s/ones/once/