### PR TITLE
Fix page build failure for vespa stateless models

### DIFF
--- a/documentation/vespa-stateless-models.html
+++ b/documentation/vespa-stateless-models.html
@@ -25,7 +25,7 @@ below the models/ directory in your application package:</p>
 <p>A complete example. This file must be saved as <code>example.model</code> somewhere below the <code>models/</code> directory, and the same
 directory must also contain a file <code>constant1asLarge.json</code> containing a tensor on JSON format.</p>
 
-<pre>
+<pre>{% raw %}
 model example {
 
     # All inputs that are not scalar (aka 0-dimensional tensor) must be declared
@@ -52,7 +52,7 @@ model example {
     }
 
 }
-</pre>
+</pre>{% endraw %}
 
 <p>It causes the model "example" to be available with the two functions "foo1" and "foo2".</p>
 
@@ -62,16 +62,16 @@ model example {
 model [name] {
 
     ([input-argument-name]: [<a href="reference/tensor.html#tensor-type-spec">input-argument-type</a>])*
-    
+
     contants {
         ([constant-name]: [scalar or <a href="reference/tensor.html#tensor-literal-form">tensor in literal form</a>])*
     }
-    
+
     (constant [name] {
         type: [<a href="reference/tensor.html#tensor-type-spec">tensor-type-spec</a>]]
         file: [file path relative to this .model file]
     })*
-    
+
     (function [name]([argument-name]*) {
         expression: [<a href="reference/ranking-expressions.html">ranking expression</a>]
     })*


### PR DESCRIPTION
@bratseth `{{` needs to be enclosed in {% raw %} in jekyll.