### PR TITLE
Kkraune/tensor type reference

### DIFF
--- a/documentation/reference/tensor.html
+++ b/documentation/reference/tensor.html
@@ -20,6 +20,7 @@ The dimensions of a tensor defines its type, see the <a href="tensor.html#tensor
 </p>
 
 
+
 <h2 id="tensor-type-spec">Tensor type spec</h2>
 <p>
 Contained in <code><a href="search-definitions-reference.html#constant">constant</a></code>
@@ -54,7 +55,7 @@ Example tensor with this type (representing a matrix):
 {% endraw %}</pre>
 Note that the labels are indexes in the range <em>[0,dimension-size&gt;</em>
 </p><p>
-    A tensor with both mapped and indexed dimensions is mixed:
+A tensor with both mapped and indexed dimensions is mixed:
 <pre>
 tensor(x[2],y{})
 </pre>
@@ -66,8 +67,9 @@ Example:
 </p>
 
 
-<h2 id="tensor-literal-form">Tensor literal form</h2>
 
+<h2 id="tensor-literal-form">Tensor literal form</h2>
+<p>
 The standard literal form of tensors specified verbatim in ranking expressions is as follows (expressed in EBNF):
 <pre>
 literal tensor = ( tensor-type-spec ":" )? "{" cells "}" ;
@@ -78,16 +80,15 @@ element = dimension ":" label ;
 dimension = integer | string ;
 label = integer | string ;
 </pre>
-
-<p>If no type spec is included the type is inferred from cells.</p>
-
-<p>Tensors which are completely dense can also use the dense literal form, where
+If no type spec is included the type is inferred from cells.
+</p><p>
+Tensors which are completely dense can also use the dense literal form, where
 just the numbers are given, wrapped in square brackets in right dimension adjacent order.
-This form reequires a dimension to be specified.</p>
+This form requires a dimension to be specified.
+</p>
 
 
 <h3 id="literal-form-examples">Literal form examples</h3>
-
 <p>
 An empty tensor:
 <pre>
@@ -120,20 +121,19 @@ be omitted, so the above is equivalent to
 <pre>
 tensor(x[2],y[3]):[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 </pre>
-
 </p>
+
 
 
 <h2 id="operations">Operations</h2>
-
 <p>
-The following set of tensors operations are available to use in ranking
-expressions. We group the operations in primitive functions and convenience
+The following set of tensors operations are available to use in ranking expressions.
+Operations are grouped in primitive functions and convenience
 functions that can be implemented by primitive functions.
 </p>
 
-<h3 id="primitive-functions">Primitive functions</h3>
 
+<h3 id="primitive-functions">Primitive functions</h3>
 <table class="table">
   <thead></thead>
 <tbody>
@@ -170,58 +170,42 @@ functions that can be implemented by primitive functions.
 </tbody>
 </table>
 
-
 <h4 id="lambda">Lambda functions in primitive functions</h4>
-
 <p>
 Some of the primitive functions accept lambda functions that are evaluated
 and applied to a set of tensor cells. The functions contain a single expression
 that have the same format and built-in functions as
 <a href="ranking-expressions.html">general ranking expressions</a>.
 However, the atoms are the arguments defined in the argument list of the lambda.
-</p>
-
-<p>
+</p><p>
 The expression cannot access variables or data structures outside of the lambda,
 i.e. they are not closures.
-</p>
-
-<p>
+</p><p>
 Examples:
-</p>
-
 <pre>
 f(x)(abs(x))
 f(x,y)(if(x &lt; y, 0, 1))
 </pre>
-
+</p>
 
 <h4 id="map">- Map</h4>
-
 <p>
 Arguments:
 <ul>
     <li><code>tensor</code>: a tensor.</li>
     <li><code>f(x)(expr)</code>: a <a href="#lambda">lambda function</a> with one argument.</li>
 </ul>
-</p>
-
-<p>
 Returns a new tensor where the expression in the lambda function is
 evaluated in each cell in <code>tensor</code>.
-</p>
-
-<p>
+</p><p>
 Examples:
-</p>
-
 <pre>
 map(t, f(x)(abs(x)))
 map(t, f(i)(if(i &lt; 0, 0, i)))
 </pre>
+</p>
 
 <h4 id="reduce">- Reduce</h4>
-
 <p>
 Arguments:
 <ul>
@@ -229,15 +213,10 @@ Arguments:
     <li><code>aggregator</code>: the aggregator to use. See below.</li>
     <li><code>dim1, dim2, ...</code>: the dimensions to reduce over. Optional.</li>
 </ul>
-</p>
-
-<p>
 Returns a new tensor with the aggregator applied across dimensions
 <code>dim1</code>, <code>dim2</code>, etc.
 If no dimensions are specified, reduce over all dimensions.
-</p>
-
-<p>
+</p><p>
 Available aggregators are:
 <ul>
     <li><code>avg</code>: arithmetic mean</li>
@@ -247,19 +226,14 @@ Available aggregators are:
     <li><code>max</code>: maximum value</li>
     <li><code>min</code>: minimum value</li>
 </ul>
-</p>
-
-<p>
 Examples:
-</p>
-
 <pre>
 reduce(t, sum)         # Sum all values in tensor
 reduce(t, count, x)    # Count number of cells along dimension x
 </pre>
+</p>
 
 <h4 id="join">- Join</h4>
-
 <p>
 Arguments:
 <ul>
@@ -267,27 +241,18 @@ Arguments:
     <li><code>tensor2</code>: a tensor.</li>
     <li><code>f(x,y)(expr)</code>: a <a href="#lambda">lambda function</a> with two arguments.</li>
 </ul>
-</p>
-
-<p>
 Returns a new tensor constructed from the <em>natural join</em>
 between <code>tensor1</code> and <code>tensor2</code>, with the
 resulting cells having the value as calculated from <code>f(x,y)(expr)</code>,
 where <code>x</code> is the cell value from <code>tensor1</code> and
 <code>y</code> from <code>tensor2</code>.
-</p>
-
-<p>
+</p><p>
 Formally, the result of the <code>join</code> is a new tensor with dimensions
 the union of dimension between <code>tensor1</code> and <code>tensor2</code>.
 The cells are the set of all combinations of cells that have equal values
 on their common dimensions.
-</p>
-
-<p>
+</p><p>
 Examples:
-</p>
-
 {% raw %}
 <pre>
 t1 = {{x:0}: 1.0, {x:1}: 2.0}
@@ -298,43 +263,32 @@ join(t1, t2, f(x,y)(x * y)) = {{x:0,y:0}: 3.0, {x:0,y:1}: 4.0, {x:1,y:0}: 10.0, 
 reduce(join(t1, t2, f(x,y)(x * y)), sum) = 29.0
 </pre>
 {% endraw %}
-
+</p>
 
 <h4 id="tensor">- tensor</h4>
-
 <p>
 Arguments:
 <ul>
     <li><code>tensor-type-spec</code>: a <a href="#tensor-type-spec">indexed tensor type specification.</a></li>
     <li><code>(expr)</code>: a <a href="#lambda">lambda function</a> expressing how to generate the tensor.</li>
 </ul>
-</p>
-
-<p>
 Generates new tensors according to the type specification and expression <code>expr</code>. The tensor
 type must be an indexed tensor (e.g. <code>tensor(x[10])</code>). The expression in <code>expr</code>
 will be evaluated for each cell.
 The arguments in the expression is implicitly the names of the dimensions defined in the type spec.
-</p>
-
-<p>
+</p><p>
 Useful for creating transformation tensors.
-</p>
-
-<p>
+</p><p>
 Examples:
-</p>
-
 {% raw %}
 <pre>
 tensor(x[3])(x) = {{x:0}: 0.0, {x:1}: 1.0, {x:2}: 2.0}
 tensor(x[2],y[2])(x == y) = {{x:0,y:0}: 1.0, {x:0,y:1}: 0.0, {x:1,y:0}: 0.0, {x:1,y:1}: 1.0}
 </pre>
 {% endraw %}
-
+</p>
 
 <h4 id="rename">- rename</h4>
-
 <p>
 Arguments:
 <ul>
@@ -342,16 +296,9 @@ Arguments:
     <li><code>dim-to-rename</code>: a dimension, or list of dimensions, to rename.</li>
     <li><code>new-names</code>: new names for the dimensions listed above.</li>
 </ul>
-</p>
-
-<p>
 Returns a new tensor with one or more dimension renamed.
-</p>
-
-<p>
+</p><p>
 Examples:
-</p>
-
 {% raw %}
 <pre>
 t1 = {{x:0,y:0}: 1.0, {x:0,y:1}: 0.0, {x:1,y:0}: 0.0, {x:1,y:1}: 1.0}
@@ -360,10 +307,9 @@ rename(t1,x,z) = {{z:0,y:0}: 1.0, {z:0,y:1}: 0.0, {z:1,y:0}: 0.0, {z:1,y:1}: 1.0
 rename(t1,(x,y),(i,j)) = {{i:0,j:0}: 1.0, {i:0,j:1}: 0.0, {i:1,j:0}: 0.0, {i:1,j:1}: 1.0}
 </pre>
 {% endraw %}
-
+</p>
 
 <h4 id="concat">- concat</h4>
-
 <p>
 Arguments:
 <ul>
@@ -371,18 +317,11 @@ Arguments:
     <li><code>tensor2</code>: a tensor or scalar.</li>
     <li><code>dim</code>: the dimension to concatenate along.</li>
 </ul>
-</p>
-
-<p>
 Returns a new tensor with the two tensors <code>tensor1</code> and
-<code>tensor2</code> concatenated along dimension <code>dim</code>. The tensors
-can also be scalars.
-</p>
-
-<p>
+<code>tensor2</code> concatenated along dimension <code>dim</code>.
+The tensors can also be scalars.
+</p><p>
 Examples:
-</p>
-
 {% raw %}
 <pre>
 t1 = {{x:0}: 0.0, {x:1}: 1.0}
@@ -391,15 +330,14 @@ t2 = {{x:0}: 2.0, {x:1}: 3.0}
 concat(t1,t2,x) = {{x:0}: 0.0, {x:1}: 1.0}, {x:2}: 2.0, {x:3}: 3.0}}
 </pre>
 {% endraw %}
+</p>
 
 
 <h3>Non-primitive functions</h3>
-
 <p>
 Non-primitive functions can be implemented by primitive functions,
 but are not necessarily so for performance reasons.
 </p>
-
 <table class="table">
   <thead></thead>
 <tbody>
@@ -774,18 +712,16 @@ but are not necessarily so for performance reasons.
         Matrix multiplication of <code>x</code> (usually a vector) and <code>w</code> (weights), with <code>b</code> added (bias). A typical operation for activations in a neural network layer, e.g. <code>sigmoid(xw_plus_b(x,w,b)))</code>.
     </td>
 </tr>
-
-
 </tbody>
 </table>
+
 
 
 <h2>Tensor Rank Features</h2>
 <p>
 The following rank features can be used to reference tensors when doing tensor operations in ranking expressions.
 The tensors can come from the document, the query or be constant for a deployment of your application.
-</p>
-<p>
+</p><p>
 Please take a look at the following reference documentations on how use tensors in documents:
 <ul class="semicompact">
     <li><a href="search-definitions-reference.html#type:tensor">Tensor field in search definition</a></li>
@@ -797,28 +733,24 @@ Please take a look at the following reference documentations on how use tensors 
 <h3>- attribute(tensor_attribute)</h3>
 <p>
 Returns the tensor value found in the given tensor attribute.
-</p>
-
-<p>
+</p><p>
 Take a look at <a href="search-definitions-reference.html#type:tensor">tensor type</a> and
 <a href="#tensor-type-spec">tensor-type-spec</a>
 reference doc for how to setup a tensor attribute in your search definition.
-</p>
-
-<p>Example tensor attribute field in a sd-file where the tensor has 2 mapped dimensions, <em>x</em> and <em>y</em>:</p>
+</p><p>
+Example tensor attribute field in a sd-file where the tensor has 2 mapped dimensions, <em>x</em> and <em>y</em>:
 <pre>
 field tensor_attribute type tensor(x{},y{}) {
     indexing: attribute | summary
 }
 </pre>
+</p>
 
 
 <h3 id="query-feature">- query(tensor_feature)</h3>
 <p>
 Returns the tensor value passed down with the query as a feature.
-</p>
-
-<p>
+</p><p>
 In order to use this feature you must define the tensor type of the query feature in a query profile type.
 In the following example the tensor type is defined to have one mapped dimension <em>x</em>:
 <pre>
@@ -826,7 +758,6 @@ In the following example the tensor type is defined to have one mapped dimension
   &lt;field name="ranking.features.query(tensor_feature)" type="tensor(x{})" /&gt;
 &lt;/query-profile-type&gt;
 </pre>
-
 The tensor value itself must be set in a searcher using the com.yahoo.search.query.ranking.RankFeatures
 instance that is associated with an instance of com.yahoo.search.Query.
 In the following example we create a tensor with a single cell with value 500:
@@ -849,10 +780,6 @@ public class TensorInQuerySearcher extends Searcher {
     }
 }
 </pre>
