### PR TITLE
Minor improvements

### DIFF
--- a/documentation/reference/ranking-expressions.html
+++ b/documentation/reference/ranking-expressions.html
@@ -336,7 +336,7 @@ concat(t1,t2,x) = {{x:0}: 0.0, {x:1}: 1.0}, {x:2}: 2.0, {x:3}: 3.0}}
           <li><code>partial-key</code>: A key can be given in the form of a tensor address {dimension:label,..},
             or for tensors having a single mapped or indexed type respectively as just a label in curly brackets {label}
             or just an index in square brackets, [index].
-            Indexes in keys may be specified by no-argument lambda functions.</li>
+            Index labels may be specified by a lambda expression enclosed in parentheses.</li>
         </ul>
         Returns a new tensor containing the cells matching the partial key.
         A common special case is producing a single value by specifying a full key.

--- a/documentation/reference/tensor.html
+++ b/documentation/reference/tensor.html
@@ -19,7 +19,6 @@ while indexed dimensions use integers in the range <code>[0,N&gt;</code> (like a
 </p>
 
 
-
 <h2 id="tensor-type-spec">Tensor type spec</h2>
 <p>
 Contained in <code><a href="search-definitions-reference.html#constant">constant</a></code>
@@ -192,9 +191,12 @@ tensor&lt;float&gt;(key{},x[2],y[3]):{ key1:[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
 </pre>
 </p>
 
+<h2>Tensor functions</h2>
+
+Tensor functions are listed in the <a href="ranking-expressions#tensor-functions">expressions</a> documentation.
 
 
-<h2>Tensor Rank Features</h2>
+<h2>Tensor rank features</h2>
 <p>
 The following rank features can be used to reference tensors when doing tensor operations in ranking expressions.
 The tensors can come from the document, the query or be constant for a deployment of the application:


### PR DESCRIPTION
- Link from tensor doc to tensor functions
- Explicitly specify that index lambda functions can be used by enclosing in parentheses

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
