### PR TITLE
Kkraune/content nodes ii

### DIFF
--- a/documentation/cloudconfig/configuration-server.html
+++ b/documentation/cloudconfig/configuration-server.html
@@ -232,7 +232,7 @@ Refer to <a href="../reference/vespa-cmdline-tools.html">tools</a> for details:
 </ol>
 This procedure completely cleans out ZooKeeper's internal data snapshots and deploys from scratch.
 </p><p>
-Note that by default the <a href="../content/content-nodes.html#clustercontroller">cluster controller</a>
+Note that by default the <a href="../content/content-nodes.html#cluster-controller">cluster controller</a>
 that maintains the state of the content cluster will use the shared same ZooKeeper instance,
 so the content cluster state is also reset when removing state.
 Manually set state will be lost (e.g. a node with user state <em>down</em>).

--- a/documentation/content/admin-states.html
+++ b/documentation/content/admin-states.html
@@ -182,19 +182,17 @@ title: "Cluster and Node States"
 
 <h2 id="inspecting-and-modifying-states">Inspecting and modifying states</h2>
 <p>
-  State information is available through the
-  <a href="api-state-rest-api.html">State Rest API</a>. This interface can
-  also be used to set user states for nodes.
-  For convenience, use the
-  command line tools. See the <em>--help</em> pages for
-  <em>vespa-get-cluster-state</em>, <em>vespa-get-node-state</em>
-  and <em>vespa-set-node-state</em>.
+State information is available through the
+<a href="api-state-rest-api.html">State Rest API</a>.
+This interface can also be used to set user states for nodes.
+Alternatively, use the tools
+<a href="../reference/vespa-cmdline-tools.html#vespa-get-cluster-state">vespa-get-cluster-state</a>,
+<a href="../reference/vespa-cmdline-tools.html#vespa-get-node-state">vespa-get-node-state</a> and
+<a href="../reference/vespa-cmdline-tools.html#vespa-set-node-state">vespa-set-node-state</a>.
 </p><p>
-  More detailed information is available in the cluster controller status pages.
-  They can change at any time, and the output of these pages may require a
-  good knowledge of content layer design to make sense. Find the status pages
-  on the STATE port used by the cluster controller component at
-  <em>/clustercontroller-status/v1/</em>
+More detailed information is available in the cluster controller status pages.
+They can change at any time, and the output of these pages may require a
+good knowledge of content layer design to make sense.
+Find the status pages on the STATE port used by the cluster controller component at
+<em>/clustercontroller-status/v1/</em>
 </p>
-
-

--- a/documentation/content/admin-states.html
+++ b/documentation/content/admin-states.html
@@ -4,179 +4,186 @@ title: "Cluster and Node States"
 ---
 
 <p>
-  Clients route requests to distributors using the distribution algorithm.
-  Node states are input to the algorithm.
-  Distributors use the distribution algorithm to keep bucket copies on correct
-  storage nodes. To do this, it needs to know which storage nodes are available
-  to hold copies and what their capacities are.
-  Service layer nodes may split requests between different partitions, in which
-  case it needs to know what partitions are available.
-  To achieve this, state is tracked for all the major components of the content layer:
+Clients route requests to distributors using the distribution algorithm.
+Node states are input to the algorithm.
+Distributors use the distribution algorithm to keep bucket copies on correct storage nodes.
+To do this, it needs to know which storage nodes are available
+to hold copies and what their capacities are.
+Service layer nodes may split requests between different partitions,
+in which case it needs to know what partitions are available.
+To achieve this, state is tracked for all the major components of the content layer:
 </p>
