### PR TITLE
link to reference, not guide

### DIFF
--- a/documentation/cloudconfig/application-packages.html
+++ b/documentation/cloudconfig/application-packages.html
@@ -54,8 +54,8 @@ Deploy the application package using <a href="../reference/vespa-cmdline-tools.h
 The application package is validated at deploy, and destructive changes blocked.
 To allow such changes to pass the validation in deploy prepare,
 add <a href="../reference/validation-overrides.html">validation-overrides.xml</a>.
-Making changes to <a href="../search-definitions.html#modify-search-definitions">search definitions</a> (e.g. add a field)
-is followed by a deployment to the application instance.
+Making changes to <a href="../reference/search-definitions-reference.html#modify-search-definitions">search definitions</a>
+(e.g. add a field) is followed by a deployment to the application instance.
 Most such changes do not require restarts or re-indexing, if they do, deployment fails, and a validation override is required.
 Use deploy to:
 <ol>

--- a/documentation/cloudconfig/deploy-rest-api-v2.html
+++ b/documentation/cloudconfig/deploy-rest-api-v2.html
@@ -398,17 +398,18 @@ Prepares an application with the <a href="#session-id">session id</a> given.
         <ul>
           <li>Log with any errors or warnings from preparing the application.</li>
           <li>An <a href="#activate-session">activate</a> URL for activating
-            the application with this <a href="#session-id">session id</a>, if there were no
-            errors.</li>
+            the application with this <a href="#session-id">session id</a>, if there were no errors.</li>
           <li>A list of actions (possibly empty) that must be performed in order to apply some config changes
             between the current active application and this next prepared application.
-            These actions are organized into two categories; restart and refeed:
+            These actions are organized into two categories; <em>restart</em> and <em>refeed</em>:
             <ul>