-
-</p>
-
-<p>
 Take a look at <a href="query-profile-reference.html#field-type">query profile field type</a>
 reference doc for more information on how to specify a field as a tensor in a query profile type.
 </p>
@@ -861,9 +788,7 @@ reference doc for more information on how to specify a field as a tensor in a qu
 <h3 id="constant-feature">- constant(tensor_constant)</h3>
 <p>
 Returns the constant tensor value with the given name as specified in your sd-file.
-</p>
-
-<p>
+</p><p>
 Take a look at <a href="search-definitions-reference.html#constant">constant</a> reference
 documentation for how to specify constant tensors in your sd-file.
 </p>
@@ -871,7 +796,8 @@ documentation for how to specify constant tensors in your sd-file.
 
 <h3 id="tensor-from-weighted-set-feature">- tensorFromWeightedSet(source, dimension)</h3>
 <p>
-Creates a tensor with one mapped dimension from the given integer or string weighted set source. The source can be either an attribute field or a query parameter.
+Creates a tensor with one mapped dimension from the given integer or string weighted set source.
+The source can be either an attribute field or a query parameter.
 The <em>source</em> parameter is required and must be specified as follows:
 <ul class="semicompact">
     <li><em>attribute(attributeName)</em>: The tensor is created based on the content of the weighted set attribute <em>attributeName</em>.</li>
