### PR TITLE
Fix spelling error

### DIFF
--- a/documentation/cloudconfig/application-packages.html
+++ b/documentation/cloudconfig/application-packages.html
@@ -36,7 +36,7 @@ Also, find more details in the config <a href="../cloudconfig/config-introductio
 
 
 
-<h2 id="code-and-config-concistency">Code and config concistency</h2>
+<h2 id="code-and-config-consistency">Code and config consistency</h2>
 <p>
 A change to code and configuration is atomically <em>deployed</em> to running instances.
 To ensure code and config consistency, <em>config definition</em> files are compiled to Java code,


### PR DESCRIPTION
Hi folks,

This PR fixed a spelling mistake, i.e., "consistency" is misspelled as "concistency".

cc: @jobergum 

Thanks!

[JASON@CHAW]

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
