### PR TITLE
top-k-probability default is no longer 1.0

### DIFF
--- a/documentation/reference/services-content.html
+++ b/documentation/reference/services-content.html
@@ -1473,7 +1473,7 @@ Tune the query dispatch behavior - child elements:
       <td><p>
         Probability that the top K hits will be the globally best.
         Based on this probability, the dispatcher will fetch enough hits from each node to achieve this.
-        The only way to guarantee a probability of 1.0 (default) is to fetch K hits from each partition.
+        The only way to guarantee a probability of 1.0 is to fetch K hits from each partition.
         However, by reducing the probability from 1.0 to 0.99999, one can significantly reduce number of hits fetched
         and hence save both bandwidth and latency.
         The number of hits to fetch from each partion is computed as:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
