### PR TITLE
Update pip3 to grab correct dependencies

### DIFF
--- a/travis/compile-and-test.sh
+++ b/travis/compile-and-test.sh
@@ -12,6 +12,7 @@ yum localinstall -y docker-ce-18.06.0.ce-3.el7.x86_64.rpm
 
 # Install python 3 and requirements for the tests
 yum install -y python36-pip
+pip3 install --upgrade pip
 pip3 install -r test/requirements.txt --user
 
 # Some procedures use openssl


### PR DESCRIPTION
@aressem or @kkraune Please review.

This should fix the problem of not finding a new enough version of tensorflow in some of the dependency installs.