### PR TITLE
Kkraune/remove redundant group setup doc

### DIFF
--- a/documentation/operations/admin-procedures.html
+++ b/documentation/operations/admin-procedures.html
@@ -140,9 +140,9 @@ and/or add
 configuration</a> under the <em>services</em> element - example:
 <pre>
 &lt;services version="1.0"&gt;
-  &lt;config name="vespa.config.content.fleetcontroller"&gt;
-    &lt;min_time_between_new_systemstates&gt;5000&lt;/min_time_between_new_systemstates&gt;
-  &lt;/config&gt;
+    &lt;config name="vespa.config.content.fleetcontroller"&gt;
+        &lt;min_time_between_new_systemstates&gt;5000&lt;/min_time_between_new_systemstates&gt;
+    &lt;/config&gt;
 </pre>
 </p>
 
@@ -286,6 +286,13 @@ reconfiguring document processing</a>.
 </p>
 
 
+<h3 id="restart-content-node">Configure grouped setup</h3>
+<p>
+Refer to the <a href="../performance/sizing-examples.html">sizing examples</a>
+for changing from a flat to grouped cluster.
+</p>
+
+
 <h3 id="restart-distributor-node">Restart distributor node</h3>
 <p>
 When a distributor stops, it will try to respond to any pending cluster state request first.
@@ -370,163 +377,6 @@ During the initializing stage, bucket metadata is unknown.
 Distributors will assume other copies are more appropriate for serving read requests.
 If all copies of a bucket are in an initializing state at the same time,
 read requests may be sent to a bucket copy that does not have the most updated state to process it.
