### PR TITLE
Use separate node for config server

### DIFF
--- a/documentation/vespa-quick-start-multinode-aws-ecs.html
+++ b/documentation/vespa-quick-start-multinode-aws-ecs.html
@@ -25,7 +25,7 @@ Docker image on <a href="https://us-east-2.console.aws.amazon.com/ecs">AWS ECS</
           <thead></thead><tbody>
             <tr><td style="width:300px">Cluster name</td><td>vespa</td></tr>
             <tr><td>EC2 instance type</td><td>t2.medium</td></tr>
-            <tr><td>Number of instances</td><td>4</td></tr>
+            <tr><td>Number of instances</td><td>5</td></tr>
             <tr><td>Key pair</td><td><i>Select or create your keypair</i></td></tr>
             <tr><td>Security group inbound rules - Port range</td><td>0 - 65535</td></tr>
           </tbody>
@@ -37,7 +37,7 @@ Docker image on <a href="https://us-east-2.console.aws.amazon.com/ecs">AWS ECS</
   </li><li>
     <strong>Configure ECS instances</strong><br/>
     <ul>
-      <li>Click the <strong>ECS Instances tab</strong> - this should show 4 container instances</li>
+      <li>Click the <strong>ECS Instances tab</strong> - this should show 5 container instances</li>
       <li>Select the first Container instance checkbox,
         then <strong>Actions -> View/Edit attributes</strong></li>
       <li>Click <strong>Add attribute</strong>.
@@ -187,6 +187,10 @@ Docker image on <a href="https://us-east-2.console.aws.amazon.com/ecs">AWS ECS</
           <td>services</td>
           <td>ec2-18-220-230-182.us-east-2.compute.amazonaws.com</td>
           <td>ip-10-0-0-38.us-east-2.compute.internal</td>
+        </tr><tr>
+          <td>services</td>
+          <td>ec2-18-220-230-183.us-east-2.compute.amazonaws.com</td>
+          <td>ip-10-0-0-39.us-east-2.compute.internal</td>
         </tr>
       </tbody>
     </table>

--- a/documentation/vespa-quick-start-multinode-aws.html
+++ b/documentation/vespa-quick-start-multinode-aws.html
@@ -62,7 +62,7 @@ Also read <a href="vespa-quick-start-multinode-aws-ecs.html">using ECS to set up
     </ol>
 
     <li>
-        <strong>Launch 4 instances</strong>
+        <strong>Launch 5 instances</strong>
         <p>Under <em>Instances</em>, click the <strong>Launch</strong> instance button and follow the wizard steps:</p>
         <ol>
             <li>
@@ -81,7 +81,7 @@ Also read <a href="vespa-quick-start-multinode-aws-ecs.html">using ECS to set up
             </li>
             <li>
                 <strong>Configure Instance:</strong>
-                <p>Enter 4 in the <em>Number of instances</em> field.</p>
+                <p>Enter 5 in the <em>Number of instances</em> field.</p>
             </li>
             <li>
                 <strong>Add Storage:</strong>
@@ -135,6 +135,7 @@ ip-172-1-1-1.us-east-2.compute.internal
 ip-172-1-1-2.us-east-2.compute.internal
 ip-172-1-1-3.us-east-2.compute.internal
 ip-172-1-1-4.us-east-2.compute.internal
+ip-172-1-1-5.us-east-2.compute.internal
 </pre>
   </li><li>
     Download and distribute the aws <a href="https://github.com/vespa-engine/sample-apps/blob/master/aws_bootstrap.sh">bootstrap</a> script to all instances:
@@ -187,18 +188,21 @@ $ cd sample-apps/basic-search
 &lt;hosts&gt;
   &lt;host name="ip-172-1-1-1.us-east-2.compute.internal"&gt;
     &lt;alias&gt;admin0&lt;/alias&gt;
-    &lt;alias&gt;stateless0&lt;/alias&gt;
   &lt;/host&gt;
 
   &lt;host name="ip-172-1-1-2.us-east-2.compute.internal"&gt;
-    &lt;alias&gt;stateless1&lt;/alias&gt;
+    &lt;alias&gt;stateless0&lt;/alias&gt;
   &lt;/host&gt;
 
   &lt;host name="ip-172-1-1-3.us-east-2.compute.internal"&gt;
-    &lt;alias&gt;content0&lt;/alias&gt;
+    &lt;alias&gt;stateless1&lt;/alias&gt;
   &lt;/host&gt;
 
   &lt;host name="ip-172-1-1-4.us-east-2.compute.internal"&gt;
+    &lt;alias&gt;content0&lt;/alias&gt;
+  &lt;/host&gt;
+
+  &lt;host name="ip-172-1-1-5.us-east-2.compute.internal"&gt;
     &lt;alias&gt;content1&lt;/alias&gt;
   &lt;/host&gt;
 &lt;/hosts&gt;


### PR DESCRIPTION
A separate node should be used for config server in multinode setups, that's better both for operations and performance.
