### PR TITLE
Document new syntax for overriding container threadpool configuration

### DIFF
--- a/documentation/performance/container-tuning.html
+++ b/documentation/performance/container-tuning.html
@@ -17,18 +17,22 @@ generic config overrides</a>.
 <h2 id="container-worker-threads">Container worker threads</h2>
 <p>
     Most handlers use the jdisc default threadpool, which is controlled by a central Executor provider.
-    The Executor provider will pre-start the worker threads, so even an idle container will report running several hundred threads.
     Some built-in handlers have separate threadpools, e.g search handler and http-client-api handler.
     Do note that e.g. federation will spawn off extra worker threads separate from the search handler threadpool.
     The default threadpool configuration can be overridden using the <em>config</em> element for <i>container.handler.threadpool</i> in services.xml
     Handlers with dedicated threapools have separate syntax in services.xml (see example below).
 </p>
 <p>
+    The jdisc threadpools will pre-start the worker threads (<em>min-threads</em>), so even an idle container will report running several hundred threads.
     Note that tuning the capacity upwards increases the risk of high GC pressure
     as concurrency becomes higher with more in-flight requests.
     The GC pressure is a function of number of in-flight requests,
     the time it takes to complete the request
     and the amount of garbage produced per request.
+    Increasing the queue size will allow the application to handle shorter traffic bursts without rejecting requests,
+    although increasing the average latency for those requests that are queued up.
+    Large queues will also increase heap consumption in overload situations.
+    Extra threads will be created once the queue is full (if <em>max-threads &gt; min-threads</em>), and are destroyed after an idle timeout.
 <p>
 <pre>
 &lt;container id="container" version="1.0"&gt;

--- a/documentation/performance/container-tuning.html
+++ b/documentation/performance/container-tuning.html
@@ -16,20 +16,40 @@ generic config overrides</a>.
 
 <h2 id="container-worker-threads">Container worker threads</h2>
 <p>
-The worker threads for e.g. search queries is handled by a central Executor provider
-which is set up with the configuration named <em>threadpool</em>.
-The variable for controlling the max number is an integer variable named <em>maxthreads</em>,
-the default value is 500.
-Do note that e.g. federation will spawn off extra worker threads in addition to this number.
-The Executor provider will pre-start the worker threads,
-so even an idle container will report running several hundred threads.
-Note that tuning this upwards increases the risk of high GC pressure
-as concurrency becomes higher with more in-flight requests.
-The GC pressure is a function of number of in-flight requests,
-the time it takes to complete the request
-and the amount of garbage produced per request.
+    Most handlers use the jdisc default threadpool, which is controlled by a central Executor provider.
+    The Executor provider will pre-start the worker threads, so even an idle container will report running several hundred threads.
+    Some built-in handlers have separate threadpools, e.g search handler and http-client-api handler.
+    Do note that e.g. federation will spawn off extra worker threads separate from the search handler threadpool.
+    The default threadpool configuration can be overridden using the <em>config</em> element for <i>container.handler.threadpool</i> in services.xml
+    Handlers with dedicated threapools have separate syntax in services.xml (see example below).
+</p>
+<p>
+    Note that tuning the capacity upwards increases the risk of high GC pressure
+    as concurrency becomes higher with more in-flight requests.
+    The GC pressure is a function of number of in-flight requests,
+    the time it takes to complete the request
+    and the amount of garbage produced per request.
+<p>
 <pre>
 &lt;container id="container" version="1.0"&gt;
+  ...
+  &lt;search&gt;
+    &lt;threadpool&gt;
+      &lt;max-threads&gt;500&lt;/max-threads&gt;
+      &lt;min-threads&gt;500&lt;/min-threads&gt;
+      &lt;queue-size&gt;0&lt;/queue-size&gt;
+    &lt;/threadpool&gt;
+  &lt;/search&gt;
+  ...
+  &lt;document-api&gt;
+    &lt;http-client-api&gt;
+      &lt;threadpool&gt;
+        &lt;max-threads&gt;50&lt;/max-threads&gt;
+        &lt;min-threads&gt;10&lt;/min-threads&gt;
+        &lt;queue-size&gt;1000&lt;/queue-size&gt;
+      &lt;/threadpool&gt;
+    &lt;/http-client-api&gt;
+  &lt;/document-api&gt;
   ...
   &lt;config name="container.handler.threadpool"&gt;
     &lt;maxthreads&gt;200&lt;/maxthreads&gt;

--- a/documentation/reference/services-container.html
+++ b/documentation/reference/services-container.html
@@ -55,6 +55,11 @@ container [version, id]
         <a href="#timeout">timeout</a>
         <a href="#tracelevel">tracelevel</a>
         <a href="#mbusport">mbusport</a>
