### PR TITLE
Document test-and-set feature

### DIFF
--- a/documentation/feed-using-hadoop-pig-oozie.html
+++ b/documentation/feed-using-hadoop-pig-oozie.html
@@ -245,9 +245,12 @@ Parameters for <code>VespaStorage</code> and <code>VespaDocumentOperation</code>
     <tr><th>operation</th>
       <td><em>put</em></td>
       <td>Any <a href="reference/document-json-format.html">valid Vespa document operation</a></td></tr>
+    <tr><th>condition</th>
+      <td></td>
+      <td>A <a href="reference/document-json-format.html#test-and-set">test-and-set condition</a> template. Replaces &lt;field-name&gt; with its value for every record</td></tr>
     <tr><th>docid</th>
       <td></td>
-      <td>A document id template. Replaces &lt;field-name&gt; with it's value for every record</td></tr>
+      <td>A document id template. Replaces &lt;field-name&gt; with its value for every record</td></tr>
     <tr><th>exclude-fields</th>
       <td></td>
       <td>A list of fields to exclude when creating document operation.


### PR DESCRIPTION
The feature was added via https://github.com/vespa-engine/vespa/pull/12081.

@lesters 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
