### PR TITLE
remove attribute: huge references

### DIFF
--- a/documentation/attributes.html
+++ b/documentation/attributes.html
@@ -66,6 +66,9 @@ When <em>resizing</em> attributes, both current and new attribute will temporari
 Hence, increasing an attribute means more than doubling the memory used -
 refer to the <a href="content/setup-proton-tuning.html#resizing">resizing reference</a>.
 </p><p>
+Multi-value attributes use an adaptive approach in how data is stored in memory,
+and up to 1 billion documents per node is supported.
+</p><p>
 Read the <a href="performance/attribute-memory-usage.html">attribute sizing guide</a>.
 </p>
 

--- a/documentation/attributes.html
+++ b/documentation/attributes.html
@@ -67,7 +67,7 @@ Hence, increasing an attribute means more than doubling the memory used -
 refer to the <a href="content/setup-proton-tuning.html#resizing">resizing reference</a>.
 </p><p>
 Multi-value attributes use an adaptive approach in how data is stored in memory,
-and up to 1 billion documents per node is supported.
+and up to 2 billion documents per node is supported.
 </p><p>
 Read the <a href="performance/attribute-memory-usage.html">attribute sizing guide</a>.
 </p>

--- a/documentation/performance/attribute-memory-usage.html
+++ b/documentation/performance/attribute-memory-usage.html
@@ -152,8 +152,7 @@ listed below - concepts:
     <tr>
       <td>IW</td>
       <td>Index width</td>
-      <td>Width of index - 4 bytes, 8 bytes if
-        <a href="../reference/search-definitions-reference.html#attribute">huge</a> is set</td>
+      <td>Width of index - 4 bytes</td>
     </tr>
     <tr>
       <td>ROF</td>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1244,9 +1244,6 @@ the context of applying partial updates and when used in a
 <a href="services-content.html#documents">selection expression</a> for garbage collection.
 If <code>redundancy</code> == <code>searchable-copies</code> (default) this property is a no-op.
 </td></tr>
-<tr><td>huge</td><td>Deprecated. This setting no longer have any effect.
-        All multi-value attributes now use a more adaptive approach in how data is stored in memory,
-        and up to 1 billion documents per node is supported.</td></tr>
 <tr><td><a href="#alias">alias</a></td><td>An alias for the attribute.
   Add an attribute name before the colon to specify an alias for another attribute than the one given by field name.</td>
 <tr><td><a href="#sorting">sorting</a></td><td>The sort specification for this attribute.</td></tr>
@@ -3024,7 +3021,7 @@ Changes:
   <tr><th>Change the attribute settings for an attribute field</th><th>index, streaming</th>
   <td>
   For mode <em>index</em>: Change the following attribute settings:
-  <code>fast-search</code>, <code>fast-access</code>, <code>huge</code>.
+  <code>fast-search</code>, <code>fast-access</code>.
   <br>
   For mode <em>streaming</em>: Change the following attribute settings:
   <code>fast-access</code> (the other settings are not used)

--- a/documentation/writing-to-vespa.html
+++ b/documentation/writing-to-vespa.html
@@ -155,17 +155,15 @@ The following limits will block feeding:
   </td><td>content.proton.documentdb.attribute.resource_usage.enum_store</td>
   <td>For string attribute fields or attribute fields with
     <a href="attributes.html#attributes-and-search">fast-search</a>,
-    there is a max limit on the size of the unique values stored for that attribute.
-    The component storing these values is called enum store. The limit is 32GB</td></tr>
+    there is a 32GB max limit on the size of the unique values stored for that attribute.
+    The component storing these values is called enum store</td></tr>
 <tr><td>attribute multi-value</td>
   <td><a href="https://github.com/vespa-engine/vespa/blob/master/searchcore/src/vespa/searchcore/config/proton.def">
     writefilter.attribute.multivaluelimit</a>
   </td><td>content.proton.documentdb.attribute.resource_usage.multi_value</td>
   <td>For array or weighted set attribute fields,
     there is a max limit on the number of documents that can have the same number of values.
-    The limit is 128M (2^27) documents.
-    To remedy, either change the attribute field to use
-    <a href="reference/search-definitions-reference.html#attribute">huge</a>, or add/change nodes</td></tr>
+    The limit is 128M (2^27) documents</td></tr>
 </tbody>
 </table>
 To remedy, add nodes to the content cluster or swap nodes with higher capacity.

--- a/documentation/writing-to-vespa.html
+++ b/documentation/writing-to-vespa.html
@@ -163,7 +163,7 @@ The following limits will block feeding:
   </td><td>content.proton.documentdb.attribute.resource_usage.multi_value</td>
   <td>For array or weighted set attribute fields,
     there is a max limit on the number of documents that can have the same number of values.
-    The limit is 128M (2^27) documents</td></tr>
+    The limit is 2 billion documents per node</td></tr>
 </tbody>
 </table>
 To remedy, add nodes to the content cluster or swap nodes with higher capacity.


### PR DESCRIPTION
ref https://github.com/vespa-engine/vespa/issues/8376 - _attribute: huge:_ has no effect and will be removed - so might as well remove from documentation now

@baldersheim FYI