### PR TITLE
Add note about fileNamePattern being optional when accesslog 'type' i…

### DIFF
--- a/documentation/reference/services-container.html
+++ b/documentation/reference/services-container.html
@@ -623,10 +623,10 @@ Access logging can be disabled by setting the type to <code>disabled</code>. Att
       <td>json</td>
       <td>The accesslog type: <em>json</em>, <em>vespa</em> or <em>disabled</em></td></tr>
     <tr id="accesslog.fileNamePattern"><th>fileNamePattern</th>
-      <td>required</td>
+      <td>required*</td>
       <td>string</td>
       <td>JsonAccessLog.&lt;container id&gt;.%Y%m%d%H%M%S</td>
-      <td>File name pattern</td></tr>
+      <td>File name pattern. * Note: Optional when <em>type</em> is <em>disabled</em></td></tr>
     <tr id="accesslog.symlinkName"><th>symlinkName</th>
       <td>optional</td>
       <td>string</td>


### PR DESCRIPTION
…s 'disabled'
