### PR TITLE
temporarily revert to previous navbar color

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -14,6 +14,9 @@
   --vespa-color-sidebar-border: #eee;
   --vespa-color-searchform:     #3f9dd8;
   --vespa-color-text-sidebar:   #848484;
+
+  /* 2019 colors */
+  --vespa-color-light-blue-original #3f9dd8;
 }
 
 
@@ -67,8 +70,8 @@ h3,
 }
 
 .navbar-default {
-    background-color: var(--vespa-color-light-blue);
-    border-color: var(--vespa-color-light-blue);
+    background-color: var(--vespa-color-light-blue-original);
+    border-color: var(--vespa-color-light-blue-original);
 }
 
 .navbar-brand {


### PR DESCRIPTION
to not violate blue logo on dark color restriction

but I really do not like this way either (yet another blue, which is not in the updated guide), so lets think of alternatives - maybe white logo or something else