+        <a href="#http-client-api">http-client-api</a>
+            <a href="#http-client-api-threadpool">threadpool</a>
+                <a href="#http-client-api-threadpool">max-threads</a>
+                <a href="#http-client-api-threadpool">min-threads</a>
+                <a href="#http-client-api-threadpool">queue-size</a>
     <a href="../stateless-model-evaluation.html">model-evaluation</a>
     <a href="#document">document [type, class, bundle]</a>
     <a href="#accesslog">accesslog [type, fileNamePattern, symlinkName, rotationInterval, rotationScheme]</a>
@@ -559,6 +564,13 @@ Children elements:
         Configure the level of which to trace messages sent.
         The higher the level, the more detailed descriptions.
       </td></tr>
+    <tr>
+        <th>http-client-api</th>
+        <td>optional</td>
+        <td></td>
+        <td></td>
+        <td>Configuration for the Vespa HTTP client API</td>
+    </tr>
   </tbody>
 </table>
 Example:
@@ -575,10 +587,48 @@ Example:
   &lt;route&gt;default&lt;/route&gt;
   &lt;timeout&gt;250.5&lt;/timeout&gt;
   &lt;tracelevel&gt;3&lt;/tracelevel&gt;
+  &lt;http-client-api&gt;
+    &lt;threadpool&gt;
+      &lt;max-threads&gt;50&lt;/max-threads&gt;
+      &lt;min-threads&gt;10&lt;/min-threads&gt;
+      &lt;queue-size&gt;1000&lt;/queue-size&gt;
+    &lt;/threadpool&gt;
+  &lt;/http-client-api&gt;
 &lt;document-api&gt;
 </pre>
 </p>
 
+
+<h2 id="http-client-api">http-client-api</h2>
+<p>
+<pre>
+&lt;http-client-api&gt;
+  &lt;threadpool&gt;
+    &lt;max-threads&gt;50&lt;/max-threads&gt;
+    &lt;min-threads&gt;10&lt;/min-threads&gt;
+    &lt;queue-size&gt;1000&lt;/queue-size&gt;
+  &lt;/threadpool&gt;
+&lt;/http-client-api&gt;
+</pre>
+Children elements:
+<table class="table">
+    <thead>
+    <tr><th>Name</th><th>Required</th><th>Value</th><th>Default</th><th>Description</th></tr>
+    </thead><tbody>
+    <tr id="http-client-api-threadpool"><th>threadpool</th>
+        <td>optional</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td>
+            Contains configuration of the threadpool for the http client api handler.
+            The pool is initialized with minimum number of threads during startup.
+            Additional threads will be created on demand once the request queue is full.
+            Requests are rejected once maximum threads are reached, all threads are busy and the the request queue is full.
+        </td>
+    </tr></tbody>
+</table>
+</p>
 
 
 <h2 id="document">document</h2>

--- a/documentation/reference/services-search.html
+++ b/documentation/reference/services-search.html
@@ -33,6 +33,10 @@ declared as a subelement to <a href="services-container.html">container</a>:
     <a href="#nodes">nodes</a>
       <a href="#node">node</a>
   <a href="#renderer">renderer [id, class, bundle]</a>
+  <a href="#threadpool">threadpool</a>
+    <a href="#threadpool-max-threads">max-threads</a>
+    <a href="#threadpool-min-threads">min-threads</a>
+    <a href="#threadpool-queue-size">queue-size</a>
 </pre>
 <a href="config-files.html#generic-configuration-in-services-xml">config</a>
 applies to all searchers in the JDisc cluster's search chains, unless
@@ -514,4 +518,27 @@ Used by http/vespa providers to specify endpoints. Attributes:
       <td>port</td></tr>
   </tbody>
 </table>
+</p>
+
+<h2 id="threadpool">threadpool</h2>
+<p>
+  Contains configuration of the threadpool for the jdisc search handler.
+  The pool is initialized with minimum number of threads during startup.
+  Additional threads will be created on demand once the request queue is full.
+  Requests are rejected once maximum threads are reached, all threads are busy and the the request queue is full.
+</p>
+
+<h2 id="threadpool-max-threads">max-threads</h2>
+<p>
+  Maximum number of threads in pool
+</p>
+
+<h2 id="threadpool-min-threads">min-threads</h2>
+<p>
+  Minimum number of threads in pool
+</p>
+
+<h2 id="threadpool-queue-size">queue-size</h2>
+<p>
+  Request queue size
 </p>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
