### PR TITLE
Remove distracting example

### DIFF
--- a/documentation/tensor-user-guide.html
+++ b/documentation/tensor-user-guide.html
@@ -54,25 +54,9 @@ There are two options when feeding tensors.
     to a tensor during document processing using the
     <a href="http://javadoc.io/page/com.yahoo.vespa/vespajlib/latest/com/yahoo/tensor/Tensor.html">tensor Java API</a>.</li>
   <li>Feed tensors using the <a href="reference/document-json-format.html#tensor">
-    tensor JSON format</a> - example:
-<pre>
-{
-    "fields": {
-        "tensor_attribute": {
-            "cells": [
-                { "address" : { "x" : "0" }, "value": 1.0 },
-                { "address" : { "x" : "1" }, "value": 2.0 },
-                { "address" : { "x" : "2" }, "value": 3.0 },
-                { "address" : { "x" : "3" }, "value": 5.0 }
-            ]
-        }
-    }
-}
-</pre>
+    tensor JSON format</a>.
   </li>
 </ul>
-Here, the <code>x</code>-dimension is indexed, so the indices must be numeric.
-For mapped dimensions, indices can be any textual value.
 </p><p>
 Tensors can be updated - one can
 <a href="https://docs.vespa.ai/documentation/reference/document-json-format.html#tensor-add">add</a>,


### PR DESCRIPTION
Removed distracting example so that people can focus on clicking on the informative link.