### PR TITLE
test only failing procedure for now

### DIFF
--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -1,16 +1,4 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 urls:
-    - "http://docs.vespa.ai/documentation/vespa-quick-start.html"
-    - "http://docs.vespa.ai/documentation/tutorials/blog-search.html"
-    - "http://docs.vespa.ai/documentation/tutorials/text-search.html"
-    - "https://cloud.vespa.ai/getting-started-custom-code.html"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/blog-recommendation/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/blog-search/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/boolean-search/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/generic-request-processing/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/http-api-using-request-handlers-and-processors/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/multiple-bundles/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/tensor-playground/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/text-search/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/use-case-shopping/README.md"


### PR DESCRIPTION
running https://github.com/vespa-engine/sample-apps/blob/master/use-case-shopping/README.md manually works for me

./travis/start-docker-container.sh also worked well running from my laptop

lets test only this procedure first to cut testing time

it times out when feeding to the second doc type

********************************************************************************
* docker exec vespa bash -c 'java -jar /opt/vespa/lib/jars/vespa-http-client-jar-with-dependencies.jar  --file /vespa-sample-apps/use-case-shopping/feed_items.json --host localhost --port 8080'
********************************************************************************
Tue Apr 21 09:40:40 UTC 2020 Result received: 0 (0 failed so far, 1959 sent, success rate 0.00 docs/sec).
Tue Apr 21 09:41:05 UTC 2020 Result received: 9920 (0 failed so far, 9920 sent, success rate 395.64 docs/sec).
********************************************************************************
* docker exec vespa bash -c 'java -jar /opt/vespa/lib/jars/vespa-http-client-jar-with-dependencies.jar  --file /vespa-sample-apps/use-case-shopping/feed_reviews.json --host localhost --port 8080'
********************************************************************************
Tue Apr 21 09:44:07 UTC 2020 Result received: 0 (0 failed so far, 10001 sent, success rate 0.00 docs/sec).
Failure: Result for document 'id:review:review::B00H3TNL0W-A37MRLG1Z8I78R' 
1587462067220 Trace starting 
1587462247734 Asked about retrying for cluster ID 0, number of retries is 1 Detail:
Detail resultType=FATAL_ERROR exception='Timed out in sendQ' endpoint=localhost:8080 ssl=false resultTimeLocally=1587462247733
1587462247734 Got detail: Detail resultType=FATAL_ERROR exception='Timed out in sendQ' endpoint=localhost:8080 ssl=false resultTimeLocally=1587462247733
:
    Detail resultType=FATAL_ERROR exception='Timed out in sendQ' endpoint=localhost:8080 ssl=false resultTimeLocally=1587462247733