### PR TITLE
Make it easier to find doc summary info

### DIFF
--- a/documentation/document-summaries.html
+++ b/documentation/document-summaries.html
@@ -4,37 +4,34 @@ title: "Document Summaries"
 ---
 
 <p>
-Use multiple document summaries to search the same document type,
-but present different subsets of fields in different situations.
-</p><p>
-The <em>default</em> summary always contains <em>all</em> fields that
+Use document summaries to configure which fields to include in results.
+The <em>default</em> summary contains <em>all</em> fields that
 are possible to include in summaries; all other summaries will contain
 a subset of the fields included in the <em>default</em> summary.
+</p><p>
+Vespa keeps <a href="attributes.html">attribute</a>
+type fields in memory and fetches those fields from
+memory when requested as part of document summaries.
+This means summaries are memory-only operations if all fields are attributes.
+The other document fields are stored as blobs/records in the
+<a href="#document-store">document store</a>.
+This record is used when processing summary requests
+that include fields in this record, and as needed during visiting or
+re-distribution of content to handle elasticity.
+</p><p>
+The default summary class will always access the document store because it
+includes the <a href="documents.html#document-ids">document ID</a> which is stored here.
+To include the <a href="documents.html#document-ids">document ID</a> in a custom summary
+class, add a field for the id and include it in the summary class.
+</p><p>
+When using additional summary classes to increase performance,
+only the network data size is changed - the data read from storage is unchanged.
+Having "debug" fields with summary enabled will hence also affect the
+amount of information that needs to be read from disk.
+</p><p>
+Use <a href="/documentation/reference/search-definitions-reference.html#summary">dynamic</a>
+to generate dynamic abstracts of fields, based on search keywords.
 </p>
-
-<ul class="alert-success">
-  <li>When configuring or using additional summaries for performance
-  reasons, you only limit the amount of network bandwidth used
-  when using a summary with fewer fields than the default. Having
-  'debug' fields with summary enabled will hence also affect the
-  amount of information that needs to be read from disk even for the
-  production summaries.</li>
-  <li>Vespa keeps <a href="attributes.html">attribute</a>
-  type fields in memory and fetches those fields from
-  memory when requested as part of document summaries.
-  This means summaries are memory-only operations if all fields are attributes.</li>
-  <li>The remaining document fields are stored as blobs/records in the
-  <a href="#document-store">document store</a>,
-  possibly compressed, possibly along with a number of other
-  documents in order to have sufficient data to achieve a reasonable
-  compression ratio. This record is used when processing summary requests
-  that include fields in this record, and as needed during visiting or
-  re-distribution of content to handle elasticity.</li>
-  <li>The default summary class will always access the document store because it
-  includes the <a href="documents.html#document-ids">document ID</a> which is stored here.</li>
-  <li>To include the <a href="documents.html#document-ids">document ID</a> in a custom summary 
-  class it has to be included in an explicit summary definition.</li>
-</ul>
 
 
 

--- a/documentation/search-api.html
+++ b/documentation/search-api.html
@@ -220,88 +220,16 @@ for the full list.
 </p>
 
 
-<h2 id="default-result-format">Default Result Format</h2>
+<h2 id="results">Results</h2>
 <p>
-The default output format is <a href="./reference/default-result-format.html">JSON</a>.
-The basic structure is:
-<pre>
-{
-    "root": {
-        "children": [
-            objects with same structure as root itself...
-        ],
-        "fields": {
-            "document field name": "document field contents",
-            …
-        }
-    }
-}
-</pre>
-As for a complete example of the structure:
-<pre>
-{
-    "root": {
-        "children": [
-            {
-                "children": [
-                    {
-                        "fields": {
-                            "c": "d",
-                            "uri": "http://localhost/1"
-                        },
-                        "id": "http://localhost/1",
-                        "relevance": 0.9,
-                        "types": [
-                            "summary"
-                        ]
-                    }
-                ],
-                "id": "usual",
-                "relevance": 1.0
-            },
-            {
-                "fields": {
-                    "e": "f"
-                },
-                "id": "type grouphit",
-                "relevance": 1.0,
-                "types": [
-                    "grouphit"
-                ]
-            },
-            {
-                "fields": {
-                    "description": "foo",
-                    "uri": "http://localhost/"
-                },
-                "id": "http://localhost/",
-                "relevance": 0.95,
-                "types": [
-                    "summary"
-                ]
-            }
-        ],
-        "coverage": {
-            "coverage": 100,
-            "documents": 500,
-            "full": true,
-            "nodes": 1,
-            "results": 1,
-            "resultsFull": 1
-        },
-        "errors": [
-            {
-                "code": 18,
-                "message": "boom",
-                "summary": "Internal server error."
-            }
-        ],
-        "fields": {
-            "totalCount": 130
-        },
-        "id": "toplevel",
-        "relevance": 1.0
-    }
-}
-</pre>
+All fields are returned in results by default.
+To specify a subset of fields, use <a href="/documentation/document-summaries.html">document summaries</a>.
+When searching text, having a static abstract of the document in a field, or
+using a <a href="/documentation/reference/search-definitions-reference.html#summary">dynamic summary</a>
+can both improve the visual relevance of the search, as well as cut bandwidth used.
+</p><p>
+The default output format is JSON, find details in the <a href="./reference/default-result-format.html">reference</a>.
+</p><p>
+Read more on <a href="/documentation/jdisc/processing.html">request-response</a> processing -
+use this to write code to manipulate results.
 </p>


### PR DESCRIPTION
- link from search api
- remove example that is also found in JSON doc
- link to dynamic summaries
- better format