### PR TITLE
Fix broken link to application package doc

### DIFF
--- a/documentation/search-definitions.html
+++ b/documentation/search-definitions.html
@@ -21,7 +21,7 @@ the search definition is a required file.
 Search definitions can be modified without restart / re-indexing - with some restrictions.
 Refer to the
 <a href="reference/search-definitions-reference.html#modify-search-definitions">reference</a> for details,
-and the <a href="application-packages.html">application package</a> for how to deploy.
+and the <a href="cloudconfig/application-packages.html">application package</a> for how to deploy.
 </p><p>
 Example
 <a href="https://github.com/vespa-engine/sample-apps/blob/master/basic-search/src/main/application/searchdefinitions/music.sd">


### PR DESCRIPTION
Broken link reported by Flickr team - assuming we want to link to the doc page (already linked earlier in document) and not the [application package reference page](https://docs.vespa.ai/documentation/reference/application-packages-reference.html)?

@kkraune Please review.