### PR TITLE
Kkraune/rank literal

### DIFF
--- a/documentation/ranking.html
+++ b/documentation/ranking.html
@@ -223,26 +223,28 @@ The resulting normalized rank scores makes it possible to implement
 relevance based blending, search assistance triggering when there are no good hits and so on.</p>
 
 
-<h2 id="literal-boosting">Literal boosting</h2>
 
-<p>By default, Vespa does <a href="stemming.html">stemming</a> and <em>normalization</em> of the
-words in the indexes and queries to increase recall.
+<h2 id="literal-boosting">Literal boosting</h2>
+<p>
+By default, Vespa does <a href="stemming.html">stemming</a> and
+<a href="reference/search-definitions-reference.html#normalizing">normalization</a>
+of the words in the indexes and queries to increase recall.
 Some times it helps relevance to write a ranking expression which gives a higher
 score to matches where the literal form used in the query matches the
 literal form used in the document.
 This can be done by adding <code>rank:literal</code> to the fields in question
 to turn this feature on, and writing a ranking function which accesses
 features for a field names as the original field with
-<code>_literal</code> appended. For example, if you have a field:
+<code>_literal</code> appended. Example field and ranking expression:
 <pre>
 field title type string {
     indexing: index
     rank:     literal
 }
-</pre>
-You can write this ranking expression: <code>0.9*fieldMatch(title) +
-0.1*fieldMatch(title_literal)</code>
+</pre><pre>
+0.9*fieldMatch(title) + 0.1*fieldMatch(title_literal)</pre>
 </p>
+
 
 
 <h2 id="if-function-and-string-equality-tests">The <code>if</code> function and string equality tests</h2>

--- a/documentation/reference/advanced-indexing-language.html
+++ b/documentation/reference/advanced-indexing-language.html
@@ -434,7 +434,7 @@ The following are the unclassified expressions available:
     <td><code>normalize</code></td>
     <td>
       Performs accent normalization on the input data (see
-      <a href="#normalize">normalization table</a>).
+      <a href="search-definitions-reference.html#normalizing">normalization table</a>).
       The corresponding query command for this function is
       <code>normalize</code>.
     </td>
@@ -622,69 +622,3 @@ the following will happen for the different partial updates:
   </tbody>
 </table>
 </p>
-
-
-<h2 id="normalize">Normalization table</h2>
-<p>
-This table shows how different characters are normalized when using
-the <code>normalize</code> expression. All normalization preserves case.
-</p>
-<table class="table">
-  <thead>
-  </thead><tbody>
-  <tr>
-    <td>à &#x21D2; a</td>
-    <td>ç &#x21D2; c</td>
-    <td>ð &#x21D2; d</td>
-    <td>ù &#x21D2; u</td>
-  </tr>
-  <tr>
-    <td>â &#x21D2; a</td>
-    <td>è &#x21D2; e</td>
-    <td>ñ &#x21D2; n</td>
-    <td>ú &#x21D2; u</td>
-  </tr>
-  <tr>
-    <td>á &#x21D2; a</td>
-    <td>é &#x21D2; e</td>
-    <td>ò &#x21D2; o</td>
-    <td>û &#x21D2; u</td>
-  </tr>
-  <tr>
-    <td>ã &#x21D2; a</td>
-    <td>ê &#x21D2; e</td>
-    <td>ó &#x21D2; o</td>
-    <td>ü &#x21D2; ue</td>
-  </tr>
-  <tr>
-    <td>ä &#x21D2; ae</td>
-    <td>ë &#x21D2; e</td>
-    <td>ô &#x21D2; o</td>
-    <td>&#xFD; &#x21D2; y</td>
-  </tr>
-  <tr>
-    <td>å &#x21D2; aa</td>
-    <td>ì &#x21D2; i</td>
-    <td>õ &#x21D2; o</td>
-    <td>ÿ &#x21D2; y</td>
-  </tr>
-  <tr>
-    <td>æ &#x21D2; ae</td>
-    <td>í &#x21D2; i</td>
-    <td>ö &#x21D2; oe</td>
-    <td>ß &#x21D2; ss</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td>î &#x21D2; i</td>
-    <td>ø &#x21D2; oe</td>
-    <td>&#xFE; &#x21D2; th</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td>ï &#x21D2; i</td>
-    <td></td>
-    <td></td>
-  </tr>
-  </tbody>
-</table>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1783,7 +1783,10 @@ Used to turn off implicit <code>rank: filter</code> when using <a href="#exact">
 If both <code>filter</code> and <code>normal</code> are set somehow,
 the effect is as if only <code>normal</code> was specified.
 </td></tr>
