### PR TITLE
multithreaded

### DIFF
--- a/documentation/proton.html
+++ b/documentation/proton.html
@@ -313,7 +313,9 @@ Metrics are available at the <a href="reference/metrics-health-format.html">Metr
           <thead>
           </thead><tbody>
             <tr><th>CPU</th><td>
-              Little - one thread merges indices
+              Multiple threads merge indices, configured as a function of
+              <a href="content/setup-proton-tuning.html#feeding-concurrency">feeding concurrency</a> -
+              refer to this for details
             </td></tr>
             <tr><th>Memory</th><td>
               Little


### PR DESCRIPTION
also go through linked doc / other docs in the domain (defaults etc) so this is correct