### PR TITLE
move text to reference docs

### DIFF
--- a/documentation/geo-search.html
+++ b/documentation/geo-search.html
@@ -4,9 +4,9 @@ title: "Geo Search"
 ---
 
 <p>
-A field can have type <a href="reference/search-definitions-reference.html#type:position">position</a>.
-This enables users to limit hits to within an area,
-or use the distance from a particular point as a criteria for relevancy calculation.
+To model position(s) in documents, use field(s) of type
+<a href="reference/search-definitions-reference.html#type:position">position</a>.
+Use this to limit hits to within an area, or use the distance from a position in rank functions.
 Sample search definition and document:
 <pre>
 search local {
@@ -33,19 +33,36 @@ search local {
     }
 ]
 </pre>
-Restrict search results to a <a href="reference/search-api-reference.html#geographical-searches">geographical position</a>,
-using <a href="reference/search-api-reference.html#pos.ll">pos.ll</a>:
+
+
+<h2 id="restrict">Restrict</h2>
+<p>
+To <a href="reference/search-api-reference.html#geographical-searches">restrict search results</a>,
+define the area using a position + radius or a bounding box.
+</p><p>
+Restrict search results using <a href="reference/search-api-reference.html#pos.ll">pos.ll</a> and default radius (50km):
 <pre>
 $ curl -H "Content-Type: application/json" \
   --data '{"yql" : "select * from sources * where title contains \"pizza\";"}' \
   http://localhost:8080/search/?pos.ll=N37.416383%3BW122.024683
 </pre>
-Alter the <a href="reference/search-api-reference.html#pos.radius">pos.radius</a> from the default:
+Set a different <a href="reference/search-api-reference.html#pos.radius">pos.radius</a>:
 <pre>
 $ curl -H "Content-Type: application/json" \
   --data '{"yql" : "select * from sources * where title contains \"pizza\";"}' \
   http://localhost:8080/search/?pos.ll=N37.416383%3BW122.024683&amp;pos.radius=5km
 </pre>
+Restrict search results using <a href="reference/search-api-reference.html#pos.bb">pos.bb</a> bounding box:
+<pre>
+    $ curl -H "Content-Type: application/json" \
+    --data '{"yql" : "select * from sources * where title contains \"pizza\";"}' \
+    http://localhost:8080/search/?pos.bb=n=37.44899,s=37.3323,e=-121.98241,w=-122.06566
+</pre>
+</p>
+
+
+<h2 id="rank">Rank</h2>
+<p>
 The corresponding rank features for this example are
 <a href="reference/rank-features.html#distance(name)">distance(latlong)</a> or
 <a href="reference/rank-features.html#closeness(name)">closeness(latlong)</a> or
@@ -57,13 +74,7 @@ the last is probably the most useful when combining distance ranking with textua
 
 <h2 id="summary-fields">Summary fields</h2>
 <p>
-A position field configured as:
-<pre>
-field location type position {
-    indexing: attribute
-}
-</pre>
-is rendered as:
+A summary field is normally rendered like:
 <pre>
 "location.position": {
   "x": -121996000,
@@ -72,29 +83,9 @@ is rendered as:
 },
 "location.distance": 27488
 </pre>
-Adding <em>summary</em>:
-<pre>
-field location type position {
-    indexing: summary | attribute
-}
-</pre>
-will render it as:
-<pre>
-"location": {
-  "x": -121996000,
-  "y": 37401000
-},
-"location.position": {
-  "x": -121996000,
-  "y": 37401000,
-  "latlong": "N37.401000;W121.996000"
-},
-"location.distance": 27488
-</pre>
-
-
-<h3 id="distance">Distance</h3>
-<p>
+See the <a href="reference/search-definitions-reference.html#type:position">reference</a>
+for rendering options.
+</p><p>
 Note that search results has an additional <em>distrance</em> entry
 with the distance from the position, in millionths of a degree - about 10 cm.
 The new entry gets the name of the search definition field and the suffix <em>distance</em>:
@@ -108,8 +99,7 @@ For documents with multiple positions in the attribute, the distance to the near
 
 <h3 id="x-y">X/Y</h3>
 <p>
-Note that the numbers used for "x" and "y" in the above two fields are integers -
-it's a direct representation of the internal x/y struct used for position.
+The numbers used for "x" and "y" in the above two fields are integers.
 These are in millionths of a degree.
 Also note which is which of "x" and "y":
 </p><img src="img/Mercator_projection.jpg" height="407" width="480"><p>
@@ -119,39 +109,6 @@ so "x" is the longitude (east-west) and "y" the latitude (north-south).
 The third summary field is the distance, also as an integer, and also in millionths of degrees.
 When converting to internal units (millionths of degrees), the Earth polar radius is used,
 so <code>degrees = 180.0 * meters / (Math.PI * 6356752.0);</code> is the basic conversion formula.