-</p>
-
-
-
-<h2 id="migrate-to-using-groups-example-1">Migrate to using groups - example 1</h2>
-<p>
-Migrating from flat distribution to a
-<a href="../elastic-vespa.html#grouped-distribution">hierarchy</a>
-will temporarily reduce query coverage.
-To work around, increase redundancy first, then reconfigure to using groups.
-When adding new group(s), it will take some time to populate the new nodes.
-During this transition period, queries hitting these nodes will return partial results.
-<a href="../reference/services-content.html#nodes">Reference documentation</a>.
-</p><p>
-Example - migrate to using groups. Starting point:
-A cluster with 4 nodes and flat distribution and redundancy 2.
-End state: all 4 nodes with all documents:
-<pre>
-&lt;content id="music" version="1.0"&gt;
-  &lt;redundancy&gt;2&lt;/redundancy&gt;
-  &lt;documents&gt;
-    &lt;document mode="index" type="music" /&gt;
-  &lt;/documents&gt;
-  &lt;nodes&gt;
-    &lt;node hostalias="node0"/&gt;
-    &lt;node hostalias="node1"/&gt;
-    &lt;node hostalias="node2"/&gt;
-    &lt;node hostalias="node3"/&gt;
-  &lt;/nodes&gt;
-  &lt;engine&gt;
-    &lt;proton&gt;
-      &lt;searchable-copies&gt;2&lt;/searchable-copies&gt;
-    &lt;/proton&gt;
-  &lt;/engine&gt;
-&lt;/content&gt;
-</pre>
-Increase <em>redundancy</em> and <em>searchable-copies</em> to 4.
-After deploying this, wait for all search nodes to finish redistribution
-(i.e. all nodes have all documents):
-<pre>
-&lt;content id="music" version="1.0"&gt;
-  &lt;redundancy&gt;4&lt;/redundancy&gt;
-  &lt;documents&gt;
-    &lt;document mode="index" type="music" /&gt;
-  &lt;/documents&gt;
-  &lt;nodes&gt;
-    &lt;node hostalias="node0"/&gt;
-    &lt;node hostalias="node1"/&gt;
-    &lt;node hostalias="node2"/&gt;
-    &lt;node hostalias="node3"/&gt;
-  &lt;/nodes&gt;
-  &lt;engine&gt;
-    &lt;proton&gt;
-      &lt;searchable-copies&gt;4&lt;/searchable-copies&gt;
-    &lt;/proton&gt;
-  &lt;/engine&gt;
-&lt;/content&gt;
-</pre>
-Reconfigure to 4 groups, setting <em>redundancy</em>
-and <em>searchable-copies</em> to 1 (these settings apply per group):
-<pre>
-&lt;content id="music" version="1.0"&gt;
-  &lt;redundancy&gt;1&lt;/redundancy&gt;
-  &lt;documents&gt;
-    &lt;document mode="index" type="music" /&gt;
-  &lt;/documents&gt;
-  &lt;group distribution-key="0" name="mytopgroup"&gt;
-    &lt;distribution partitions="1|*"/&gt;
-    &lt;group distribution-key="0" name="mygroup0"&gt;
-      &lt;node distribution-key="0" hostalias="node0"/&gt;
-    &lt;/group&gt;
-    &lt;group distribution-key="1" name="mygroup1"&gt;
-      &lt;node distribution-key="0" hostalias="node1"/&gt;
-    &lt;/group&gt;
-    &lt;group distribution-key="2" name="mygroup2"&gt;
-      &lt;node distribution-key="0" hostalias="node1"/&gt;
-    &lt;/group&gt;
-    &lt;group distribution-key="3" name="mygroup3"&gt;
-      &lt;node distribution-key="0" hostalias="node1"/&gt;
-    &lt;/group&gt;
-  &lt;/group&gt;
-  &lt;engine&gt;
-    &lt;proton&gt;
-      &lt;searchable-copies&gt;1&lt;/searchable-copies&gt;
-    &lt;/proton&gt;
-  &lt;/engine&gt;
-&lt;/content&gt;
-</pre>
-</p>
-
-
-<h2 id="migrate-to-using-groups-example-2">Migrate to using groups - example 2</h2>
-<!-- ToDo: Reference to performance/sizing-search.html and/or migrate this there -->
-<p>
-The following example has a simple content cluster with flat distribution,
-redundancy 2 and 3 content/search nodes:
-<pre>
-&lt;content version="1.0" id="mycluster"&gt;
-  &lt;redundancy&gt;2&lt;/redundancy&gt;
-  &lt;documents&gt;
-    &lt;document mode="index" type="mydoctype"/&gt;
-  &lt;/documents&gt;
-  &lt;group distribution-key="0" name="mytopgroup"&gt;
-    &lt;node distribution-key="0" hostalias="node0"/&gt;
-    &lt;node distribution-key="1" hostalias="node1"/&gt;
-    &lt;node distribution-key="2" hostalias="node2"/&gt;
-  &lt;/group&gt;
-  &lt;engine&gt;
-    &lt;proton&gt;
-      &lt;searchable-copies&gt;2&lt;/searchable-copies&gt;
-    &lt;/proton&gt;
-  &lt;/engine&gt;
-&lt;/content&gt;
-</pre>
-Lets say we need to increase the QPS in our system by a factor of 2
-and that the static query cost (SQC) is high.
-We cannot just add 3 more content/search nodes to reach the desired QPS.
-Instead we use hierarchical distribution to get extra groups
-that also contain the entire document collection.
-The next section shows how to setup such a system.
-</p><p>
-We have defined 2 leaf groups (<em>mygroup0</em>, <em>mygroup1</em>)
-that are located under the top group.
-Each leaf group has 3 content/search nodes.
-The total redundancy of the system is now 4,
-and the <em>distribution partitions</em>
-is specified such that each leaf group will have 2 copies of the documents in the system.
-Each query can be sent to the nodes of a single group instead of all nodes in the system
-and the QPS requirement can be met through parallelization of searches.
-With redundancy 2 per leaf group we can also lose a node from a group
-and still have enough coverage.
-<pre>
-&lt;content version="1.0" id="mycluster"&gt;
-  &lt;redundancy&gt;4&lt;/redundancy&gt;
-  &lt;documents&gt;
-    &lt;document mode="index" type="mydoctype"/&gt;
-  &lt;/documents&gt;
-  &lt;group distribution-key="0" name="mytopgroup"&gt;
-    &lt;distribution partitions="2|*"/&gt;
-    &lt;group distribution-key="0" name="mygroup0"&gt;
-      &lt;node distribution-key="0" hostalias="node0"/&gt;
-      &lt;node distribution-key="1" hostalias="node1"/&gt;
-      &lt;node distribution-key="2" hostalias="node2"/&gt;
-    &lt;/group&gt;
-    &lt;group distribution-key="1" name="mygroup1"&gt;
-      &lt;node distribution-key="3" hostalias="node3"/&gt;
-      &lt;node distribution-key="4" hostalias="node4"/&gt;
-      &lt;node distribution-key="5" hostalias="node5"/&gt;
-    &lt;/group&gt;
-  &lt;/group&gt;
-  &lt;engine&gt;
-    &lt;proton&gt;
-      &lt;searchable-copies&gt;4&lt;/searchable-copies&gt;
-    &lt;/proton&gt;
-  &lt;/engine&gt;
-&lt;/content&gt;
-</pre>
 </p>
 
 

--- a/documentation/performance/sizing-examples.html
+++ b/documentation/performance/sizing-examples.html
@@ -241,3 +241,19 @@ as queries are dispatched to one group at a time using a
 The <em>adaptive</em> policy takes group latency into account
 when deciding which group the query request should be routed to.
 </p>
