### PR TITLE
Remove doc for specifying tensor type on the attribute.

### DIFF
--- a/documentation/onnx.md
+++ b/documentation/onnx.md
@@ -39,7 +39,6 @@ search onnx {
     document onnx {
         field document_tensor type tensor(d0[1],d1[784]) {
             indexing: attribute | summary
-            attribute: tensor(d0[1],d1[784])
         }
     }
     rank-profile default inherits default {

--- a/documentation/reference/document-json-update-format.html
+++ b/documentation/reference/document-json-update-format.html
@@ -72,7 +72,6 @@ field title type string {
 <pre>
 field tensorfield type tensor(x{},y{}) {
   indexing: attribute | summary
-  attribute: tensor(x{},y{})
 }
 </pre>
 <pre>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1247,7 +1247,6 @@ If <code>redundancy</code> == <code>searchable-copies</code> (default) this prop
 <tr><td><a href="#alias">alias</a></td><td>An alias for the attribute.
   Add an attribute name before the colon to specify an alias for another attribute than the one given by field name.</td>
 <tr><td><a href="#sorting">sorting</a></td><td>The sort specification for this attribute.</td></tr>
-<tr><td><a href="#tensor-type-spec">[tensor-type-spec]</a></td><td>The tensor type specification for this tensor attribute.</td></tr>
 </tbody>
 </table>
 An attribute is multi-valued if assigning it multiple values during indexing,
@@ -1333,7 +1332,7 @@ sorting {
 
 <h2 id="tensor-type-spec">tensor-type-spec</h2>
 <p>
-Contained in <code><a href="#attribute">attribute</a></code> or <code><a href="#constant">constant</a></code>.
+Contained in <code><a href="#constant">constant</a></code> or <code><a href="#type:tensor">tensor field type</a></code>.
 Specifies the tensor type for a tensor.
 A tensor type contains a list of dimensions on the format:
 <pre>
@@ -2532,12 +2531,10 @@ for the JSON feed format for tensors.
 <pre>
 field tensorfield type tensor(x{},y{}) {
     indexing: attribute | summary
-    attribute: tensor(x{},y{})
 }
 
 field tensorfield type tensor(x[2],y[2]) {
     indexing: attribute | summary
-    attribute: tensor(x[2],y[2])
 }
 </pre>
 <table class="table">

--- a/documentation/reference/tensor.html
+++ b/documentation/reference/tensor.html
@@ -741,7 +741,6 @@ reference doc for how to setup a tensor attribute in your search definition.
 <pre>
 field tensor_attribute type tensor(x{},y{}) {
     indexing: attribute | summary
-    attribute: tensor(x{},y{})
 }
 </pre>
 

--- a/documentation/tensor-user-guide.html
+++ b/documentation/tensor-user-guide.html
@@ -35,7 +35,6 @@ this example sets up a tensor field called <code>tensor_attribute</code>:
 <pre>
 field tensor_attribute type tensor(x{}) {
     indexing: attribute | summary
-    attribute: tensor(x{})
 }
 </pre>
 A tensor requires a type - <code>x{}</code> means <em>sparse</em> dimension,
@@ -293,7 +292,6 @@ search example {
   document example {
     field document_vector type tensor(x[4]) {
       indexing: attribute | summary
-      attribute: tensor(x[4])
     }
   }
   rank-profile dot_product {

--- a/documentation/tensorflow.md
+++ b/documentation/tensorflow.md
@@ -93,7 +93,6 @@ search tf {
     document tf {
         field document_tensor type tensor(d0[1],d1[784]) {
             indexing: attribute | summary
-            attribute: tensor(d0[1],d1[784])
         }
     }
     rank-profile default inherits default {

--- a/documentation/tutorials/blog-recommendation.md
+++ b/documentation/tutorials/blog-recommendation.md
@@ -232,7 +232,6 @@ A tensor field `user_item_cf` is added to `blog_post.sd` to hold the blog post l
 
 	field user_item_cf type tensor(user_item_cf[10]) {
 		indexing: summary | attribute
-		attribute: tensor(user_item_cf[10])
 	}
 
 	field has_user_item_cf type byte {
@@ -260,7 +259,6 @@ A new search definition  `user.sd`  defines a  document type named `user` to hol
 
             field user_item_cf type tensor(user_item_cf[10]) {
                 indexing: summary | attribute
-                attribute: tensor(user_item_cf[10])
             }
 
             field has_user_item_cf type byte {


### PR DESCRIPTION
This have no effect as the tensor type is always part of the field type definition.
The sd parser will be updated as well.

@bratseth please review
@toregge @lesters FYI