### PR TITLE
Add missing IDs used in other pages

### DIFF
--- a/documentation/reference/document-json-format.html
+++ b/documentation/reference/document-json-format.html
@@ -372,7 +372,7 @@ The are two methods for document operations:
 </ul>
 <table class="table">
   <tr>
-    <td colspan="2"><h3>PUT</h3>
+    <td colspan="2"><h3 id="put">PUT</h3>
   </tr><tr>
     <td>Vespa HTTP client:
 <pre>
@@ -394,7 +394,7 @@ http <span style="background-color: yellow;">POST</span> /document/v1/music/musi
 </pre>
     </td>
   </tr><tr>
-    <td colspan="2"><h3>GET</h3>
+    <td colspan="2"><h3 id="get">GET</h3>
   </tr><tr>
     <td>Vespa HTTP client:
 <pre>
@@ -406,7 +406,7 @@ http <span style="background-color: yellow;">GET</span> /document/v1/music/music
 </pre>
     </td>
   </tr><tr>
-    <td colspan="2"><h3>REMOVE</h3>
+    <td colspan="2"><h3 id="remove">REMOVE</h3>
   </tr><tr>
     <td>Vespa HTTP client:
 <pre>
@@ -422,7 +422,7 @@ http <span style="background-color: yellow;">DELETE</span> /document/v1/music/mu
 </pre>
     </td>
   </tr><tr>
-    <td colspan="2"><h3>UPDATE</h3>
+    <td colspan="2"><h3 id="update">UPDATE</h3>
   </tr><tr>
     <td>Vespa HTTP client:
 <pre>


### PR DESCRIPTION
We need to add those IDs to make the use of links to those anchors possible.

(e.g.: https://github.com/vespa-engine/documentation/blob/master/documentation/writing-to-vespa.html#L37)

Also it corresponds to the guidelines of this documentation: https://github.com/vespa-engine/documentation#links