### PR TITLE
[VESPA-14634] Add excluded char per RFC 2396 MERGEOK

### DIFF
--- a/documentation/vespa7-release-notes.html
+++ b/documentation/vespa7-release-notes.html
@@ -321,6 +321,10 @@ Vespa 7 requires these characters to be properly percent-encoded (RFC 2396).
     <td>%5E</td>
   </tr>
   <tr>
+    <td>`</td>
+    <td>%60</td>
+  </tr>    
+  <tr>
     <td>{</td>
     <td>%7B</td>
   </tr>


### PR DESCRIPTION
Back-tick is rejected by Vespa 7.
Brackets are still allowed with Vespa 7 but not per the RFC.

@kkraune / @bratseth Please review and merge.