### PR TITLE
Remove experimental enable-multiple-bucket-spaces

### DIFF
--- a/documentation/reference/services-content.html
+++ b/documentation/reference/services-content.html
@@ -57,8 +57,6 @@ title: "services.xml - 'content'"
             <a href="#stable-state-period">stable-state-period</a>
             <a href="#min-distributor-up-ratio">min-distributor-up-ratio</a>
             <a href="#min-storage-up-ratio">min-storage-up-ratio</a>
-    <a href="#experimental">experimental</a>
-        <a href="#enable-multiple-bucket-spaces">enable-multiple-bucket-spaces</a>
 
 </pre>
 
@@ -1144,48 +1142,3 @@ Tuning parameters for the cluster controller managing this cluster - child eleme
         cluster state to be <em>up</em>.</td></tr>
   </tbody>
 </table>
-
-<h2 id="experimental">experimental</h2>
-<p>Contained in <a href="#content"><code>content</code></a>, optional. Contains flags to conditionally enable features
-that are undergoing active development or that have recently been added.
-Optional sub-elements:
-<ul>
-  <li><a href="#enable-multiple-bucket-spaces"><code>enable-multiple-bucket-spaces</code></a></li>
-</ul>
-</p>
-
-<h2 id="enable-multiple-bucket-spaces">enable-multiple-bucket-spaces</h2>
-<p>
-Contained in <a href="#experimental"><code>experimental</code></a>.
-Valid values are <strong>true</strong> (default) or <strong>false</strong>.
-If set to true, global documents are distributed to all nodes in the content
-cluster regardless of the cluster's topology.
-</p>
-<p class="alert alert-success">
-<strong>This feature is enabled by default on Vespa 6.245 and beyond.</strong>
-You don't need to set this flag unless you are on an older version.
-</p>
-<p class="alert alert-warning">
-<strong>To enable multiple bucket spaces, all distributor and searchnode processes
-must be restarted.</strong> All nodes must be upgraded to a Vespa version supporting
-this feature before any global documents may be fed into the system.
-<br/><br/>
-If you already have documents marked as global <em>before</em> enabling this feature,
-<strong>all distributor and searchnode processes must be shut down prior</strong> to
-deploying an application version enabling it. Once the application has been deployed
-successfully, you may start the processes back up. This is because the existing
-global documents must be moved into the correct data space upon startup, and this
-cannot happen while the system is running.
-</p>
-<p>
-Example:
-<pre>
-&lt;documents&gt;
-  &lt;document global='true' mode='index' type='campaign'/&gt;
-  &lt;document mode='index' type='ad'/&gt;
-&lt;/documents&gt;
-&lt;experimental&gt;
-  &lt;enable-multiple-bucket-spaces&gt;true&lt;/enable-multiple-bucket-spaces&gt;
-&lt;/experimental&gt;
-</pre>
-</p>


### PR DESCRIPTION
This feature is enabled by default on Vespa 6.245 and beyond. You don't need to set this flag unless you are on an older version.

Ref https://github.com/vespa-engine/vespa/pull/7753