-              <li>Restart actions are done after the application has been activated and are handled by restarting all listed services. Please see <a href="../search-definitions.html#modify-search-definitions">
-                search definitions</a> for more information.</li>
-              <li>Refeed actions require several steps to handle. Please see
-                <a href="../search-definitions.html#modify-search-definitions">search definitions</a>
-                for more information.</li>
+              <li><em>Restart</em> actions are done after the application has been activated
+                and are handled by restarting all listed services.
+                See <a href="../reference/search-definitions-reference.html#modify-search-definitions">
+                search definitions</a> for details.</li>
+              <li><em>Refeed</em> actions require several steps to handle.
+                See <a href="../reference/search-definitions-reference.html#modify-search-definitions">
+                search definitions</a> for details.</li>
             </ul>
           </li>
         </ul>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1239,7 +1239,7 @@ attribute [attribute-name] {
 </pre>
 Read the <a href="../attributes.html">introduction to attributes</a>.
 The attribute name can be skipped, in which case the field name is used.
-Actions required when <a href="#modify-search-definitions"> adding or modifying attributes</a>.
+Actions required when <a href="#modify-search-definitions">adding or modifying attributes</a>.
 The following properties are available:
 <table class="table">
 <thead>

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1237,10 +1237,9 @@ attribute [attribute-name] {
     &hellip;
 }
 </pre>
+Read the <a href="../attributes.html">introduction to attributes</a>.
 The attribute name can be skipped, in which case the field name is used.
-Refer to <a href="../search-definitions.html#modify-search-definitions">
-search definitions</a> for actions required when adding or modifying attributes.
-Read <a href="../attributes.html">Attributes</a> for an introduction to attributes.
+Actions required when <a href="#modify-search-definitions"> adding or modifying attributes</a>.
 The following properties are available:
 <table class="table">
 <thead>
@@ -1262,8 +1261,11 @@ If <code>redundancy</code> == <code>searchable-copies</code> (default) this prop
 <tr><td><a href="#sorting">sorting</a></td><td>The sort specification for this attribute.</td></tr>
 </tbody>
 </table>
-An attribute is multivalued if assigning it multiple values during indexing,
-either by using e.g. <em>split</em> and <em>for_each</em>
+An attribute is <a href="../search-definitions.html#multivalue-fields">multivalued</a>
+if assigning it multiple values during indexing,
+by using a multivalued field type like array or map,
+or by using e.g. <a href="advanced-indexing-language.html#split">split</a> /
+<a href="advanced-indexing-language.html#for_each">for_each</a>
 or by letting multiple fields write their value to the attribute field.
 </p><p>
 Note that <a href="#normalizing">normalizing</a> and
@@ -2951,7 +2953,7 @@ Changes:
   <tr><th>Change</th><th>Applicable for mode</th><th>Description</th></tr>
   </thead>
   <tbody>
-  <tr><th>Add a new document field</th><th>index, streaming</th>
+  <tr><th>Add a new document field</th><td>index, streaming</td>
   <td>
   Add a new document field as index, attribute, summary or any combinations of these.
   Existing documents will implicitly get the new field with no content.
@@ -2960,71 +2962,71 @@ Changes:
   then old content <em>may or may not</em> reappear
   </td></tr>
 
-  <tr><th>Remove a document field</th><th>index, streaming</th>
+  <tr><th>Remove a document field</th><td>index, streaming</td>
   <td>
   Existing documents will no longer see the removed field,
   but the field data is not completely removed from the search node
   </td></tr>
 
-  <tr><th>Add or remove an existing document field from document summary</th><th>index, streaming</th>
+  <tr><th>Add or remove an existing document field from document summary</th><td>index, streaming</td>
   <td>
   Add an existing field to summary or any number of summary classes,
   and remove an existing field from summary or any number of summary classes
   </td></tr>
 
-  <tr><th>Remove the attribute aspect from a field that is also an index field</th><th>index</th>
+  <tr><th>Remove the attribute aspect from a field that is also an index field</th><td>index</td>
   <td>
   This is the only scenario of changing the attribute aspect of a document field that is allowed without restart
   </td></tr>
 
-  <tr><th>Change the attribute aspect of a document field</th><th>streaming</th>
+  <tr><th>Change the attribute aspect of a document field</th><td>streaming</td>
   <td>
   Add or remove a field as attribute.
   In mode <em>streaming</em> this only indicates that the field is used for grouping, sorting, ranking and matching.
   No changes to underlying data structures
   </td></tr>
 
-  <tr><th>Change the index aspect of a document field</th><th>streaming</th>
+  <tr><th>Change the index aspect of a document field</th><td>streaming</td>
   <td>
   Add or remove a field as index.
   In mode <em>streaming</em> this only indicates that the field is used for matching.
   No changes to underlying data structures
   </td></tr>
 
-  <tr><th>Add, change or remove match settings for a field</th><th>streaming</th>
+  <tr><th>Add, change or remove match settings for a field</th><td>streaming</td>
   <td>
   In mode streaming such change does not effect the documents stored in the backend
   and can be done without restart and re-feed
   </td></tr>
 
-  <tr><th>Add, change or remove field sets</th><th>index, streaming</th>
+  <tr><th>Add, change or remove field sets</th><td>index, streaming</td>
   <td>
   Change <a href="#fieldset">fieldsets</a> used to group fields together for searching
   </td></tr>
 
-  <tr><th>Change the alias or sorting attribute settings for an attribute field</th><th>index, streaming</th>
+  <tr><th>Change the alias or sorting attribute settings for an attribute field</th><td>index, streaming</td>
   <td><!-- ToDo -->
   </td></tr>
 
-  <tr><th>Add, change or remove rank profiles</th><th>index, streaming</th>
+  <tr><th>Add, change or remove rank profiles</th><td>index, streaming</td>
   <td><!-- ToDo -->
   </td></tr>
 
-  <tr><th>Change document field weights</th><th>index, streaming</th>
+  <tr><th>Change document field weights</th><td>index, streaming</td>
   <td><!-- ToDo -->
   </td></tr>
 
-  <tr><th>Add, change or remove field aliases</th><th>index, streaming</th>
+  <tr><th>Add, change or remove field aliases</th><td>index, streaming</td>
   <td><!-- ToDo -->
   </td></tr>
 
-  <tr><th>Add, change or remove rank settings for a field</th><th>index, streaming</th>
+  <tr><th>Add, change or remove rank settings for a field</th><td>index, streaming</td>
   <td>
   Exception: Changing <code>rank: filter</code> on an attribute field in mode <em>index</em> requires restart.
   See details in <a href="#changes-that-require-restart-but-not-re-feed">next section</a>
   </td></tr>
 
-  <tr><th>Add or remove a search definition</th><th>index, streaming</th>
+  <tr><th>Add or remove a search definition</th><td>index, streaming</td>
   <td>
   Removing a search definition file will make <a href="../proton.html">proton</a>
   drop all documents of that type - subsequently releasing memory and disk.
@@ -3049,14 +3051,14 @@ Changes:
   <tr><th>Change</th><th>Applicable for mode</th><th>Description</th></tr>
   </thead>
   <tbody>
-  <tr><th>Change the attribute aspect of a document field</th><th>index</th>
+  <tr><th>Change the attribute aspect of a document field</th><td>index</td>
   <td>
   Add or remove a field as attribute.
   When adding, the attribute is populated based on the field value in stored documents during restart.
   When removing, the field value in stored documents is updated based on the content in the attribute during restart
   </td></tr>
 
-  <tr><th>Change the attribute settings for an attribute field</th><th>index, streaming</th>
+  <tr><th>Change the attribute settings for an attribute field</th><td>index, streaming</td>
   <td>
   For mode <em>index</em>: Change the following attribute settings:
   <code>fast-search</code>, <code>fast-access</code>.
@@ -3065,7 +3067,7 @@ Changes:
   <code>fast-access</code> (the other settings are not used)
   </td></tr>
 
-  <tr><th>Change the rank filter setting for an attribute field</th><th>index</th>
+  <tr><th>Change the rank filter setting for an attribute field</th><td>index</td>
   <td>
   Add or remove <code>rank: filter</code> on an attribute field.
   </td></tr>
@@ -3117,7 +3119,7 @@ Changes:
   <tr><th>Change</th><th>Applicable for mode</th><th>Description</th></tr>
   </thead>
   <tbody>
-      <tr><th>Change the data type or collection type of a document field</th><th>index, streaming</th>
+      <tr><th>Change the data type or collection type of a document field</th><td>index, streaming</td>
       <td>
         Existing documents will no longer have any content for this field.
         To populate the field, re-feed the existing documents using the new type for this field.
@@ -3127,7 +3129,7 @@ Changes:
         but searching this field will not give any results
       </td></tr>
 
-      <tr><th>Change index aspect of a document field</th><th>index</th>
+      <tr><th>Change index aspect of a document field</th><td>index</td>
       <td>
         This changes the document processing pipeline before documents arrive in the backend.
         Only documents fed after index aspect was added
@@ -3136,11 +3138,11 @@ Changes:
         will avoid disk bloat due to unneeded annotations
       </td></tr>
 
-      <tr><th>Change fields from static to dynamic summary, or vice versa</th><th>index</th>
+      <tr><th>Change fields from static to dynamic summary, or vice versa</th><td>index</td>
       <td><!-- ToDo -->
       </td></tr>
 
-      <tr><th>Switch stemming/normalizing on or off</th><th>index</th>
+      <tr><th>Switch stemming/normalizing on or off</th><td>index</td>
       <td>
         This changes the document processing pipeline before documents
         arrive in the backend, and what annotations are made for an indexed field.
@@ -3150,11 +3152,11 @@ Changes:
         than the one used when doing stemming/normalizing of the query terms
       </td></tr>
 
-      <tr><th>Switch bolding on or off</th><th>index</th>
+      <tr><th>Switch bolding on or off</th><td>index</td>
       <td><!-- ToDo -->
       </td></tr>
 
-      <tr><th>Add, change or remove match settings for a field</th><th>index</th>
+      <tr><th>Add, change or remove match settings for a field</th><td>index</td>
       <td>
         Example: Adding <code>match: word</code> to a field.
         <br>
@@ -3166,7 +3168,7 @@ Changes:
         while run-time is using a different match mode
       </td></tr>
 
-      <tr><th>Change the tensor type of a tensor attribute</th><th>index</th>
+      <tr><th>Change the tensor type of a tensor attribute</th><td>index</td>
       <td><!-- ToDo -->
       </td></tr>
 

--- a/documentation/search-definitions.html
+++ b/documentation/search-definitions.html
@@ -18,6 +18,11 @@ Vespa applications must have at least one search definition in the
 <a href="cloudconfig/application-packages.html">application package</a> -
 the search definition is a required file.
 </p><p>
+Search definitions can be modified without restart / re-indexing - with some restrictions.
+Refer to the
+<a href="reference/search-definitions-reference.html#modify-search-definitions">reference</a> for details,
+and the <a href="application-packages.html">application package</a> for how to deploy.
+</p><p>
 Example
 <a href="https://github.com/vespa-engine/sample-apps/blob/master/basic-search/src/main/application/searchdefinitions/music.sd">
 music.sd</a>:
@@ -64,16 +69,6 @@ search music {
     }
 }
 </pre>
-</p>
-
-
-
-<h2 id="modify-search-definitions">Modify Search Definitions</h2>
-<p>
-Search definitions can be modified without restart / re-indexing - with some restrictions.
-Refer to the
-<a href="reference/search-definitions-reference.html#modify-search-definitions">reference</a> for details,
-and the <a href="application-packages.html">application package</a> for how to deploy.
 </p>
 
 


### PR DESCRIPTION
the reference has the real info, link there

make the guide a little cleaner

bonus: some links in multivalue attribute section reference