### PR TITLE
Revert "test redirects"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,8 +21,5 @@ search:
     doctype: "open"
     endpoint: "https://vespa-documentation-search--vespa.aws-us-east-1a.vespa.oath.cloud:4443"
 
-plugins:
-  - jekyll-redirect-from
-
 # Build settings
 markdown: kramdown

--- a/documentation/container-intro.html
+++ b/documentation/container-intro.html
@@ -1,7 +1,6 @@
 ---
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 title: "The Vespa Container"
-redirect_from: "/ja/container-intro.html"
 ---
 
 <p>


### PR DESCRIPTION
Reverts vespa-engine/documentation#257

Looks like this plugin was not installed and the internal build broke.