-<dl  class="dl-horizontal">
-  <dt>Up</dt>
-  <dd>The node is up and available to keep buckets and serve requests.</dd>
-
-  <dt>Down</dt>
-  <dd>The node is not available, and can not be used. The distribution algorithm
-      will not consider this node for bucket placement.</dd>
-
-  <dt>Initializing</dt>
-  <dd>The node is starting up. It knows what buckets it stores data for, and may
-      serve requests, but it does not know the metadata for all its buckets yet,
-      such as checksums and document counts. The distribution algorithm will
-      consider this node as available when calculating bucket placement.
-  </dd>
-
-  <dt>Stopping</dt>
-  <dd>This node is stopping and is expected to be down soon. This state is
-      typically only exposed to the cluster controller to tell why the node
-      stopped. The cluster controller will expose the node as down or in
-      maintenance mode for the rest of the cluster. This state is thus not seen
-      by the distribution algorithm.
-  </dd>
-
-  <dt>Maintenance</dt>
-  <dd>This component is temporarily unavailable. The distribution algorithm will
-      count this node as available for bucket placement, causing less than
-      redundancy copies to be available. This mode is typically used to mask a
-      down state during controlled node restarts, or by an administrator that
-      need to do some short maintenance work, like upgrading software or restart
-      the node. Using this mode, new copies of the documents stored on this node
-      will not be created, allowing the node to be down with less of a performance
-      impact on the rest of the cluster.
-  </dd>
-  <dt>Retired</dt>
-  <dd>A retired node is available and serves requests.
+<table class="table">
+<tr>
+  <th>Up</th>
+  <td>The node is up and available to keep buckets and serve requests.</td>
+</tr><tr>
+  <th>Down</th>
+  <td>The node is not available, and can not be used.
+      The distribution algorithm will not consider this node for bucket placement.</td>
+</tr><tr>
+  <th>Initializing</th>
+  <td>The node is starting up.
+      It knows what buckets it stores data for, and may serve requests,
+      but it does not know the metadata for all its buckets yet,
+      such as checksums and document counts.
+      The distribution algorithm will consider this node as available when calculating bucket placement.
+  </td>
+</tr><tr>
+  <th>Stopping</th>
+  <td>This node is stopping and is expected to be down soon.
+      This state is typically only exposed to the cluster controller
+      to tell why the node stopped.
+      The cluster controller will expose the node as down
+      or in maintenance mode for the rest of the cluster.
+      This state is thus not seen by the distribution algorithm.
+  </td>
+</tr><tr>
+  <th>Maintenance</th>
+  <td>This node is temporarily unavailable.
+      The distribution algorithm will count this node as available for bucket placement,
+      causing less than redundancy copies to be available.
+      This mode is typically used to mask a down state during controlled node restarts,
+      or by an administrator that need to do some short maintenance work,
+      like upgrading software or restart the node.
+      Using this mode, new copies of the documents stored on this node will not be created,
+      allowing the node to be down with less of a performance impact on the rest of the cluster.
+  </td>
+</tr><tr>
+  <th>Retired</th>
+  <td>A retired node is available and serves requests.
       This state is used to remove nodes while keeping redundancy.
       The distribution algorithm will not consider retired nodes when calculating bucket placement.
       Buckets are moved to other nodes (with low priority), until empty.
       Special considerations apply when using
       <a href="../elastic-vespa.html#grouped-distribution">grouped distribution</a>
       as buckets are not necessarily removed.
-  </dd>
-</dl>
+  </td>
+</tr>
+</table>
 
 
 
 <h2 id="distributor-state">Distributor state</h2>
 <p>
-  The distributors use similar node states as the service layer nodes. However,
-  maintenance currently makes little sense as there is only one distributor able
-  to handle requests for a given bucket. Setting a distributor in maintenance
-  mode will make the subset owned by that distributor unavailable, and is thus
-  not recommended to be used for distributors. The cluster controller will not,
-  by default, mask distributors restarting as in maintenance mode. This will
-  change when distributor redundancy is implemented.
+The distributors use similar node states as the service layer nodes.
+However, maintenance currently makes little sense,
+as there is only one distributor able to handle requests for a given bucket.
+Setting a distributor in maintenance mode will make the subset owned by that distributor unavailable,
+and is thus not recommended to be used for distributors.
+The cluster controller will not, by default, mask distributors restarting as in maintenance mode.
 </p><p>
