### PR TITLE
Remove sample app text search testing

### DIFF
--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -12,6 +12,5 @@ urls:
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/http-api-using-request-handlers-and-processors/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/multiple-bundles/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/tensor-playground/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/text-search/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/use-case-shopping/README.md"
 


### PR DESCRIPTION
@kkraune @thigm85 Please review. 

There were 2 tests - one from documentation and one from sample apps - that essentially tested a similar application: text-search. The documentation tested the process of developing it, the sample-app tested the finished application. We'll only keep the documentation one for now.