-</p>
-
-
-
-<h2>Bounding box</h2>
-<p>
-When searching for all documents that has a location in a given map view,
-it is most convenient to specify a bounding box instead
-of searching for all documents within a radius from a point.
-This can be achieved using the <a href="reference/search-api-reference.html#pos.bb">pos.bb</a>
-parameter in the query:
-<pre>
-search/?query=pizza&amp;pos.bb=n=37.44899,s=37.3323,e=-121.98241,w=-122.06566
-</pre>
-Example result:
-<pre>
-&lt;boundingBox&gt;
-  &lt;southWest&gt;
-    &lt;latitude&gt;40.183868&lt;/latitude&gt;
-    &lt;longitude&gt;-74.819519&lt;/longitude&gt;
-  &lt;/southWest&gt;
-  &lt;northEast&gt;
-    &lt;latitude&gt;40.248291&lt;/latitude&gt;
-    &lt;longitude&gt;-74.728798&lt;/longitude&gt;
-  &lt;/northEast&gt;
-&lt;/boundingBox&gt;
-</pre>
-here you have (in order) south/west corner, north/east corner, which is simple to use in a query like this:
-<pre>
-search/?query=pizza&amp;pos.bb=s=40.183868,w=-74.819519,n=40.248291,e=-74.728798
-</pre>
-The directions S/W/N/E can appear in any order, and be specified in lower or upper case,
-but you must have N>=S and E>=W.
 </p>
 
 

--- a/documentation/reference/search-api-reference.html
+++ b/documentation/reference/search-api-reference.html
@@ -892,9 +892,10 @@ Otherwise, use grouping.
 <tr><td>Alias</td><td></td></tr>
 <tr><td>Values</td><td>
   Bounding box for positions, given as latitude and longitude boundaries.
-  The four boundaries must be specified as N, S, E, W, with degrees as
-  a decimal fraction.  Degrees south of equator or west of Greenwich are
-  input as negative numbers. Examples:
+  The four boundaries must be specified as N, S, E, W, with degrees as a decimal fraction.
+  Degrees south of equator or west of Greenwich are negative numbers.
+  S/W/N/E can be in any order, and be specified in lower or upper case,
+  Restrictions: N>=S and E>=W. Examples:
   <ul>
     <li>n=37.44899,s=37.3323,e=-121.98241,w=-122.06566</li>
     <li>s=40.183868,w=-74.819519,n=40.248291,e=-74.728798</li>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -2218,18 +2218,6 @@ or as degrees subdivided in minutes and seconds.
 It is also valid to express minutes with a decimal fraction, supporting regular GPS output format.
 Small letter o may be used as a replacement for degrees.
 </p><p>
-Position fields in <em>search results</em> are rendered with X/Y coordinates
-as <em>fieldname.position</em>:
-<pre>
-"mypos.position": {
-    "y": 37401000,
-    "x": -121996000,
-    "latlong": "N37.401000;W121.996000"
-}
-</pre>
-The X/Y coordinates are in millionths of degrees - see coordinate system  in
-<a href="../geo-search.html#summary-fields">summary fields</a>.
-</p><p>
 When using the <a href="../document-api.html">document api</a>,
 position fields are rendered without <em>latlong</em>:
 <pre>
@@ -2238,7 +2226,6 @@ position fields are rendered without <em>latlong</em>:
     "y": -22453200
 }
 </pre>
-Use <a href="../documents.html#fieldsets">fieldsets</a> to control which fields to output.
 </p>
 <table class="table">
   <thead></thead><tbody>
@@ -2248,10 +2235,52 @@ Use <a href="../documents.html#fieldsets">fieldsets</a> to control which fields 
     </tr><tr>
       <th>Attribute</th>
       <td>Added as an interleaved 64-bit integer
-        (see <a href="http://en.wikipedia.org/wiki/Z-order_curve">Z-order curve</a>).</td>
+        (see <a href="http://en.wikipedia.org/wiki/Z-order_curve">Z-order curve</a>) -
+        queries are implemented by doing a set of range searches in the attribute.
+          This attribute has <a href="../attributes.html#attributes-and-search">fast-search</a> set implicitly</td>
     </tr><tr>
       <th>Summary</th>
-      <td>Added as-is.</td>
+      <td>
+        <p>
+          A position field configured as:
+<pre>
+field location type position {
+    indexing: attribute
+}
+</pre>
+          is rendered as:
+<pre>
+"location.position": {
+  "x": -121996000,
+  "y": 37401000,
+  "latlong": "N37.401000;W121.996000"
+},
+"location.distance": 27488
+</pre>
+          Adding <em>summary</em>:
+<pre>
+field location type position {
+    indexing: summary | attribute
+}
+</pre>
+          will render it as:
+ <pre>
+"location": {
+  "x": -121996000,
+  "y": 37401000
+},
+"location.position": {
+  "x": -121996000,
+  "y": 37401000,
+  "latlong": "N37.401000;W121.996000"
+},
+"location.distance": 27488
+</pre>
+          <em>The fieldname.distance is only calculated and rendered for queries with position</em>
+        </p><p>
+          The <a href="../geo-search.html#x-y">X/Y coordinates</a> are in millionths of degrees
+        </p>
+      </td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
@arnej27959 FYI

now more info is in reference docs, where it belongs. made pos/radius or bounding box examples easier / less text