### PR TITLE
Update an struct attribute inside a map field

### DIFF
--- a/documentation/reference/document-json-format.html
+++ b/documentation/reference/document-json-format.html
@@ -635,7 +635,31 @@ for restrictions using structs.
 
 <h3 id="assign-map-field">Map field</h3>
 <p>
-Individual map entries are updated using <a href="document-field-path.html">field path</a> syntax.
+Individual map entries can be updated using <a href="document-field-path.html">field path</a> syntax.
+The following declaration defines a <code>map</code> where the <code>key</code> is an Integer and the value
+is a <code>person</code> struct.
+<pre>
+struct person {
+    field first_name type string {}
+    field last_name type string {}
+}
+field contact type map&lt;int, person&gt; {
+    indexing: summary
+}
+</pre>
+In this case, it is updated one of the attributes related to <code>person</code> struct where:
+<ul>
+    <li><code>person</code> is the struct type associated to every <code>map</code> key</li>
+    <li><code>{0}</code> is the key that it is going to be updated</li>
+    <li><code>first_name</code> is the attribute to be updated inside the <code>person</code> struct</li>
+</ul>
+<pre>
+{
+    "fields": {
+       "person{0}.first_name": { "assign": "John" }
+    }
+}
+</pre>
 Assigning an element to a key in a map will insert the key/value mapping if it does not already exist,
 or overwrite it with the new value if it does exist.
 Refer to the <a href="search-definitions-reference.html#type:map">reference</a>


### PR DESCRIPTION
Motivation: https://stackoverflow.com/questions/54697768/assigning-value-field-of-a-struct-in-a-map-struct-deletes-unspecified-values/54698231#54698231

It was added an example to illustrate how it can be updated an `struct` inside a `map`. 