### PR TITLE
Documentation typo fix

### DIFF
--- a/documentation/developing-web-services.html
+++ b/documentation/developing-web-services.html
@@ -149,7 +149,7 @@ is recommended if the application is a standalone HTTP API,
 and especially if there are properties used with the same name as those in the
 <a href="reference/search-api-reference.html">search API</a>.
 A request handler may query the search components running in the same container
-with any appreciable overhead:</p>
+without any appreciable overhead:</p>
 
 
 <h3 id="invoking-search-queries-from-a-jdisc-component">Invoking search queries from a JDisc component</h3>

--- a/documentation/document-summaries.html
+++ b/documentation/document-summaries.html
@@ -267,7 +267,7 @@ Notes:
   <li>Read more on implications of setting <em>maxfilesize</em> in
     <a href="proton.html#document-store-compaction">proton maintenance jobs</a>.</li>
   <li>Files are written in <a href="content/setup-proton-tuning.html#summary-store-logstore-chunk">chunks</a>,
-    using comression settings.
+    using compression settings.
 </ul>
 
 <h3 id="visiting-the-document-store">Visiting the document store</h3>


### PR DESCRIPTION
Looks like the word should be `without` not `with`