-  Retired mode also makes little sense for distributors, as ownership transfer
-  happens quickly at any distributor state change anyhow. A retired distributor
-  will not be used by any clients.
+Retired mode also makes little sense for distributors,
+as ownership transfer happens quickly at any distributor state change anyhow.
+A retired distributor will not be used by any clients.
 </p>
 
 
 
 <h2 id="partition-state">Partition state</h2>
 <p>
-  The content layer allows service layer nodes to be split into multiple
-  partitions, allowing parts of a service layer node to be unavailable. If the
-  backend is actually using a JBOD disk setup, and a disk is unusable, it can
-  mark it unavailable, without causing all the capacity on the entire node to be
-  lost.
+The content layer allows service layer nodes to be split into multiple partitions,
+allowing parts of a service layer node to be unavailable.
+If the backend is actually using a JBOD disk setup, and a disk is unusable,
+it can mark it unavailable, without causing all the capacity on the entire node to be lost.
 </p><p>
-  The partitions can currently only be in up or down states, and changing state
-  entails restarting the service layer node.
+The partitions can currently only be in up or down states,
+and changing state entails restarting the service layer node.
 </p>
 
 
 
 <h2 id="cluster-state">Cluster state</h2>
 <p>
-  The cluster controller generates a cluster state by combining node and
-  partition states for all the nodes. Each time the state is altered in a way that
-  has an effect on the cluster, the cluster state version is upped, and the
-  new cluster state is broadcasted to all the distributor and service layer nodes,
-  provided a minimum time has passed since last time a new state was created.
+The cluster controller generates a cluster state by combining node and
+partition states for all the nodes.
+Each time the state is altered in a way that has an effect on the cluster,
+the cluster state version is upped,
+and the new cluster state is broadcasted to all the distributor and service layer nodes,
+provided a minimum time has passed since last time a new state was created.
 </p><p>
-  The cluster controller has settings for how big a percentage of distributor
-  and service layer nodes need to be available for the cluster to be available.
-  If too many nodes are unavailable, allowing load to the remaining nodes will
-  overload the nodes and completely fill them with data. This will not give a
-  good user experience, and the cluster will use quite some time to recover
-  from this afterwards. Thus, if a cluster is missing too many nodes to perform
-  decently, the entire cluster is considered down. While this sounds drastic, it
-  allows building a failover solution, or at the
-  very least, the cluster will get back to a usable state faster once enough
-  nodes are available again.
+The cluster controller has settings for how big a percentage of distributor
+and service layer nodes need to be available for the cluster to be available.
+If too many nodes are unavailable,
+allowing load to the remaining nodes will overload the nodes and completely fill them with data.
+This will not give a good user experience,
+and the cluster will use quite some time to recover from this afterwards.
+Thus, if a cluster is missing too many nodes to perform decently,
+the entire cluster is considered down.
+While this sounds drastic, it allows building a failover solution,
+or at the very least, the cluster will get back to a usable state faster
+once enough nodes are available again.
 </p><p>
-  Note, that if a cluster has so many nodes unavailable that it is considered
-  down, the state of the individual nodes are irrelevant to the cluster, and thus
-  new cluster states will not be created and broadcasted before enough nodes are
-  back for the cluster to come back up. A cluster state indicating the entire
-  cluster is down, may thus have outdated data on the node level.
+Note, that if a cluster has so many nodes unavailable that it is considered down,
+the state of the individual nodes are irrelevant to the cluster,
+and thus new cluster states will not be created and broadcasted
+before enough nodes are back for the cluster to come back up.
+A cluster state indicating the entire cluster is down,
+may thus have outdated data on the node level.
 </p><p>
-  State is viewed in different contexts: <em>unit</em>, <em>user</em>
-  and <em>generated</em> states:
+State is viewed in different contexts: <em>unit</em>, <em>user</em> and <em>generated</em> states:
 </p>
