### PR TITLE
Add boolean

### DIFF
--- a/documentation/query-language.html
+++ b/documentation/query-language.html
@@ -195,6 +195,14 @@ Numbers must be in the signed 32-bit range. To input 64-bit signed numbers, use 
 
 
 
+<h2 id="boolean-operator">Boolean Operator</h2>
+<p>
+The boolean operator is: =
+<pre class="urlunencode" oncopy="">
+select%20%2A%20from%20sources%20%2A%20where%20alive%20%3D%20true%3B
+</pre>
+</p>
+
 <h2 id="grouping">Grouping</h2>
 <p>
 Group / aggregate results using a grouping expression:

--- a/documentation/search-api.html
+++ b/documentation/search-api.html
@@ -53,7 +53,9 @@ http://host:port/search/?param1=value1&amp;param2=value2&amp;...
 </p><p>
   Use GET or POST - Parameters can either be sent as GET-parameters or posted as JSON, these are equivalent:
 <pre>
-$ curl -H "Content-Type: application/json" --data '{"yql" : "select * from sources * where default contains \"bad\";"}' http://localhost:8080/search/
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where default contains \"bad\";"}' \
+    http://localhost:8080/search/
 
 $ curl http://localhost:8080/search/?yql=select+%2A+from+sources+%2A+where+default+contains+%22bad%22%3B
 </pre>
@@ -104,46 +106,72 @@ Examples - refer to <a href="query-language.html">YQL</a>, <a href="grouping.htm
       <th>Ordering</th>
       <td>
 <pre>
-$ curl -H "Content-Type: application/json" --data '{"yql" : "select * from sources * where default contains \"bad\"\
-<span style="background-color: yellow;">order by year desc</span>;"}' http://localhost:8080/search/
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where default contains \"bad\" order by year desc;"}' \
+    http://localhost:8080/search/
 </pre>
       </td>
     </tr><tr>
       <th>Grouping</th>
       <td>
 <pre>
-$ curl -H "Content-Type: application/json" --data '{"yql" : "select * from sources * where default contains \"bad\"\
-<span style="background-color: yellow;">| all(group(year) each(output(sum(duration))))</span>;"}' http://localhost:8080/search/
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where default contains \"bad\" | all(group(year) each(output(sum(duration))));"}' \
+    http://localhost:8080/search/
 </pre>
       </td>
     </tr><tr>
       <th>Pagination</th>
       <td>
 <pre>
-$ curl -H "Content-Type: application/json" --data '{"yql" : "select * from sources * where default contains \"bad\"\
-<span style="background-color: yellow;">limit 2 offset 1</span>;"}' http://localhost:8080/search/
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where default contains \"bad\" limit 2 offset 1;"}' \
+    http://localhost:8080/search/
 </pre>
       </td>
     </tr><tr>
       <th>Numeric</th>
       <td>
 <pre>
-$ curl -H "Content-Type: application/json" --data '{"yql" : "select * from sources * where <span style="background-color: yellow;">year > 2000</span>"} http://localhost:8080/search/
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where year > 2000;"}' \
+    http://localhost:8080/search/
+</pre>
+      </td>
+    </tr><tr>
+      <th>Boolean</th>
+      <td>
+<pre>
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where alive = true;"}' \
+    http://localhost:8080/search/
+</pre>
+      </td>
+    </tr><tr>
+      <th>Phrase</th>
+      <td>
+<pre>
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where artist contains phrase(\"michael\", \"jackson\");"}' \
+    http://localhost:8080/search/
 </pre>
       </td>
     </tr><tr>
       <th>Timeout</th>
       <td>
 <pre>
-$ curl -H "Content-Type: application/json" --data '{"yql" : "select * from sources * where default contains \"bad\"\
-<span style="background-color: yellow;">timeout 100</span>"} http://localhost:8080/search/
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where default contains \"bad\" timeout 100;"}' \
+    http://localhost:8080/search/
 </pre>
       </td>
     </tr><tr>
       <th>Regexp</th>
       <td>
 <pre>
-$ curl -H "Content-Type: application/json" --data '{"yql" : "select * from sources * where title <span style="background-color: yellow;">matches \"mado[n]+a\"</span>"} http://localhost:8080/search/
+$ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where title matches \"mado[n]+a\";"}' \
+    http://localhost:8080/search/
 </pre>
       </td>
     </tr>


### PR DESCRIPTION
- add example to search API
- add section to YQL doc
- make examples in search-api.html actually work for copy paste + readable
- bonus: add a phrase example, too

the search API / YQL doc is generally a mess:
- should have a proper YQL ref doc
  - and a query api guide with lotsof great examples - that could be tested using a sample app
- will try to get to it ...