@@ -879,11 +805,8 @@ The <em>source</em> parameter is required and must be specified as follows:
     <code>&amp;ranking.properties.propertyName={k1:w1,k2:w2,...,kN:wN}</code>.</li>
 </ul>
 The <em>dimension</em> parameter is optional, where the default value is the parameter name from the source parameter.
-</p>
-
-<p>
-Example:<br>
-Assume we have the following weighted set with keys and corresponding weights, and the dimension <em>dim</em>:
+</p><p>
+Example: Assume we have the following weighted set with keys and corresponding weights, and the dimension <em>dim</em>:
 <pre>
 {k1:w1,k2:w1,...,kN:wN}
 </pre>
@@ -905,11 +828,8 @@ The <em>source</em> parameter is required and must be specified as follows:
     <code>&amp;ranking.properties.propertyName=[v1 v2 ... vN]</code>.</li>
 </ul>
 The <em>dimension</em> parameter is optional, where the default value is the parameter name from the source parameter.
-</p>
-
-<p>
-Example:<br>
-Assume we have the following array with values and the dimension <code>dim</code>:
+</p><p>
+Example: Assume we have the following array with values and the dimension <code>dim</code>:
 <pre>
 [v1 v2 ... vN]
 </pre>
@@ -918,5 +838,3 @@ The tensor representation of this array has the dimension <em>dim</em> with the 
 { {dim:v1}:1.0, {dim:v2}:1.0, ..., {dim:vN}:1.0} }
 </pre>
 </p>