-
-
-<h3 id="unit-state">Unit state</h3>
-<p>
-  The cluster controller fetches node states from all nodes. It attempts to always
-  have a pending node state request to every node, such that any node state change
-  can be reported back to the cluster controller immediately. These states
-  are called <em>unit states</em>.
-  States reported from the nodes themselves are either <em>initializing</em>, <em>up</em> or
-  <em>stopping</em>. If the node can not be reached, a <em>down</em> state is assumed.
-</p>
-
-
-<h3 id="user-state">User state</h3>
-<p>
-  By default, it is assumed that all the nodes in the cluster are preferred to be
-  up and available. Several other cases exist though:
-<ul>
+<table class="table">
+<tr id="unit-state">
+  <th>Unit state</th>
+  <td>
+  <p>
+  The cluster controller fetches node states from all nodes.
+  It attempts to always have a pending node state request to every node,
+  such that any node state change can be reported back to the cluster controller immediately.
+  These states are called <em>unit states</em>.
+  States reported from the nodes themselves are either
+  <em>initializing</em>, <em>up</em> or <em>stopping</em>.
+  If the node can not be reached, a <em>down</em> state is assumed.
+  </p>
+  </td>
+</tr><tr id="user-state">
+  <th>User state</th>
+  <td>
+  <p>
+  By default, it is assumed that all the nodes in the cluster are preferred to be up and available.
+  other cases are:
+  <ul>
   <li>Retire a node from a cluster -
       use retiring mode to get buckets moved elsewhere</li>
   <li>Short-lived maintenance work on the node -
       set in maintenance mode to avoid the rest of the cluster spending
       resources to create more copies of buckets.</li>
   <li>A node with bad hardware or corrupt files may cause havoc in the cluster.
-      In such cases, the cluster is better off not using the node at all. The
-      cluster controller might detect this, or administrators looking into issues
+      In such cases, the cluster is better off not using the node at all.
+      The cluster controller might detect this, or administrators looking into issues
       may find issues and manually want to mark the node not to be used.</li>
-</ul>
-  Administrators or cluster controller logic may alter the preferred node state
-  for a node. Preferred states must be one of <em>up</em>, <em>down</em>,
-  <em>maintenance</em> or <em>retired</em>.
-  These are called <em>user states</em>.
-</p><p>
-  User states are stored in a ZooKeeper cluster run by the configuration
-  servers.
-</p>
-
-
-<h3 id="generated-state">Generated state</h3>
-<p>
+  </ul>
+  Administrators or cluster controller logic may alter the preferred node state for a node.
+  Preferred states (called <em>user states</em>) must be one of
+  <em>up</em>, <em>down</em>, <em>maintenance</em> or <em>retired</em>.
+  </p><p>
+  User states are stored in a ZooKeeper cluster run by the configuration servers.
+  </p>
+  </td>
+</tr><tr id="generated-state">
+  <th style="white-space: nowrap">Generated state</th>
+  <td>
+  <p>
   When viewing node states from a cluster state, one sees a state calculated based
-  on reported states, preferred states and historic knowledge kept of the node
-  by the cluster controller.
-</p><p>
+  on reported states, preferred states and historic knowledge kept of the node by the cluster controller.
+  </p><p>
   The cluster controller will typically mask a down reported state with a
