### PR TITLE
vespa-visit ref doc and bucket space placeholder

### DIFF
--- a/documentation/content/buckets.html
+++ b/documentation/content/buckets.html
@@ -43,6 +43,15 @@ Similarly buckets can be joined by requiring one less bit in common.
 </p>
 
 
+
+<h2 id="bucket-space">Bucket space</h2>
+<p>
+Buckets exist in the <em>default</em> or <em>global</em> bucket space.
+<!-- ToDo more info here -->
+</p>
+
+
+
 <h2 id="distribution">Distribution</h2>
 <p>
 Distribution happens in several layers.
@@ -165,6 +174,7 @@ The cost is that the remaining partitions on the node
 will not take over any load from the disk that went down.
 However, in clusters with many nodes, this should be a small percentage of the partitions.
 </p>
+
 
 
 <h2 id="maintenance-operations">Maintenance operations</h2>

--- a/documentation/content/visiting.html
+++ b/documentation/content/visiting.html
@@ -27,8 +27,7 @@ Throttling ensures that only a few requests are active per content node at a tim
 For programmatic access, check the
 <a href="../document-api-guide.html#visitorsession">visitor session API</a>.
 </p><p>
-<em>vespa-visit</em> is used to run a visit operation.
-See <em>vespa-visit --help</em> or <em>man vespa-visit</em> for details.
+<a href="../reference/vespa-cmdline-tools.html#vespa-visit">vespa-visit</a> is used to run a visit operation.
 By default, vespa-visit gets visited documents and emits to stdout.
 However, the tool may specify a visitor target and be used as a tool
 to run reprocessing or migration.

--- a/documentation/reference/vespa-cmdline-tools.html
+++ b/documentation/reference/vespa-cmdline-tools.html
@@ -1398,7 +1398,8 @@ Options:
     </tr><tr>
       <th> -s, --bucketspace &lt;space&gt;</th>
       <td>
-          Stat buckets within the given bucket space - if not provided, 'default' is used
+          <a href="../content/buckets.html#bucket-space">Bucket space</a>
+          (<em>default</em> or <em>global</em>). If not specified, <em>default</em> is used
       </td>
     </tr><tr>
       <th> -u, --user &lt;userid&gt;</th>
@@ -1499,11 +1500,141 @@ Options:
 
 
 
+
+
 <h2 id="vespa-visit">vespa-visit</h2>
 <p>
 Refer to <a href="../content/visiting.html">visiting</a>.