-
-

--- a/documentation/reference/tensor.html
+++ b/documentation/reference/tensor.html
@@ -8,7 +8,7 @@ A tensor is a set of named <em>dimensions</em> defining its <em>order</em>
 and a set of values located in the space of those dimensions:
 <ul class="semicompact">
   <li><em>Cell</em>: A value located in the dimension space.
-    Consists of a cell address and the floating point value at that address.</li>
+    Consists of a cell address and the value at that address.</li>
   <li><em>Address</em>: A set of key-values where each key is a <em>dimension</em> from the set of dimensions of the tensor,
     and each value is a <em>label</em> (integer or identifier) determining the cells location in that dimension.</li>
 </ul>
@@ -16,7 +16,8 @@ The set of dimensions, cell values and cell address key-values can be of any siz
 A dimension can be either mapped or indexed.
 Mapped dimensions use string identifiers as labels in the cell addresses (like a map),
 while indexed dimensions use integers in the range <code>[0,N&gt;</code> (like an array), where N is the size of the dimension.
-The dimensions of a tensor defines its type, see the <a href="tensor.html#tensor-type-spec">tensor type spec</a>.
+The dimensions of a tensor and the cell type defines its type,
+see the <a href="tensor.html#tensor-type-spec">tensor type spec</a>.
 </p>
 
 
@@ -28,41 +29,52 @@ or <code><a href="search-definitions-reference.html#type:tensor">tensor field ty
 Specifies the tensor type for a tensor.
 A tensor type contains a list of dimensions on the format:
 <pre>
-tensor(dimension-1,dimension-2,...,dimension-N)
+tensor&lt;type&gt;(dimension-1,dimension-2,...,dimension-N)
 </pre>
+The type is one of:
+<table class="table">
+<thead></thead><tbody>
+<tr>
+  <td>float</td><td>32-bit IEEE 754 floating point</td>
+</tr><tr>
+  <td>double</td><td>64-bit IEEE 754 floating point</td>
+</tr>
+</tbody>
+</table>
 A dimension is specified as follows:
 <ul>
     <li><code>dimension-name{}</code> - a mapped dimension</li>
     <li><code>dimension-name[size]</code> - an indexed dimension</li>
 </ul>
-The tensor type for a tensor with two mapped dimensions <em>x</em> and <em>y</em> looks like:
+The tensor type for a tensor&lt;float&gt; with two mapped dimensions <em>x</em> and <em>y</em> looks like:
 <pre>
-tensor(x{},y{})
+tensor&lt;float&gt;(x{},y{})
 </pre>
 Example tensor with this type:
 <pre>{% raw %}
-{{x:a,y:b}:10, {x:c,y:d}:20}
+{{x:a,y:b}:10.0, {x:c,y:d}:20.1}
 {% endraw %}</pre>
-The tensor type for a tensor with two indexed dimensions <em>x</em> and <em>y</em> with sizes 3 and 2 respectively looks like this:
+The tensor type for a tensor&lt;float&gt; with two indexed dimensions <em>x</em> and <em>y</em>
+with sizes 3 and 2 respectively looks like:
 <pre>
-tensor(x[3],y[2])
+tensor&lt;float&gt;(x[3],y[2])
 </pre>
 Example tensor with this type (representing a matrix):
 <pre>{% raw %}
-{{x:0,y:0}:1, {x:0,y:1}:2,
+{{x:0,y:0}:1, {x:0,y:1}:2.1,
  {x:1,y:0}:3, {x:1,y:1}:5,
  {x:2,y:0}:7, {x:2,y:1}:11}
 {% endraw %}</pre>
 Note that the labels are indexes in the range <em>[0,dimension-size&gt;</em>
 </p><p>
-A tensor with both mapped and indexed dimensions is mixed:
+A tensor&lt;double&gt; with both mapped and indexed dimensions is mixed:
 <pre>
-tensor(x[2],y{})
+tensor&lt;double&gt;(x[2],y{})
 </pre>
 Example:
 <pre>{% raw %}
-{{x:0,y:a}:10, {x:0,y:b}:20,
- {x:1,y:a}:5,  {x:1,y:b}:7}
+{{x:0,y:a}:10,  {x:0,y:b}:20.7,
+ {x:1,y:a}:5.3, {x:1,y:b}:7}
 {% endraw %}</pre>
 </p>
 
@@ -104,22 +116,22 @@ A tensor with multiple values and mapped dimensions <em>x</em> and <em>y</em>:
 </pre>
 A tensor where type is specified explicitly with a single indexed dimension <em>x</em> representing a vector:
 <pre>
-tensor(x[3]):{ {x:0}:3.0, {x:1}:5.0, {x:2}:7.0 }
+tensor&lt;float&gt;(x[3]):{ {x:0}:3.0, {x:1}:5.0, {x:2}:7.0 }
 </pre>
 The same tensor in dense form:
 <pre>
-tensor(x[3]):[3.0, 5.0, 7.0]
+tensor&lt;float&gt;(x[3]):[3.0, 5.0, 7.0]
 </pre>
 A matrix in dense form. Note that the values for the right-most dimension (y) are adjacent, so e.g
 the value 3 is here assigned to the cell {x:0,y:2}:
 <pre>
-tensor(x[2],y[3]):[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+tensor&lt;float&gt;(x[2],y[3]):[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
 </pre>
 Also note that left and right dimension here is by alphabetical order of the dimension names, the order in which
 they are given in the type specification is irrelevant. The inner brackets are syntactic sugar and can
 be omitted, so the above is equivalent to
 <pre>
-tensor(x[2],y[3]):[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+tensor&lt;float&gt;(x[2],y[3]):[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 </pre>
 </p>
 
@@ -269,12 +281,12 @@ reduce(join(t1, t2, f(x,y)(x * y)), sum) = 29.0
 <p>
 Arguments:
 <ul>
-    <li><code>tensor-type-spec</code>: a <a href="#tensor-type-spec">indexed tensor type specification.</a></li>
+    <li><code>tensor-type-spec</code>: an <a href="#tensor-type-spec">indexed tensor type specification.</a></li>
     <li><code>(expr)</code>: a <a href="#lambda">lambda function</a> expressing how to generate the tensor.</li>
 </ul>
-Generates new tensors according to the type specification and expression <code>expr</code>. The tensor
-type must be an indexed tensor (e.g. <code>tensor(x[10])</code>). The expression in <code>expr</code>
-will be evaluated for each cell.
+Generates new tensors according to the type specification and expression <code>expr</code>.
+The tensor type must be an indexed tensor (e.g. <code>tensor&lt;float&gt;(x[10])</code>).
+The expression in <code>expr</code> will be evaluated for each cell.
 The arguments in the expression is implicitly the names of the dimensions defined in the type spec.
 </p><p>
 Useful for creating transformation tensors.
@@ -282,8 +294,8 @@ Useful for creating transformation tensors.
 Examples:
 {% raw %}
 <pre>
-tensor(x[3])(x) = {{x:0}: 0.0, {x:1}: 1.0, {x:2}: 2.0}
-tensor(x[2],y[2])(x == y) = {{x:0,y:0}: 1.0, {x:0,y:1}: 0.0, {x:1,y:0}: 0.0, {x:1,y:1}: 1.0}
+tensor&lt;float&gt;(x[3])(x) = {{x:0}: 0.0, {x:1}: 1.0, {x:2}: 2.0}
+tensor&lt;float&gt;(x[2],y[2])(x == y) = {{x:0,y:0}: 1.0, {x:0,y:1}: 0.0, {x:1,y:0}: 0.0, {x:1,y:1}: 1.0}
 </pre>
 {% endraw %}
 </p>
@@ -740,7 +752,7 @@ reference doc for how to setup a tensor attribute in your search definition.
 </p><p>
 Example tensor attribute field in a sd-file where the tensor has 2 mapped dimensions, <em>x</em> and <em>y</em>:
 <pre>
-field tensor_attribute type tensor(x{},y{}) {
+field tensor_attribute type tensor&lt;float&gt;(x{},y{}) {
     indexing: attribute | summary
 }
 </pre>
@@ -755,7 +767,7 @@ In order to use this feature you must define the tensor type of the query featur
 In the following example the tensor type is defined to have one mapped dimension <em>x</em>:
 <pre>
 &lt;query-profile-type id="myProfileType"&gt;
-  &lt;field name="ranking.features.query(tensor_feature)" type="tensor(x{})" /&gt;
+  &lt;field name="ranking.features.query(tensor_feature)" type="tensor&lt;float&gt;(x{})" /&gt;
 &lt;/query-profile-type&gt;
 </pre>
 The tensor value itself must be set in a searcher using the com.yahoo.search.query.ranking.RankFeatures
@@ -775,7 +787,7 @@ public class TensorInQuerySearcher extends Searcher {
     @Override
     public Result search(Query query, Execution execution) {
         query.getRanking().getFeatures().put("query(tensor_feature)",
-            new MappedTensor.Builder(TensorType.fromSpec("tensor(x{})")).cell().label("x", "foo").value(500).build());
+            new MappedTensor.Builder(TensorType.fromSpec("tensor&lt;float&gt;(x{})")).cell().label("x", "foo").value(500).build());
         return execution.search(query);
     }
 }
@@ -787,10 +799,10 @@ reference doc for more information on how to specify a field as a tensor in a qu
 
 <h3 id="constant-feature">- constant(tensor_constant)</h3>
 <p>
-Returns the constant tensor value with the given name as specified in your sd-file.
+Returns the constant tensor value with the given name as specified in the sd-file.
 </p><p>
 Take a look at <a href="search-definitions-reference.html#constant">constant</a> reference
-documentation for how to specify constant tensors in your sd-file.
+documentation for how to specify constant tensors in the sd-file.
 </p>
 
 


### PR DESCRIPTION
only the second commit needs review.

questions:
- tensorFromLabels(source, dimension) creates a tensor, I assume using the default type - we should consider adding a type argument here, too, as we cannot deduct value type?
- same goes for tensorFromWeightedSet(source, dimension). or is the tensor generated based on the weighted set / query tensor value type?  