-  maintenance state for a short time if it has seen a stopping state indicating
-  a controlled restart. Assuming the node will soon be initializing again,
-  masking it as maintenance will stop distributors from creating new copies of
-  buckets during that time window. If the node fails to come back quickly
-  though, the state will become down.
-</p><p>
-  Nodes that come back up, reporting as <em>initializing</em>, may be masked as
-  <em>down</em> by the cluster controller. The cluster controller might suspect it of
-  stalling or crashing during initialization due to historic events, and may
-  keep it unused for the time being to avoid the cluster to be interrupted again.
-</p><p>
-  Node states seen through the currently active cluster state
-  are called <em>generated states</em>.
-</p>
+  maintenance state for a short time if it has seen a stopping state indicating a controlled restart.
+  Assuming the node will soon be initializing again,
+  masking it as maintenance will stop distributors from creating new copies of buckets during that time window.
+  If the node fails to come back quickly though, the state will become down.
+  </p><p>
+  Nodes that come back up, reporting as <em>initializing</em>,
+  may be masked as <em>down</em> by the cluster controller.
+  The cluster controller might suspect it of stalling or crashing during initialization due to historic events,
+  and may keep it unused for the time being to avoid the cluster to be interrupted again.
+  </p><p>
+  Node states seen through the currently active cluster state are called <em>generated states</em>.
+  </p>
+  </td>
+</tr>
+</table>
 
 
 

--- a/documentation/content/content-nodes.html
+++ b/documentation/content/content-nodes.html
@@ -236,9 +236,9 @@ This API can also be used to set a user state for a node, e.g. forcing a node pe
 </p><p>
 A few command line tools have been implemented using the State Rest API:
 <ul>
-  <li><code>vespa-get-cluster-state</code></li>
-  <li><code>vespa-get-node-state</code></li>
-  <li><code>vespa-set-node-state</code></li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-get-cluster-state">vespa-get-cluster-state</a></li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-get-node-state">vespa-get-node-state</a></li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-set-node-state">vespa-set-node-state</a></li>
 </ul>
 </p><p>
 A status page for the cluster controller is available at the status port at

--- a/documentation/content/content-nodes.html
+++ b/documentation/content/content-nodes.html
@@ -241,20 +241,7 @@ A few command line tools have been implemented using the State Rest API:
   <li><a href="../reference/vespa-cmdline-tools.html#vespa-set-node-state">vespa-set-node-state</a></li>
 </ul>
 </p><p>
-A status page for the cluster controller is available at the status port at
-<code>http://hostname:port/clustercontroller-status/v1/<em>&lt;clustername&gt;</em></code>.
-If <em>clustername</em> is not specified, the available clusters will be listed.
-The cluster controller leader status page will show if any nodes are operating with differing cluster state versions.
-It will also show how many data buckets are pending merging (document set reconciliation)
-due to either missing or being out of sync.
-<pre>
-$ <a href="../reference/vespa-cmdline-tools.html#vespa-model-inspect">vespa-model-inspect</a> service container-clustercontroller | grep HTTP
-</pre>
-With multiple cluster controllers, look at the one with a "/0" suffix in its config ID;
-it is the preferred leader.
-</p><p>
-The cluster state version is listed under the <em>SSV</em> table column.
-Divergence here usually points to host or networking issues.
+Also see the cluster controller <a href="../operations/admin-procedures.html#status-pages">status page</a>.
 </p>
 
 

--- a/documentation/elastic-vespa.html
+++ b/documentation/elastic-vespa.html
@@ -118,7 +118,7 @@ The distributor maps the document to bucket, and sends it to <em>content nodes</
     </tr><tr id="cluster-controller">
       <th>Cluster controller</th>
       <td>
-        The <a href="content/content-nodes.html#clustercontroller">cluster controller</a>
+        The <a href="content/content-nodes.html#cluster-controller">cluster controller</a>
         manages the state of the distributor and content nodes.
         This <em>cluster state</em> is used by the document processing chains
         to know which distributor to send documents to,

--- a/documentation/operations/admin-procedures.html
+++ b/documentation/operations/admin-procedures.html
@@ -20,8 +20,8 @@ for a primer on how to set up a cluster. Required architecture is <em>x86_64</em
   <li>Use <a href="../reference/search-api-reference.html#tracelevel">query tracing</a></li>
   <li>Use <a href="../reference/services.html#clients">feed tracing</a></li>
     <!-- ToDo: this works? must document ... -->
