### PR TITLE
link works but current link checker does not assume extension

### DIFF
--- a/documentation/document-processing.html
+++ b/documentation/document-processing.html
@@ -48,7 +48,7 @@ chain it should be part of:
   <li>If it performs general data-processing, such as populating some document fields from others,
     looking up data in external services, etc., it should be added to a general docproc chain.</li>
   <li>If, and only if, it performs processing required for <em>indexing</em>, or requires this to
-    have already been run — e.g., for processing the <a href="/documentation/annotations">annotations</a>
+    have already been run — e.g., for processing the <a href="/documentation/annotations.html">annotations</a>
     created by the default indexing document processor — it should be added to a chain which
     inherits the <em>indexing</em> chain, and which is used for indexing by a content cluster.</li>
 </ul>
@@ -77,7 +77,7 @@ processor to the chain for a particular content cluster:
 The "default" chain, if it exists, is run by default, before the chain used for indexing. The default indexing
 chain is called "indexing", and <em>must</em> be inherited by any chain that is to replace it.
 </p><p>
-To run through any chain, specify a <a href="/documentation/routing">route</a> which includes the chain.
+To run through any chain, specify a <a href="/documentation/routing.html">route</a> which includes the chain.
 For example, the route <code>default/chain.my-chain indexing</code> would route feed operations
 through the chain "my-chain" in the "default" container cluster, and then to the "indexing" hop,
 which resolves to the specified indexing chain for each content cluster the document should be sent to. 


### PR DESCRIPTION
we use @freva 's link checker here, it does not assume extension I believe. We can start using the htmlproofer we do for other repos, for now work around adding extension
