### PR TITLE
app package root

### DIFF
--- a/documentation/cloudconfig/application-packages.html
+++ b/documentation/cloudconfig/application-packages.html
@@ -5,46 +5,43 @@ title: "Application Packages"
 
 <p>
 An <em>application package</em> is a set of files in a specific structure that defines a deployable application.
-An application package contains all the configuration, components and auxiliary files
-needed to specify how a given cloud config-enabled set of subsystems should behave to run the application.
+An application package contains all the configuration, components, models and auxiliary files.
 The application package can also have Java components that implement parts of the application
-running in a <a href="../jdisc/">Vespa container</a> -
-<a href="../getting-started-vespa-applications.html">get started developing java components</a>.
+running in a <a href="../jdisc/">Vespa container</a>.
 </p><p>
 <em>The Vespa application is hence fully defined by its application package - all code and config is there.</em>
 </p><p>
-A change to code and configuration is atomically <em>deployed</em> to running instances.
-To ensure code and config consistency, <em>config definition</em> files are compiled to Java code,
-discrepancies causes build failures, which is easier to manage than production errors.
-Read more in <a href="../configuring-components.html">configuring components</a>.
-</p><p>
-The application package is a directory with the same name as the application, containing at minimum:
-<pre>
-application/<a href="../reference/services.html">services.xml</a>           - <em>mandatory specification of services required</em>
-application/<a href="../reference/hosts.html">hosts.xml</a>              - <em>mapping of host ids to physical hosts</em>
-</pre>
+The application package is a directory, containing at minimum <a href="../reference/services.html">services.xml</a>.
 Additionally, <em>services.xml</em> might consume other files or directories from the application package -
 a quick summary of optional content
 (see the <a href="../reference/application-packages-reference.html">reference</a> for a full list):
 <pre>
-application/components/            - <em>OSGi components to be deployed to container nodes. See <a
+components/            - <em>OSGi components to be deployed to container nodes. See <a
   href="../component-types.html">component types</a></em>
-application/searchdefinitions/     - <em>Vespa <a
+searchdefinitions/     - <em>Vespa <a
   href="../search-definitions.html">document schemas</a>, and optionally how to search them</em>
-application/search/query-profiles/ - <em>Vespa <a
+search/query-profiles/ - <em>Vespa <a
   href="../query-profiles.html">query profiles</a>; named collections of search request parameters</em>
 </pre>
-</p><p>
 Most application packages are stored as source code in a code repository.
 However, some resources are generated and/or too large to store in a code repository,
-like an <a href="../reference/vespa-cmdline-tools.html#vespa-makefsa">FSA</a>.
+like models or an <a href="../reference/vespa-cmdline-tools.html#vespa-makefsa">FSA</a>.
 See below for how to use the <a href="../reference/config-files.html#url">url</a> config type
 to download resources to container nodes.
 </p><p>
-See <a href="../vespa-quick-start.html">Vespa quick-start</a>,
-<a href="../getting-started-vespa-applications.html">Vespa Applications</a> or
-the <a href="../tutorials/blog-search.html">Blog search tutorial</a> for examples.
+Refer to the <a href="../bundle-plugin.html">bundle plugin</a>
+for how to build and zip an application package for deployment.
 Also, find more details in the config <a href="../cloudconfig/config-introduction.html">introduction</a>.
+</p>
+
+
+
+<h2 id="code-and-config-concistency">Code and config concistency</h2>
+<p>
+A change to code and configuration is atomically <em>deployed</em> to running instances.
+To ensure code and config consistency, <em>config definition</em> files are compiled to Java code,
+discrepancies causes build failures, which is easier to manage than production errors.
+Read more in <a href="../configuring-components.html">configuring components</a>.
 </p>
 
 

--- a/documentation/reference/application-packages-reference.html
+++ b/documentation/reference/application-packages-reference.html
@@ -14,89 +14,72 @@ The application package is a directory of files and subdirectories:
 <table class="table">
   <thead>
     <tr>
-      <th>Directory/file</th><th>Description</th><th>Required</th>
+      <th>Directory/file</th><th>Required</th><th>Description</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>[application]/</td>
-    <td>The top level directory is the name of the application</td>
+    <td><a href="services.html">services.xml</a></td>
     <td>Yes</td>
-</tr>
-<tr>
-    <td>[application]/<a href="services.html">services.xml</a></td>
     <td>Describes which services to run where, and their main configuration</td>
