### PR TITLE
Remove (partially) incorrect normalization table

### DIFF
--- a/documentation/linguistics.html
+++ b/documentation/linguistics.html
@@ -210,7 +210,7 @@ use <code><a href="reference/schema-reference.html#indexing-rewrite">indexing-re
 </p><p>
 Also see <a href="reference/schema-reference.html#gram">N-gram matching</a>.
 </p><p>
-Tokenization is not supported in <a href="streaming-search.html">streaming search</a>.
+Tokenization is not used in <a href="streaming-search.html">streaming search</a>.
 </p>
 
 
@@ -227,7 +227,7 @@ to normalize text, see
 SimpleTransformer.java</a>.
 Normalization preserves case.
 </p><p>
-Normalization is not supported in <a href="streaming-search.html">streaming search</a>.
+Normalization is not used in <a href="streaming-search.html">streaming search</a>.
 </p>
 
 

--- a/documentation/linguistics.html
+++ b/documentation/linguistics.html
@@ -205,86 +205,30 @@ and splits the string into <em>tokens</em> on each word boundary.
 In addition, CJK tokens are split using a <em>segmentation</em> algorithm.
 The resulting tokens are then searchable in the index.
 </p><p>
-Not supported in <a href="streaming-search.html">streaming search</a>.
-</p><p>
 To index strings as-is (that is, avoid tokenization),
 use <code><a href="reference/schema-reference.html#indexing-rewrite">indexing-rewrite</a>: none</code>.
 </p><p>
 Also see <a href="reference/schema-reference.html#gram">N-gram matching</a>.
+</p><p>
+Tokenization is not supported in <a href="streaming-search.html">streaming search</a>.
 </p>
 
 
 
 <h2 id="normalization">Normalization</h2>
 <p> <!-- ToDo: write more here -->
-Normalization preserves case.
+An example normalization is à &#x21D2; a.
 Normalizing will cause accents and similar decorations which are often misspelled
 to be normalized the same way both in documents and queries.
 </p><p>
-Not supported in <a href="streaming-search.html">streaming search</a>.
+Vespa uses <a href="https://docs.oracle.com/javase/7/docs/api/java/text/Normalizer.html">java.text.Normalizer</a>
+to normalize text, see
+<a href="https://github.com/vespa-engine/vespa/blob/master/linguistics/src/main/java/com/yahoo/language/simple/SimpleTransformer.java">
+SimpleTransformer.java</a>.
+Normalization preserves case.
 </p><p>
-Normalizations: <!-- ToDo: check if this table is still valid -->
-<table class="table">
-    <thead>
-    </thead><tbody>
-        <tr>
-            <td>à &#x21D2; a</td>
-            <td>ç &#x21D2; c</td>
-            <td>ð &#x21D2; d</td>
-            <td>ù &#x21D2; u</td>
-        </tr>
-        <tr>
-            <td>â &#x21D2; a</td>
-            <td>è &#x21D2; e</td>
-            <td>ñ &#x21D2; n</td>
-            <td>ú &#x21D2; u</td>
-        </tr>
-        <tr>
-            <td>á &#x21D2; a</td>
-            <td>é &#x21D2; e</td>
-            <td>ò &#x21D2; o</td>
-            <td>û &#x21D2; u</td>
-        </tr>
-        <tr>
-            <td>ã &#x21D2; a</td>
-            <td>ê &#x21D2; e</td>
-            <td>ó &#x21D2; o</td>
-            <td>ü &#x21D2; ue</td>
-        </tr>
-        <tr>
-            <td>ä &#x21D2; ae</td>
-            <td>ë &#x21D2; e</td>
-            <td>ô &#x21D2; o</td>
-            <td>&#xFD; &#x21D2; y</td>
-        </tr>
-        <tr>
-            <td>å &#x21D2; aa</td>
-            <td>ì &#x21D2; i</td>
-            <td>õ &#x21D2; o</td>
-            <td>ÿ &#x21D2; y</td>
-        </tr>
-        <tr>
-            <td>æ &#x21D2; ae</td>
-            <td>í &#x21D2; i</td>
-            <td>ö &#x21D2; oe</td>
-            <td>ß &#x21D2; ss</td>
-        </tr>
-        <tr>
-            <td></td>
-            <td>î &#x21D2; i</td>
-            <td>ø &#x21D2; oe</td>
-            <td>&#xFE; &#x21D2; th</td>
-        </tr>
-        <tr>
-            <td></td>
-            <td>ï &#x21D2; i</td>
-            <td></td>
-            <td></td>
-        </tr>
-    </tbody>
-</table>
+Normalization is not supported in <a href="streaming-search.html">streaming search</a>.
 </p>
-
 
 
 


### PR DESCRIPTION
- no need for it - link to implementation instead, that again links to UNICODE NORMALIZATION FORMS

FYI @geirst 