-  <li>Use the <a href="../elastic-vespa.html#cluster-controller">
-    Cluster Controller</a> to track the status of search/storage nodes.</li>
+  <li>Use the <em>cluster controller</em> status page (below)
+    to track the status of search/storage nodes.</li>
 </ul>
 
 
@@ -30,7 +30,7 @@ for a primer on how to set up a cluster. Required architecture is <em>x86_64</em
 <p>
 All Vespa processes have a PID file <em>$VESPA_HOME/var/run/{service name}.pid</em>,
 where <em>{service name}</em> is the Vespa service name, e.g. <em>container</em> or <em>distributor</em>.
-It is the same name which is used in the telnet administration interface
+It is the same name which is used in the administration interface
 in the <a href="../config-sentinel.html">config sentinel</a>.
 </p>
 
@@ -61,9 +61,7 @@ $ vespa-model-inspect service [Options] &lt;service-name&gt;
     These ports are tagged HTTP. The cluster controller have multiple ports tagged HTTP,
     where the port tagged STATE is the one with the status page.
     Try connecting to the root at the port, or /state/v1/metrics.
-    The <em>distributor</em> and <em>storagenode</em> status pages are available at <code>/</code>,
-    while the <em>container-clustercontroller</em> status page is found at
-    <code>/clustercontroller-status/v1/[clustername/]</code>. Example:
+    The <em>distributor</em> and <em>storagenode</em> status pages are available at <code>/</code>:
 <pre>
   $ vespa-model-inspect service searchnode
   searchnode @ myhost.mydomain.com : search
@@ -86,6 +84,20 @@ $ vespa-model-inspect service [Options] &lt;service-name&gt;
   $ curl http://myhost.mydomain.com:19118/
   ...
 </pre>
+    A status page for the cluster controller is available at the status port at
+<code>http://hostname:port/clustercontroller-status/v1/<em>&lt;clustername&gt;</em></code>.
+If <em>clustername</em> is not specified, the available clusters will be listed.
+The cluster controller leader status page will show if any nodes are operating with differing cluster state versions.
+It will also show how many data buckets are pending merging (document set reconciliation)
+due to either missing or being out of sync.
+<pre>
+$ <a href="../reference/vespa-cmdline-tools.html#vespa-model-inspect">vespa-model-inspect</a> service container-clustercontroller | grep HTTP
+</pre>
+With multiple cluster controllers, look at the one with a "/0" suffix in its config ID;
+it is the preferred leader.
+</p><p>
+The cluster state version is listed under the <em>SSV</em> table column.
+Divergence here usually points to host or networking issues.
   </li>
 </ol>
 </p>

--- a/documentation/reference/files-processes-and-ports.html
+++ b/documentation/reference/files-processes-and-ports.html
@@ -148,7 +148,7 @@ to see port allocations.
   <td>Content layer distributor processes</td>
   </tr>
 <tr>
-  <td style="white-space: nowrap"><a href="../content/content-nodes.html#clustercontroller">Cluster controller</a></td>
+  <td style="white-space: nowrap"><a href="../content/content-nodes.html#cluster-controller">Cluster controller</a></td>
   <td>Content cluster</td>
   <td>dynamically allocated in 19100 - 19899 range</td>
   <td>java (...) -jar

--- a/documentation/reference/vespa-cmdline-tools.html
+++ b/documentation/reference/vespa-cmdline-tools.html
@@ -551,7 +551,66 @@ Options:
 
 
 
