### PR TITLE
Remove guava dependency

### DIFF
--- a/documentation/document-api-guide.html
+++ b/documentation/document-api-guide.html
@@ -66,12 +66,7 @@ DocumentAccess</a> javadoc. Sample app:
     &lt;dependency&gt;
         &lt;groupId&gt;com.yahoo.vespa&lt;/groupId&gt;
         &lt;artifactId&gt;documentapi&lt;/artifactId&gt;
-        &lt;version&gt;7.168.4&lt;/version&gt; &lt;!-- Find latest version at <a href="https://search.maven.org/search?q=g:com.yahoo.vespa%20a:documentapi">search.maven.org/search?q=g:com.yahoo.vespa%20a:documentapi</a> --&gt;
-    &lt;/dependency&gt;
-    &lt;dependency&gt; &lt;!-- ToDo: remove this once ImmutableList is removed --&gt;
-        &lt;groupId&gt;>com.google.guava&lt;/groupId&gt;
-        &lt;artifactId&gt;guava&lt;/artifactId&gt;
-        &lt;version&gt;28.2-jre&lt;/version&gt;
+        &lt;version&gt;7.246.11&lt;/version&gt; &lt;!-- Find latest version at <a href="https://search.maven.org/search?q=g:com.yahoo.vespa%20a:documentapi">search.maven.org/search?q=g:com.yahoo.vespa%20a:documentapi</a> --&gt;
     &lt;/dependency&gt;
 &lt;dependencies&gt;
 </pre>


### PR DESCRIPTION
- It's now included in the 'documentapi' artifact, after splitting
  out another artifact for the container bundle.