+</p><p>
+Synopsis: <code>vespa-visit [options]</code>
+</p><p>
+Options:
+<table class="table">
+  <thead></thead><tbody>
+    <tr>
+      <th style="width:300px">--abortonclusterdown</th>
+      <td>Abort if cluster is down</td>
+    </tr><tr>
+      <th>-b, --maxbuckets &lt;num&gt;</th>
+      <td>Maximum buckets per visitor</td>
+    </tr><tr>
+      <th>--bucketspace &lt;space&gt;</th>
+      <td>
+        <a href="../content/buckets.html#bucket-space">Bucket space</a> to visit
+        (<em>default</em> or <em>global</em>). If not specified, <em>default</em> is used
+      </td>
+    </tr><tr>
+      <th>-c, --cluster &lt;cluster&gt;</th>
+      <td>Visit the given cluster</td>
+    </tr><tr>
+      <th>-d, --datahandler &lt;target&gt;</th>
+      <td>Send results to the given target</td> <!-- ToDo document vespa-visit-target below and link to it -->
+    </tr><tr>
+      <th>-f, --from &lt;timestamp&gt;</th>
+      <td>Only visit from the given timestamp (microseconds)</td> <!-- ToDo: Does this work now? -->
+    </tr><tr>
+      <th>-h, --help</th>
+      <td>Show help text</td>
+    </tr><tr>
+      <th>-i, --printids</th>
+      <td>Display only document identifiers</td>
+    </tr><tr>
+      <th>--jsonoutput</th>
+      <td>Output documents as JSON (default format)</td> <!-- ToDo: remove this? -->
+    </tr><tr>
+      <th>-l, --fieldset &lt;fieldset&gt;</th>
+      <td>
+        Retrieve the specified fields only, see <a href="../documents.html#fieldsets">fieldsets</a>.
+        Default is <em>[all]</em>
+      </td>
+    </tr><tr>
+      <th>--libraryparam &lt;key&gt; &lt;val&gt;</th>
+      <td>Send parameter to the visitor library</td>
+    </tr><tr>
+      <th>-m, --maxpending &lt;num&gt;</th>
+      <td>Maximum pending messages to data handlers per storage visitor</td>
+    </tr><tr>
+      <th>--maxhits &lt;num&gt;</th>
+      <td>
+        Abort visiting when received this many "first pass" documents.
+        Only appropriate for visiting involving id.order. <!-- ToDo: order is not supported, I think? Remove this? -->
+        This is an approximate number,
+        all pending work will be completed and those documents will also be returned
+      </td>
+    </tr><tr>
+      <th>--maxpendingsuperbuckets &lt;num&gt;</th>
+      <td>
+        Maximum pending visitor messages from the vespa-visit client.
+        If set, dynamic throttling of visitors is disabled <!-- ToDo: link to somewhere documenting throttling -->
+      </td>
+    </tr><tr>
+      <th>--maxtotalhits &lt;num&gt;</th>
+      <td>
+        Abort visiting when received this many total documents.
+        This is only an approximate number,
+        all pending work will be completed and those documents will also be returned
+      </td>
+    </tr><tr>
+      <th>-o, --timeout &lt;milliseconds&gt;</th>
+      <td>Time out visitor after given time</td>
+    </tr><tr>
+      <th>--ordering &lt;order&gt;</th>
+      <td>
+        Order to visit documents in.
+        Only makes sense in conjunction with a document selection involving id.order.
+        Values are <em>ascending</em> or <em>descending</em> <!-- ToDo: check. possibley fix document-select-language.html -->
+      </td>
+    </tr><tr>
+        <th>-p, --progress &lt;file&gt;</th>
+      <td>Use given file to track progress</td>
+    </tr><tr>
+      <th>--priority &lt;name&gt;</th>
+      <td>
+        Visitor <a href="services.html#clients">priority</a>. Defaults to NORMAL_3.
+        Use with care to avoid starving lower prioritized traffic in the cluster
+      </td>
+    </tr><tr>
+      <th>--processtime &lt;num&gt;</th>
+      <td>
+        Sleep this amount of millisecs before processing message.
+        (Debug option for pretending to be slow client)
+      </td>
+    </tr><tr>
+      <th>-r, --visitremoves</th>
+      <td>Include information of removed documents</td>
+    </tr><tr>
+      <th>-s, --selection &lt;selection&gt;</th>
+      <td><a href="document-select-language.html">Selection</a> string for which documents to visit</td>
+    </tr><tr>
+      <th>--skipbucketsonfatalerrors</th>
+      <td>Skip visiting super buckets with fatal error codes</td>
+    </tr><tr>
+      <th>--statistics &lt;args&gt;</th>
+      <td>Use CountVisitor for document statistics. Use comma-separated arguments</td>
+    </tr><tr>
+      <th>-t, --to &lt;timestamp&gt;</th>
+      <td>Only visit up to the given timestamp (microseconds)</td>
+    </tr><tr>
+      <th>--tracelevel &lt;level&gt;</th>
+      <td>Tracelevel ([0-9]), for debugging</td>
+    </tr><tr>
+      <th>-u, --buckettimeout &lt;milliseconds&gt;</th>
+      <td>Fail visitor if visiting a single bucket takes longer than this (default same as timeout)</td>
+    </tr><tr>
+      <th>-v, --verbose</th>
+      <td>Show progress and info on STDERR</td>
+    </tr><tr>
+      <th>--visitinconsistentbuckets</th>
+      <td>Don't wait for inconsistent buckets to become consistent</td>
+    </tr><tr>
+      <th>--visitlibrary &lt;string&gt;</th>
+      <td>Use the given visitor library</td>
+    </tr><tr>
+      <th>-x, --xmloutput</th>
+      <td>Output documents as XML</td> <!-- ToDo; deprecated? -->
+    </tr>
+  </tbody>
+</table>
 </p>
 
-
-
-<!--h2 id="vespa-visit">vespa-visit-target</h2-->
+<!--h2 id="vespa-visit">vespa-visit-target</h2--> <!-- linked from content/visiting.html -->


### PR DESCRIPTION
- for later improvements for doc on visiting global docs

please comment on (some of) the Todo's - not important to cover all, this is a lot ...

content primarily from -h output - without _-e,--headersonly_ which is no more ...