+
+
+
+<h2 id="changing-group-configuration">Changing Group Configuration</h2>
+<p>
+Migrating from flat distribution to a
+<a href="../elastic-vespa.html#grouped-distribution">hierarchy</a>
+will temporarily reduce query coverage
+(likewise for changing from grouped config to another).
+When adding new group(s), it will take some time to populate the new nodes.
+During this transition period, queries hitting these nodes will return partial results.
+<a href="../reference/services-content.html#nodes">Reference documentation</a>.
+</p><p>
+A possible workaround for some cases is increasing <em>redundancy</em>
+and let replicas re-distribute, before changing the group configuration.
+</p>

--- a/documentation/performance/sizing-examples.html
+++ b/documentation/performance/sizing-examples.html
@@ -73,33 +73,32 @@ When using grouped distribution in an indexed content cluster, the following res
 <ul>
   <li>There can only be a single level of leaf groups under the top group</li>
   <li>Each leaf group must have the same number of nodes </li>
-  <li>The number of leaf groups must be a factor of the redundancy</li>
+  <li>The number of leaf groups must be a factor of the
+      <a href="../reference/services-content.html#redundancy">redundancy</a></li>
   <li>The <a href="../reference/services-content.html#distribution">distribution partitions</a>
     must be specified such that the redundancy per group is equal</li>
-  <li>The number of <em>searchable-copies</em> must be less than, or equal to, <em>redundancy</em>
+  <li>The number of <a href="../reference/services-content.html#searchable-copies">searchable-copies</a>
+      must be less than, or equal to, <em>redundancy</em>
   <li>The number of leaf groups must be a factor of <em>searchable-copies</em></li>
 </ul>
-
-<p>With a low number of nodes per group it's important to remember that a node failure 
+With a low number of nodes per group, it's important to remember that a node failure
 will cause the data to be re-distributed to the remaining nodes
-and their memory footprint and disk usage will grow when those nodes starts activating the 
-documents originally activated on the failed node. 
-With e.g. 2 nodes per group, the remaining healthy node will start activating all the 
-content which will cause a 2x memory and disk fooprint compared with the ideal state. 
-The
-<a href="../reference/services-content.html#min-node-ratio-per-group">min-node-ratio-per-group</a> 
-controls the data distribution behavior inside a group in cases of 
-node failures. The setting states a lower bound requirement on the ratio of nodes 
-within individual groups 
-
-that must be online and able to accept feed and query traffic before the entire group is 
-automatically taken out of service from both feed and search/serving. 
-Once number of nodes in the group have been restored and ideal state has been achieved,
+and their memory footprint and disk usage will grow
+when those nodes starts activating the documents originally activated on the failed node.
+E.g. with 2 nodes per group, the remaining healthy node will start activating all the content,
+which will cause a 2x memory and disk footprint compared with the ideal state.
+</p><p>
+The <a href="../reference/services-content.html#min-node-ratio-per-group">min-node-ratio-per-group</a>
+controls the data distribution behavior inside a group in cases of node failures.
+This sets a lower bound on the ratio of nodes within groups
+that must be online and accepting feed and query traffic,
+before the entire group is automatically taken out of service from both feed and search/serving.
+Once number of nodes in the group have been restored, and ideal state has been achieved,
 the group will be automatically set in service.  
 </p>
 
 
-<h3>9 nodes, 3 groups with 3 nodes per group</h3>
+<h2>9 nodes, 3 groups with 3 nodes per group</h2>
 <p>
 This example has 3 groups and each group index all of the documents over the 3 nodes in the group.
 With 3 groups there are 3 replicas in total of each document, and each replica is indexed and active.
@@ -150,7 +149,8 @@ Losing a node does not reduce search coverage.
 </p>
 
 
-<h3>9 nodes, 9 groups with 1 node per group</h3>
+
+<h2>9 nodes, 9 groups with 1 node per group</h2>
 <p>
 This example has 9 groups and each group index all of the documents on a single node.
 With 9 groups there are 9 replicas in total of each document, and each replica is indexed and active.
@@ -158,7 +158,6 @@ Losing a node does not reduce search coverage.
 With a single node, indexing throughput is limited by the single node performance,
 as all data needs to go all nodes.
 <pre>
-&lt;services version="1.0"&gt;
 &lt;services version="1.0"&gt;
   &lt;container id="stateless-container-cluster" version="1.0"&gt;  
     &lt;search/&gt;


### PR DESCRIPTION
the new sizing examples are much better, kill the other confusing doc!
