### PR TITLE
Files used for search on indexed fields are memory mapped.

### DIFF
--- a/documentation/content/setup-proton-tuning.html
+++ b/documentation/content/setup-proton-tuning.html
@@ -407,10 +407,6 @@ Tune various aspect with the handling of disk and memory indexes. Optional sub-e
         Controls io read options used during index dump and fusion,
         values={normal,directio}, default directio
         </li>
-        <li id="index-io-search"><code>search</code>:
-        Controls io read options used during searching in disk index,
-        values={normal,directio,mmap}, default mmap
-        </li>
     </ul>
     </li>
 </ul>


### PR DESCRIPTION
@geirst: please review
