### PR TITLE
Update REST "put state" documentaton

### DIFF
--- a/documentation/content/api-state-rest-api.html
+++ b/documentation/content/api-state-rest-api.html
@@ -340,9 +340,6 @@ admin/cluster-controllers/0
 <h3>Set node user state</h3>
 <pre class="code">
     HTTP PUT /cluster/v2/<em>&lt;cluster&gt;</em>/<em>&lt;service-type&gt;</em>/<em>&lt;node&gt;</em>
-</pre>
-<p>Example success result:</p>
-<pre class="code">
     Content-Type: application/json
 
     {
@@ -352,6 +349,16 @@ admin/cluster-controllers/0
                 "reason" : "This colo will be removed soon"
             }
         }
+    }
+</pre>
+<p>Success result:</p>
+<pre class="code">
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    
+    {
+        "wasModified": true,
+        "reason": "ok"
     }
 </pre>
 


### PR DESCRIPTION
The REST "put  state" documentation was specifying the payload as a result, and did not actually show what a success result is.