### PR TITLE
Remove deprecated maxentries 

### DIFF
--- a/documentation/content/setup-proton-tuning.html
+++ b/documentation/content/setup-proton-tuning.html
@@ -197,6 +197,7 @@ Tune the number of request threads used on a search node - optional sub-elements
     &lt;summary&gt;16&lt;/summary&gt;
 &lt;/requestthreads&gt;
 </pre>
+Number of threads per search can adjusted down per rank-profile using <a href="../reference/search-definitions-reference.html#num-threads-per-search">num-threads-per-search</a>
 </p>
 
 
@@ -289,7 +290,6 @@ Optional sub-elements:
             &lt;maxage&gt;86400&lt;/maxage&gt;
         &lt;/component&gt;
         &lt;transactionlog&gt;
-            &lt;maxentries&gt;1000000&lt;/maxentries&gt;
             &lt;maxsize&gt;21474836480&lt;/maxsize&gt;
         &lt;/transactionlog&gt;
         &lt;conservative&gt;
@@ -613,17 +613,15 @@ proton.def</a> to look for parameter values and defaults. Optional sub-elements:
         &lt;cache&gt;
             &lt;maxsize&gt;0&lt;/maxsize&gt;
             &lt;compression&gt;
-                &lt;type&gt;lz4&lt;/type&gt;
-                &lt;level&gt;9&lt;/level&gt;
+                &lt;type&gt;none&lt;/type&gt;
             &lt;/compression&gt;
         &lt;/cache&gt;
         &lt;logstore&gt;
             &lt;maxfilesize&gt;1000000000&lt;/maxfilesize&gt;
             &lt;chunk&gt;
                 &lt;maxsize&gt;65536&lt;/maxsize&gt;
-                &lt;maxentries&gt;256&lt;/maxentries&gt;
                 &lt;compression&gt;
-                    &lt;type&gt;lz4&lt;/type&gt;
+                    &lt;type&gt;zstd&lt;/type&gt;
                     &lt;level&gt;9&lt;/level&gt;
                 &lt;/compression&gt;
             &lt;/chunk&gt;


### PR DESCRIPTION
Bailed out on the proton.def pointers. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
