### PR TITLE
add default for flush-on-shutdown

### DIFF
--- a/documentation/reference/services-content.html
+++ b/documentation/reference/services-content.html
@@ -538,8 +538,7 @@ Note that this is only useful if <code>searchable-copies</code> is less than <co
 
 <h2 id="flush-on-shutdown">flush-on-shutdown</h2>
 <p>
-Contained in <code><a href="#proton">proton</a></code>.
-Defult value is false.
+Contained in <code><a href="#proton">proton</a></code>. Defult value is true.
 If set to true, search nodes will flush a set of components (e.g. memory index, attributes) to disk
 before shutting down such that the time it takes to flush these components
 plus the time it takes to replay the transaction log after restart is as low as possible.

--- a/documentation/reference/services-content.html
+++ b/documentation/reference/services-content.html
@@ -539,6 +539,7 @@ Note that this is only useful if <code>searchable-copies</code> is less than <co
 <h2 id="flush-on-shutdown">flush-on-shutdown</h2>
 <p>
 Contained in <code><a href="#proton">proton</a></code>.
+Defult value is false.
 If set to true, search nodes will flush a set of components (e.g. memory index, attributes) to disk
 before shutting down such that the time it takes to flush these components
 plus the time it takes to replay the transaction log after restart is as low as possible.

--- a/documentation/reference/services-content.html
+++ b/documentation/reference/services-content.html
@@ -538,7 +538,7 @@ Note that this is only useful if <code>searchable-copies</code> is less than <co
 
 <h2 id="flush-on-shutdown">flush-on-shutdown</h2>
 <p>
-Contained in <code><a href="#proton">proton</a></code>. Defult value is true.
+Contained in <code><a href="#proton">proton</a></code>. Default value is true.
 If set to true, search nodes will flush a set of components (e.g. memory index, attributes) to disk
 before shutting down such that the time it takes to flush these components
 plus the time it takes to replay the transaction log after restart is as low as possible.


### PR DESCRIPTION
I don't know if the default is true or false - could not see from https://github.com/vespa-engine/vespa/blob/a902861604ddbaa45be0078a733add8f5009a30e/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java#L84 nor https://github.com/vespa-engine/vespa/blob/49a532f515d9ce217def27443b5bb9faa6410124/config-model/src/main/resources/schema/content.rnc#L164
