### PR TITLE
simplify max-length doc

### DIFF
--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1701,8 +1701,7 @@ foo AND (artist:"'N Sync" OR artist:"*NSYNC" OR artist:A*teens OR artist:"Wham!"
 <tr id="max-length"><td><code>max-length</code></td>
 <td>Indexes, streaming</td>
 <td><p>
-  Override <code><a href="#fieldmatchmaxlength">fieldmatchmaxlength</a></code> -
-  this limits the length of the field that will be used for matching.
+ Limit the length of the field that will be used for matching.
 </p></td>
 </tr>
 

--- a/documentation/reference/search-definitions-reference.html
+++ b/documentation/reference/search-definitions-reference.html
@@ -1701,7 +1701,7 @@ foo AND (artist:"'N Sync" OR artist:"*NSYNC" OR artist:A*teens OR artist:"Wham!"
 <tr id="max-length"><td><code>max-length</code></td>
 <td>Indexes, streaming</td>
 <td><p>
- Limit the length of the field that will be used for matching.
+  Limit the length of the field that will be used for matching.
 </p></td>
 </tr>
 


### PR DESCRIPTION
in #729  we removed _ fieldmatchmaxlength_ documentation - remove here too. not sure if the _max-length_ needs more text, this removes the broken link