### PR TITLE
Kkraune/versions

### DIFF
--- a/documentation/vespa-versions.html
+++ b/documentation/vespa-versions.html
@@ -7,7 +7,7 @@ title: "Vespa Versions"
 Vespa uses <a href="http://semver.org/">semantic versioning</a>.
 </p><p>
 Java APIs, web service APIs and all application package constructs are supported through a major release
-and only removed on a new release if they are already marked deprecated.
+and only removed in a new release if they are already marked deprecated.
 </p><p>
 Use of deprecated Java APIs will cause a warning on compilation,
 and use of deprecated application package constructs will cause a deprecation warning on deployment.
@@ -20,13 +20,13 @@ Note that Java APIs come in two categories:
 </ul>
 Check the Javadoc list to verify that you are using public packages.
 </p><p>
-In addition, some public Java classes and methods are marked with the com.google.common.annotations.Beta tag.
-These are under development and may still change before they stabilize.
+Some public Java classes and methods are annotated with <em>com.google.common.annotations.Beta</em>.
+These are under development, and may still change before they stabilize.
 </p>
 
 
 
-<h2 id="data">Stored Data</h2>
+<h2 id="stored-data">Stored Data</h2>
 <p>
 Data written to Vespa is compatible between adjacent releases.
 For self-hosted systems, it may be necessary to upgrade through each

--- a/documentation/vespa-versions.html
+++ b/documentation/vespa-versions.html
@@ -14,11 +14,11 @@ and use of deprecated application package constructs will cause a deprecation wa
 Note that Java APIs come in two categories:
 <ul>
   <li><em>Public APIs</em> carry the compatibility guarantee and are visible from your code
-    as well as in the javadoc</li> <!-- ToDo javadoc - link to something here if possible -->
+    as well as in the <a href="https://javadoc.io/doc/com.yahoo.vespa/application">javadoc</a></li>
   <li><em>Exported APIs</em> are also visible from your code,
-   but is not in the public Javadoc and carry no compatibility guarantee</li>
+   but is not in the public javadoc and carry no compatibility guarantee</li>
 </ul>
-Check the Javadoc list to verify that you are using public packages.
+Check the javadoc list to verify that you are using public packages.
 </p><p>
 Some public Java classes and methods are annotated with <em>com.google.common.annotations.Beta</em>.
 These are under development, and may still change before they stabilize.

--- a/documentation/vespa-versions.html
+++ b/documentation/vespa-versions.html
@@ -32,4 +32,20 @@ Data written to Vespa is compatible between adjacent releases.
 For self-hosted systems, it may be necessary to upgrade through each
 minor release rather than in larger leaps to ensure Vespa can read existing data.
 This is a good practice in any case.
+</p><p>
+When changes to the format of the stored data in Vespa are made,
+one cannot downgrade / roll back an upgrade without going through the below list
+to understand steps required:
 </p>
+<ul>
+  <li></li>
+</ul>
+<!--
+ It is hard to be specific, this depends on the change made.
+ It would be great if we can release versions that can read the new format but not write it yet.
+ That way, one can upgrade to vespa-x.y.z1 (which can _read_ new format),
+ then vespa-x.y.z2 or higher (which also _writes_ new format)
+ One can then roll back to vespa-x.y.z1 as needed.
+ Maybe this is overcomplicating - but this doc should nevertheless track such changes in specific versions,
+ and precautions per release
+-->

--- a/documentation/vespa-versions.html
+++ b/documentation/vespa-versions.html
@@ -33,6 +33,8 @@ For self-hosted systems, it may be necessary to upgrade through each
 minor release rather than in larger leaps to ensure Vespa can read existing data.
 This is a good practice in any case.
 </p><p>
+Also see the <a href="operations/live-upgrade.html">upgrade procedure</a>.
+</p><p>
 When changes to the format of the stored data in Vespa are made,
 one cannot downgrade / roll back an upgrade without going through the below list
 to understand steps required:


### PR DESCRIPTION
Only the three last commits need review

Side note: need to find out why some packages default to a vespa-6 javadoc version

As we are making changes to index format shortly, lets use this as an exercise to get this right - see my comment in last commit. The doc currently has nothing on downgrading. I think this is the best doc to put such things, open to suggestions