### PR TITLE
Remove outdated meta-info from example searcher class comment.

### DIFF
--- a/documentation/searcher-development.html
+++ b/documentation/searcher-development.html
@@ -155,9 +155,6 @@ import com.yahoo.search.searchchain.Execution;
 
 /**
  * A searcher adding a new hit.
- *
- * @author  Joe Developer
- * @version $Id$
  */
 public class SimpleSearcher extends Searcher {
 


### PR DESCRIPTION
@bratseth 