-<!--h2 id="vespa-get-cluster-state">vespa-get-cluster-state</h2-->
+<h2 id="vespa-get-cluster-state">vespa-get-cluster-state</h2>
+<p>
+Get cluster state - refer to <a href="../content/content-nodes.html">content nodes</a>.
+</p><p>
+Synopsis: <code>vespa-get-cluster-state [options]</code>
+</p><p>
+Options:
+<table class="table">
+  <thead></thead><tbody>
+    <tr>
+      <th>-h, --help</th>
+      <td>
+        Show help
+      </td>
+    </tr><tr>
+      <th>-v</th>
+      <td>
+        More verbose output
+      </td>
+    </tr><tr>
+      <th>-s</th>
+      <td>
+        Less verbose output
+      </td>
+    </tr><tr>
+      <th>--show-hidden</th>
+      <td>
+        Also show hidden undocumented debug options
+      </td>
+    </tr><tr>
+      <th>-c, --cluster</th>
+      <td>
+        Cluster name of cluster to query.
+        If unspecified, and vespa is installed on current node,
+        information will be attempted auto-extracted
+      </td>
+    </tr><tr>
+      <th>-f, --force</th>
+      <td>
+        Force execution
+      </td>
+    </tr><tr>
+      <th>--config-server</th>
+      <td>
+        Host name of config server to query
+      </td>
+    </tr><tr>
+      <th>--config-server-port</th>
+      <td>
+        Port to connect to config server on
+       </td>
+    </tr><tr>
+      <th>--config-request-timeout</th>
+      <td>
+        Timeout of config request
+      </td>
+    </tr>
+  </tbody>
+</table>
+</p>
 
 
 
@@ -639,7 +698,95 @@ Options:
 
 
 
-<!--h2 id="vespa-get-node-state">vespa-get-node-state</h2-->
+<h2 id="vespa-get-node-state">vespa-get-node-state</h2>
+<p>
+Get the state of one or more storage services from the fleet controller -
+refer to <a href="../content/content-nodes.html">content nodes</a>:
+<table class="table">
+<tr>
+  <th>Unit state</th>
+  <td>The state of the node seen from the cluster controller.</td>
+</tr><tr>
+  <th>User state</th>
+  <td>The state the administrator want the node to be in, default "up".
+    Can be set by using <a href="#vespa-set-node-state">vespa-set-node-state</a>
+    or by the cluster controller</td>
+</tr><tr>
+  <th style="white-space:nowrap;">Generated state</th>
+  <td>The state of a given node in the current cluster state.
+    This is the state all the other nodes know about.
+    This state is a product of the other two states
+    and cluster controller logic to keep the cluster stable.</td>
+</tr>
+</table>
+Synopsis: <code>vespa-get-node-state [options]</code>
+</p><p>
+Options:
+<table class="table">
+  <thead></thead><tbody>
+    <tr>
+      <th>-h, --help</th>
+      <td>
+        Show help
+      </td>
+    </tr><tr>
+      <th>-v</th>
+      <td>
+        More verbose output
+      </td>
+    </tr><tr>
+      <th>-s</th>
+      <td>
+        Less verbose output
+      </td>
+    </tr><tr>
+      <th>--show-hidden</th>
+      <td>
+        Also show hidden undocumented debug options
+      </td>
+    </tr><tr>
+      <th>-c, --cluster</th>
+      <td>
+        Cluster name of cluster to query.
+        If unspecified, and vespa is installed on current node,
+        information will be attempted auto-extracted
+      </td>
+    </tr><tr>
+      <th>-f, --force</th>
+      <td>
+        Force execution
+      </td>
+    </tr><tr>
+      <th>-t, --type</th>
+      <td>
+        Node type - can either be 'storage' or 'distributor'.
+        If not specified, the operation will use state for both types
+      </td>
+    </tr><tr>
+      <th>-i, --index</th>
+      <td>
+        Node index. If not specified,
+        all nodes found running on this host will be used
+      </td>
+    </tr><tr>
+      <th>--config-server</th>
+      <td>
+        Host name of config server to query
+      </td>
+    </tr><tr>
+      <th>--config-server-port</th>
+      <td>
+        Port to connect to config server on
+       </td>
+    </tr><tr>
+      <th>--config-request-timeout</th>
+      <td>
+        Timeout of config request
+      </td>
+    </tr>
+  </tbody>
+</table>
+</p>
 
 
 
@@ -1313,9 +1460,6 @@ Options:
 
 
 