-    <td>Yes</td>
-</tr>
-<tr>
-    <td>[application]/<a href="validation-overrides.html">validation-overrides.xml</a></td>
-    <td>Override, allowing this package to deploy even if it fails validation</td>
+</tr><tr>
+    <td><a href="../reference/hosts.html">hosts.xml</a></td>
     <td>No</td>
-</tr>
-<tr>
-    <td>[application]/<a href="stateless-model-reference.html">models</a>/</td>
+    <td>The mapping from logical nodes to actual hosts</td>
+</tr><tr>
+    <td style="white-space: nowrap"><a href="validation-overrides.html">validation-overrides.xml</a></td>
+    <td>No</td>
+    <td>Override, allowing this package to deploy even if it fails validation</td>
+</tr><tr>
+    <td><a href="stateless-model-reference.html">models</a>/</td>
+    <td>No</td>
     <td>Machine-learned models in the application package.
         Refer to <a href="../stateless-model-evaluation.html">stateless model evaluation</a>,
         <a href="../tensorflow.html">Tensorflow</a>, <a href="../onnx.html">Onnx</a>,
         <a href="../xgboost.html">XGBoost</a>, and <a href="../lightgbm.html">LightGBM</a>, also see
         <a href="../cloudconfig/application-packages.html#deploying-remote-models">deploying remote models</a>
     </td>
+</tr><tr>
+    <td><a href="../search-definitions.html">searchdefinitions</a>/</td>
     <td>No</td>
-</tr>
-<tr>
-    <td>[application]/<a href="../search-definitions.html">searchdefinitions</a>/</td>
     <td>Contains the *.sd files describing the document types of the application and how they should be searched</td>
+</tr><tr>
+    <td><a href="../jdisc/container-components.html">components</a>/</td>
     <td>No</td>
-</tr>
-<tr>
-    <td>[application]/<a href="../jdisc/container-components.html">components</a>/</td>
     <td>Contains *.jar files containing searcher(s) for the JDisc Container.</td>
+</tr><tr>
+    <td><a href="semantic-rules.html">rules</a>/</td>
     <td>No</td>
-</tr>
-<tr>
-    <td>[application]/<a href="semantic-rules.html">rules</a>/</td>
     <td>Contains *.sr files containing rule bases for semantic recognition and translation of the query</td>
+</tr><tr>
+    <td><a href="services-search.html#chain">search</a>/</td>
     <td>No</td>
-</tr>
-<tr>
-    <td>[application]/<a href="services-search.html#chain">search</a>/</td>
     <td>Search chains config</td>
+</tr><tr>
+    <td><a href="/documentation/tensor-user-guide.html#constant-tensors">constants</a>/</td>
     <td>No</td>
-</tr>
-<tr>
-  <td>[application]/<a href="/documentation/tensor-user-guide.html#constant-tensors">constants</a>/</td>
-  <td>Constant tensors</td>
-  <td>No</td>
-</tr>
-<tr>
-    <td>[application]/ext/</td>
+    <td>Constant tensors</td>
+</tr><tr>
+    <td>ext/</td>
+    <td>No</td>
     <td>Files that are guaranteed to be ignored by Vespa (i.e. they
       will be excluded when processing the application package and
       cannot be referenced from any other place in the application
       package)</td>
-    <td>No</td>
-</tr>
-<tr class="alert">
-    <td>[application]/<a href="../reference/hosts.html">hosts.xml</a></td>
-    <td>The mapping from logical nodes to actual hosts</td>
-    <td>No</td>
 </tr>
   </tbody>
 </table>
 <p>
 Additional files and directories can be placed anywhere in the application package.
 These will be not be processed explicitly by Vespa when deploying the application package
-(i.e., they will only be considered if they are referred to from within the application package),
+(i.e. they will only be considered if they are referred to from within the application package),
 but there is no guarantee to how these might be processed in a future release.
 To extend the application package in a way that is guaranteed
-to be ignored by Vespa in all future releases,
-use the <em>[application]/ext/</em> directory.
+to be ignored by Vespa in all future releases, use the <em>ext/</em> directory.
 </p><p>
-An application package can be zipped for deployment - both of these are supported
-(here the application package is in the <em>application</em> directory):
+An application package can be zipped for deployment:
 <pre>
 $ zip -r ../app.zip .
-$ zip -r app.zip application
 </pre>
 Use whatever name for the zip file - then refer to the file instead of the path in deploy commands -
 <a href="vespa-cmdline-tools.html#vespa-deploy">example</a>.


### PR DESCRIPTION
make tables prettier, and remove (hopefully) all references to a top-level directory in the app package - files and dirs should be in the root.

the guide and ref docs are still messy, promise to clean up more in next PR
