### PR TITLE
Add information about coverage object in logs

### DIFF
--- a/documentation/access-logging.html
+++ b/documentation/access-logging.html
@@ -60,8 +60,8 @@ logged via Searcher code. The following fields are pre-defined by Vespa:
 <tr><td class="left">search</td><td class="left">object</td><td class="left">Object holding search specific fields</td><td class="left">no</td></tr>
 <tr><td class="left">search.totalhits</td><td class="left">number</td><td class="left">The total number of hits for the query</td><td class="left">no</td></tr>
 <tr><td class="left">search.hits</td><td class="left">number</td><td class="left">The hits returned in this specific response</td><td class="left">no</td></tr>
-<tr><td class="left">attributes</td><td class="left">object</td><td class="left">Object holding <a href="#logging-key-values-
-to-the-json-access-log-from-searchers">custom key/value pairs</a> logged in searcher.</td><td class="left">no</td></tr>
+<tr><td class="left">search.coverage</td><td class="left">object</td><td class="left">Object holding <a href="graceful-degradation.html#coverage">query coverage information</a> similar to that returned in result set.</td><td class="left">no</td></tr>
+<tr><td class="left">attributes</td><td class="left">object</td><td class="left">Object holding <a href="#logging-key-values-to-the-json-access-log-from-searchers">custom key/value pairs</a> logged in searcher.</td><td class="left">no</td></tr>
 </tbody>
 </table>
 <p>
@@ -71,7 +71,7 @@ to-the-json-access-log-from-searchers">custom key/value pairs</a> logged in sear
 </p><p>
 An example log line will look like this:
 <pre>
-{"ip":"152.200.54.243","time":920880005.023,"duration":0.122,"responsesize":9875,"code":200,"method":"GET","uri":"/search?query=test&amp;param=value","version":"HTTP/1.1","agent":"Mozilla/4.05 [en] (Win95; I)","host":"localhost","search":{"totalhits":1234,"hits":0}}
+{"ip":"152.200.54.243","time":920880005.023,"duration":0.122,"responsesize":9875,"code":200,"method":"GET","uri":"/search?query=test&amp;param=value","version":"HTTP/1.1","agent":"Mozilla/4.05 [en] (Win95; I)","host":"localhost","search":{"totalhits":1234,"hits":0,"coverage":{"coverage": 98, "documents": 100, "degraded": {"non-ideal-state": true}}}}
 </pre>
 A pretty print version of the same example:
 <pre>
@@ -88,7 +88,14 @@ A pretty print version of the same example:
   "host": "localhost",
   "search": {
     "totalhits": 1234,
-    "hits": 0
+    "hits": 0,
+    "coverage": {
+      "coverage": 98,
+      "documents": 100,
+      "degraded": {
+        "non-ideal-state": true
+      }
+    }
   }
 }
 </pre>
@@ -115,8 +122,6 @@ If the remote address or -port differs from those initiating the HTTP request,
 the address and port for the immediate client making the request are logged as
 <em>peeraddress</em> and <em>peerport</em> respectively.
 </p>
-
-
 
 <h2 id="configuring-logging">Configuring Logging</h2>
 <p>
@@ -228,8 +233,6 @@ Ending the list with '...' means continuing the
 defined by the two last numbers for the rest of the day.
 E.g. "0 100 240 480 ..." is expanded to "0 100 240 480 720 960 1200"
 </p>
-
-
 
 <h2 id="logging-key-values-to-the-json-access-log-from-searchers">Logging Key/Value pairs to the JSON Access Log from Searchers</h2>
 <p>


### PR DESCRIPTION
@kkraune / @baldersheim Please review

Re-using (pointing) to documentation already existing in https://docs.vespa.ai/documentation/graceful-degradation.html#coverage