-
-
-
 <h2 id="vespa-route">vespa-route</h2>
 <p>
 <em>vespa-route</em> is a  tool to inspect Vespa routing configurations.
@@ -1520,9 +1664,98 @@ Output - each line has the following fields:
 
 
 
-<!--h2 id="vespa-set-node-state">vespa-set-node-state</h2-->
+<h2 id="vespa-set-node-state">vespa-set-node-state</h2>
+<p>
+Set the user state of a node - refer to <a href="../content/content-nodes.html">content nodes</a>.
+This will set the generated state to the user state
+if the user state is "better" than the generated state that would have been created
+if the user state was up.
+For instance, a node that is currently in initializing state can be forced into down state,
+while a node that is currently down can not be forced into retired state,
+but can be forced into maintenance state.
+</p><p>
+Synopsis: <code>vespa-set-node-state [options] up|down|maintenance|retired [description]</code>
+</p><p>
+Example:
+<pre>
+$ vespa-set-node-state -i 0 maintenance "Set to maintenance for software upgrade"
+</pre>
+Options:
+<table class="table">
+  <thead></thead><tbody>
+    <tr>
+      <th>-h, --help</th>
+      <td>
+        Show help
+      </td>
+    </tr><tr>
+      <th>-v</th>
+      <td>
+        More verbose output
+      </td>
+    </tr><tr>
+      <th>-s</th>
+      <td>
+        Less verbose output
+      </td>
+    </tr><tr>
+      <th>--show-hidden</th>
+      <td>
+        Also show hidden undocumented debug options
+      </td>
+    </tr><tr>
+      <th>-n, --no-wait</th>
+      <td>
+        Do not wait for node state changes to be visible in the cluster before returning
+      </td>
+    </tr><tr>
+      <th>-c, --cluster</th>
+      <td>
+        Cluster name of cluster to query.
+        If unspecified, and vespa is installed on current node,
+        information will be attempted auto-extracted
+      </td>
+    </tr><tr>
+      <th>-f, --force</th>
+      <td>
+        Force execution
+      </td>
+    </tr><tr>
+      <th>-t, --type</th>
+      <td>
+        Node type - can either be 'storage' or 'distributor'.
+        If not specified, the operation will use state for both types
+      </td>
+    </tr><tr>
+      <th>-i, --index</th>
+      <td>
+        Node index. If not specified,
+        all nodes found running on this host will be used
+      </td>
+    </tr><tr>
+      <th>--config-server</th>
+      <td>
+        Host name of config server to query
+      </td>
+    </tr><tr>
+      <th>--config-server-port</th>
+      <td>
+        Port to connect to config server on
+       </td>
+    </tr><tr>
+      <th>--config-request-timeout</th>
+      <td>
+        Timeout of config request
+      </td>
+    </tr>
+  </tbody>
+</table>
+</p>
+
+
+
 <!--h2 id="vespa-slobrok-cmd">vespa-slobrok-cmd</h2-->
-<!--h2 id="vespa-spoolmaster">vespa-spoolmaster</h2-->
+
 
 
 <h2 id="vespa-stat">vespa-stat</h2>

--- a/documentation/vespa-quick-start-multinode-aws.html
+++ b/documentation/vespa-quick-start-multinode-aws.html
@@ -265,7 +265,8 @@ $ curl -s --head http://localhost:8080/ApplicationStatus
   <li>
     <p><strong>Inspect &amp; Verify</strong>:</p>
     <p>
-    Inspect the system state using <a href="content/admin-states.html"><samp>vespa-get-cluster-state</samp></a>,
+    Inspect the system state using
+    <a href="reference/vespa-cmdline-tools.html#vespa-get-cluster-state"><samp>vespa-get-cluster-state</samp></a>,
     making sure services are 'up':
 <pre>
 $ vespa-get-cluster-state


### PR DESCRIPTION
The only real change is adding doc for the get/set node/cluster state tools (based on the help text) - will reorganize this a bit, coordinate with the other docs later
