### PR TITLE
Correct metric

### DIFF
--- a/documentation/performance/sizing-search.html
+++ b/documentation/performance/sizing-search.html
@@ -553,7 +553,7 @@ content.proton.documentdb.matching.rank_profile.query_setup_time
 </pre>
 <em>Metric capturing dynamic query work (DQW) at content nodes</em>
 <pre>
-content.proton.documentdb.matching.rank_profile.match_time
+content.proton.documentdb.matching.rank_profile.query_latency 
 </pre>
 <p>
 By sampling these metrics,


### PR DESCRIPTION
content.proton.documentdb.matching.rank_profile.query_latency is in default metric set, match_time is not.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