-</tbody>
+<tr id="literal"><td><code>literal</code></td><td>
+Rank literal matches higher (i.e. the non-stemmed/non-normalized form).
+Refer to <a href="../ranking.html#literal-boosting">literal boosting</a> for details
+</td></tr></tbody>
 </table>
 </p>
 

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1173,23 +1173,82 @@ all fields should use the same stemming type.
 
 <h2 id="normalizing">normalizing</h2>
 <p>Contained in <code><a href="#field">field</a></code>.
-Sets the normalizing to be done on this field. Normalizing will cause accents
-and similar decorations which are often misspelled to be normalized
-the same way both in documents and queries.
+Sets the normalizing to be done on this field.
+Default is to normalize. Normalization preserves case. 
+Normalizing will cause accents and similar decorations which are often misspelled
+to be normalized the same way both in documents and queries.
 <em>Not supported in <a href="../streaming-search.html">streaming search</a>.</em>
 <pre>
 normalizing: [normalizing-type]
 </pre>
-The normalizing type available is:
 <table class="table">
 <thead>
 <tr><th>Type</th><th>Description</th></tr>
 </thead><tbody>
-<tr><td><code>none</code></td><td>No normalizing</td></tr>
+<tr><td><code>none</code></td><td>No normalizing.</td></tr>
 </tbody>
 </table>
-If this is not set, normalization will be done for this field.
+Normalizations:
 </p>
+<table class="table">
+  <thead>
+  </thead><tbody>
+  <tr>
+    <td>à &#x21D2; a</td>
+    <td>ç &#x21D2; c</td>
+    <td>ð &#x21D2; d</td>
+    <td>ù &#x21D2; u</td>
+  </tr>
+  <tr>
+    <td>â &#x21D2; a</td>
+    <td>è &#x21D2; e</td>
+    <td>ñ &#x21D2; n</td>
+    <td>ú &#x21D2; u</td>
+  </tr>
+  <tr>
+    <td>á &#x21D2; a</td>
+    <td>é &#x21D2; e</td>
+    <td>ò &#x21D2; o</td>
+    <td>û &#x21D2; u</td>
+  </tr>
+  <tr>
+    <td>ã &#x21D2; a</td>
+    <td>ê &#x21D2; e</td>
+    <td>ó &#x21D2; o</td>
+    <td>ü &#x21D2; ue</td>
+  </tr>
+  <tr>
+    <td>ä &#x21D2; ae</td>
+    <td>ë &#x21D2; e</td>
+    <td>ô &#x21D2; o</td>
+    <td>&#xFD; &#x21D2; y</td>
+  </tr>
+  <tr>
+    <td>å &#x21D2; aa</td>
+    <td>ì &#x21D2; i</td>
+    <td>õ &#x21D2; o</td>
+    <td>ÿ &#x21D2; y</td>
+  </tr>
+  <tr>
+    <td>æ &#x21D2; ae</td>
+    <td>í &#x21D2; i</td>
+    <td>ö &#x21D2; oe</td>
+    <td>ß &#x21D2; ss</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>î &#x21D2; i</td>
+    <td>ø &#x21D2; oe</td>
+    <td>&#xFE; &#x21D2; th</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>ï &#x21D2; i</td>
+    <td></td>
+    <td></td>
+  </tr>
+  </tbody>
+</table>
 
 
 


### PR DESCRIPTION
per https://github.com/vespa-engine/vespa/blob/master/config-model/src/main/java/com/yahoo/searchdefinition/document/Ranking.java, _literal_ was the only thing missing for _rank:_ in search def reference.

bonus: improve normalization ref / links, too