### PR TITLE
Improve getting started landing page

### DIFF
--- a/en/getting-started.html
+++ b/en/getting-started.html
@@ -10,35 +10,93 @@ Vespa can do many things, and be deployed in many ways.
 <a href="https://cloud.vespa.ai/support">Let us know</a> if something is missing.
 </p>
 
-
-
 <table class="table">
 <tr>
   <th>Minimal Quick Start</th>
   <td>
-  Install Vespa, insert a few documents and run a query, using Docker or Vagrant:
+  Install Vespa, insert a few documents and run a query, using Docker or Vagrant. This is the "Hello World" of Vespa 
+where you can use your laptop or our <a href="https://cloud.vespa.ai/>cloud</a> offering to play with it:
   <ul>
     <li><a href="vespa-quick-start.html">Mac / Linux</a></li>
     <li><a href="vespa-quick-start-windows.html">Windows</a></li>
     <li><a href="vespa-quick-start-vagrant.html">Vagrant</a></li>
   </ul>
   For <a href="https://cloud.vespa.ai/">Vespa Cloud</a> users, see
-  <a href="https://cloud.vespa.ai/getting-started">Getting Started</a>.
+  <a href="https://cloud.vespa.ai/getting-started">Getting Started with Cloud</a> which includes free trial.
 </td>
 </tr>
 
 <tr>
-  <th>Monitoring Quick Start</th>
+  <th>Tutorials and Use Cases</th>
   <td>
-  Try the <a href="monitoring-with-grafana-quick-start.html">Monitoring Quick Start</a> -
-  it builds on the <em>Minimal Quick Start</em>,
-  and adds more features that most applications normally use:
+  <p>Moving from the minimal quick start to more advanced use cases</p>
+
+  <b>Search</b>
   <ul>
-    <li>Monitoring using a Grafana dashboard</li>
-    <li>High-performance feeding API</li>
-    <li>A document and query simulator - to validate the dashboard,
-      but also something to build on for own application development</li>
+
+    <li><a href="tutorials/blog-search.html">Tutorial: Blog Search</a> 
+    Vespa tutorial introducing read and write API's, Vespa's query language,
+    YQL, ranking and relevancy, faceted search (grouping) and sorting.
+    </li>
+
+    <li><a href="tutorials/text-search.html">Tutorial: Text Search</a>
+    A text search tutorial and introduction to text ranking with Vespa using traditional information retrieval techniques like BM25.
+    </li>
+
+    <li><a href="tutorials/text-search-ml.html">Tutorial: Improving Text Search with Machine Learning</a>. 
+    This tutorial builds
+    on the <a href="tutorials/text-search.html">text search tutorial</a> but introduces Learning to Rank to improve relevancy.
+    </li>
+
+    <li><a href="tutorials/text-search-semantic.html">Tutorial: Text Search using Vectors</a>. 
+    This tutorial introduce using pre-trained embedding models to do text search.
+    This tutorial uses Vespa support for <a href="nearest-neighbor-search.html">nearest neighbor search</a>, there is
+    also support for fast <a href="approximate-nn-hnsw.html">approximate nearest neighbor search</a> in Vespa. 
+    See also <a href="semantic-qa-retrieval.html">Semantic Retrieval for Question Answering Applications</a> with examples for doing hybrid
+    retrieval using both sparse (term based) and dense (vector) based search and retrieval.
+    </li>
+
   </ul>
+  <b>Recommendation</b>
+  <p>Vespa is great for search use cases, but also supports advanced real time online serving of recommender models, see how with our
+    recommendation serving with Vespa:</p>
+  <ul>
+    <li><a href="tutorials/blog-recommendation.html">Tutorial: Blog Recommendation</a> This builds on the Blog Search tutorial and uses 
+  collaborative filtering to recommend blog posts.</li>
+    <li><a href="tutorials/blog-recommendation-nn.html">Tutorial: Blog recommendation with Neural Network models</a></li>
+  </ul>
+
+  <b>Question Answering</b>
+  <p>From 10 blue links to answering questions. 
+   Try the <a href="use-case-question-answering.html">Question Answering</a> use case. This use case demonstrates several of the advanced capabilities of Vespa.
+   Ranking with Transformer (e.g BERT) models, dense retrieval using vectors, multi phased retrieval and ranking, and custom plugins to build an end to end application.
+  </p>
+
+  <b>E-Commerce Search</b>
+  <p>Try the <a href="use-case-shopping.html">e-commerce shopping</a> use case which demonstrates Vespa grouping, 
+  true in-place partial updates, custom ranking and more.</p>
+  </td>
+</tr>
+
+<tr>
+  <th>Deployments</th>
+  <td>
+    <p>
+    Vespa is an open source platform and can be deployed in multiple ways - explore some of the options for deployment:
+    <ul>
+      <li><a href="vespa-quick-start-kubernetes.html">quick-start-kubernetes</a> (minikube)
+      and <a href="https://github.com/vespa-engine/sample-apps/tree/master/basic-search-on-gke">
+      basic-search-on-gke</a></li>
+      <li><a href="vespa-quick-start-multinode-aws.html">quick-start-multinode-aws</a></li>
+      <li><a href="vespa-quick-start-multinode-aws-ecs.html">quick-start-multinode-aws-ecs</a></li>
+      <li><a href="https://github.com/vespa-engine/sample-apps/tree/master/basic-search-on-docker-swarm">basic-search-on-docker-swarm</a></li>
+      <li><a href="monitoring-with-grafana-quick-start.html">Monitoring Vespa with Grafana</a></li> 
+    </ul>
+    These guides are good starters for building clusters of <a href="multinode-systems.html">more than one node</a>.
+    </p><p>
+    Also try deploying to <a href="https://cloud.vespa.ai/">Vespa Cloud</a>,
+    a managed service running Vespa.
+    </p>
   </td>
 </tr>
 
@@ -47,7 +105,8 @@ Vespa can do many things, and be deployed in many ways.
   <td>
     <p>
     Vespa supports writing plugins in languages that runs in the JVM.
-    Use this to simplify Query and Document processing:
+    Use this to simplify query and document processing and build serving logic close to the content nodes, 
+    avoid network hops and overhead of HTTP(s):
     <ul>
       <li><a href="https://github.com/vespa-engine/sample-apps/tree/master/vespa-cloud/album-recommendation-searcher">
       album-recommendation-searcher</a> for Searcher development</li>
@@ -66,70 +125,22 @@ Vespa can do many things, and be deployed in many ways.
     -->
   </td>
 </tr>
-
-<tr>
-  <th>Deployments</th>
-  <td>
-    <p>
-    Vespa is an open source platform and can be deployed in multiple ways - explore:
-    <ul>
-      <li><a href="vespa-quick-start-kubernetes.html">quick-start-kubernetes</a> (minikube)
-      and <a href="https://github.com/vespa-engine/sample-apps/tree/master/basic-search-on-gke">
-      basic-search-on-gke</a></li>
-      <li><a href="vespa-quick-start-multinode-aws.html">quick-start-multinode-aws</a></li>
-      <li><a href="vespa-quick-start-multinode-aws-ecs.html">quick-start-multinode-aws-ecs</a></li>
-      <li><a href="https://github.com/vespa-engine/sample-apps/tree/master/basic-search-on-docker-swarm">basic-search-on-docker-swarm</a>      </li>
-    </ul>
-    These guides are good starters for building clusters of <a href="multinode-systems.html">more than one node</a>.
-    </p><p>
-    Also try deploying to <a href="https://cloud.vespa.ai/">Vespa Cloud</a>,
-    a managed service running Vespa.
-    </p>
-  </td>
-</tr>
-
-<tr>
-  <th>Jupyter Notebooks</th>
-  <td>
-    <p>
-    This is under active development, check back for more pointers later:
-    <ul>
-      <li><a href="https://www.kaggle.com/jkb123/semantic-search-using-vespa-ai-s-cord19-index">
-          semantic-search-using-vespa-ai-s-cord19-index</a></li>
-    </ul>
-    </p>
-  </td>
-</tr>
-
 </table>
-
-
-
-<h2 id="tutorials-and-use-cases">Tutorials and use cases</h2>
-<p>
-Run the tutorials to learn how Vespa can be used in search and recommender applications:
-<ul>
-  <li><a href="tutorials/text-search.html">Text Search</a></li>
-  <li><a href="tutorials/text-search-ml.html">Improving Text Search through ML</a></li>
-  <li><a href="tutorials/text-search-semantic.html">Semantic Text Search</a></li>
-</ul>
-<ul>
-  <li><a href="tutorials/blog-search.html">Blog Search</a></li>
-  <li><a href="tutorials/blog-recommendation.html">Blog Recommendation</a></li>
-  <li><a href="tutorials/blog-recommendation-nn.html">Blog recommendation with Neural Network models</a></li>
-</ul>
-Try the <a href="use-case-shopping.html">e-commerce shopping</a> use case.
-</p>
-
-
 
 <h2 id="next-steps">Next Steps</h2>
 <ul>
   <li>
-    Follow the <a href="https://blog.vespa.ai/">Vespa Blog</a> for product updates and use cases
-  </li><li>
+    Scaling Vespa Serving - Performance and more, see <a href="en/performance/">Performance and scaling</a>.
+    Vespa scales in any dimension, 
+    document volume, read and write throughput and latency.</a> 
+  </li>
+  
+  <li>
     <a href="api.html">Vespa APIs</a> is useful to understand how to interface with Vespa
-  </li><li>
+  </li>
+  <li>See the <a href="faq.html">FAQ</a>, also with links to how to get support.</li>
+
+  <li>
     Vespa's sample applications are found in
     <a href="https://github.com/vespa-engine/sample-apps">sample-apps</a>.
     Some of the guides above use these - find more info in the README files.</a>
@@ -139,125 +150,8 @@ Try the <a href="use-case-shopping.html">e-commerce shopping</a> use case.
     Developers: <a href="build-install-vespa.html">Build</a>,
     <a href="https://github.com/vespa-engine/vespa/blob/master/CONTRIBUTING.md">Contribute</a>
   </li>
+  <li>
+    Follow the <a href="https://blog.vespa.ai/">Vespa Blog</a> for product updates and use cases
+  </li>
 </ul>
 
-
-
-<h2 id="troubleshooting">Troubleshooting</h2>
-<p>
-Also see the <a href="faq.html">FAQ</a>.
-</p>
-
-<table class="table">
-<tr id="no-endpoint">
-  <th>No endpoint</th>
-  <td>
-    Most problems with the quick start guides are due to Docker out of memory.
-    Make sure at least 6G memory is allocated to Docker:
-<pre>
-$ docker info | grep "Total Memory"
-</pre>
-    OOM symptoms include
-<pre>
-INFO: Problem with Handshake localhost:8080 ssl=false: localhost:8080 failed to respond
-</pre>
-    The container is named <em>vespa</em> in the guides, for a shell do:
-<pre>
-$ docker exec -it vespa bash
-</pre>
-  </td>
-</tr>
-<tr id="log-viewing">
-  <th>Log viewing</th>
-  <td>
-    Use <a href="reference/vespa-cmdline-tools.html#vespa-logfmt">vespa-logfmt</a> to view the vespa log - example:
-<pre>
-$ /opt/vespa/bin/vespa-logfmt -l warning,error
-</pre>
-  </td>
-</tr>
-<tr id="json">
-  <th>Json</th>
-  <td>
-    For json pretty-print, append
-<pre>
-| python -m json.tool
-</pre>
-    to commands that output json - or use <a href="https://stedolan.github.io/jq/">jq</a>.
-  </td>
-</tr>
-</table>
-
-
-<h3 id="vespa-cloud-deployments">Vespa Cloud deployments</h3>
-<table class="table">
-  <tr>
-  <th>Slow deployments:</th>
-  <td>First time deployments takes a few minutes,
-  seeing CERTIFICATE_NOT_READY / PARENT_HOST_NOT_READY / LOAD_BALANCER_NOT_READY is normal.
-  "Installation succeeded!" in the bottom pane indicates success</td>
-  </tr><tr>
-  <th>HTTP: 502 — Bad Gateway:</th>
-  <td>This means the endpoint is not ready, or failing.
-  A Vespa software upgrade will cause this — the application will then be unavailable for 15 minutes or so,
-  as dev instances are not redundant. Look for stopping services in logs to check for this.</td>
-  </tr><tr>
-  <th>Retrying — request failed: Java heap space:</th>
-  <td>If this happens when deploying from the laptop, mvn runs out of memory.
-  Use export MAVEN_OPTS=-Xmx3g to increase the heap size to 3G (or larger as needed).</td>
-  </tr>
-</table>
-
-
-
-<h3 id="plugin-development">Plugin Development</h3>
-<table class="table">
-  <tr id="generated-sources"><th>Cannot find <em>*Config</em> classes</th>
-    <td><p>
-      Several projects depend on generated configuration classes.
-      These are created by the <em>generate-sources</em> Maven target.
-      The easiest way to avoid the problem is building the project with Maven from the shell,
-      <em>then</em> importing in Eclipse/IntelliJ.
-      If the project is already imported,
-      first run the <em>generate-sources</em> target either from the IDE or the shell,
-      then mark the pertinent <em>target/generated-sources/vespa-configgen-plugin</em>
-      directories as source directories.
-    </p></td></tr>
-  <tr id="troubleshooting-maven"><th>Maven</th>
-    <td><p>
-      On error:
-<pre>
-  at org.codehaus.plexus.archiver.AbstractArchiver$1.hasNext(AbstractArchiver.java:482)
-</pre>
-      increase the maven thread stack size by <em>export MAVEN_OPTS=-Xss2m</em>
-    </p></td></tr>
-  <tr id="running-on-linux"><th>Running on Linux</th>
-    <td><p>
-      IntelliJ does not pick up custom test profiles from <code>pom.xml</code>.
-      If running IntelliJ on a Linux, configure its test environment with a reference to the
-      library path (i.e. <code>$VESPA_ROOT/lib64</code>).
-      The simplest way to do this is to edit the default configuration for JUnit.
-    </p></td></tr>
-  <tr id="ignored-provider"><th>Ignored provider</th>
-    <td><p>
-      This it is usually a packaging problem:
-<pre>
-A provider [the class] registered in SERVER runtime does not implement any provider interfaces
-applicable in the SERVER runtime.
-Due to constraint configuration problems the provider [the class] will be ignored.
-</pre>
-      The JAX-RS classes, like the @GET annotation, have been bundled inside the
-      plug-in bundle, causing the container not to recognize them as valid annotations.
-      The fix is using <em>mvn dependency:tree</em> to figure out what
-      dependency has caused JAX-RS to be included,
-      and then add the proper exclusion clause to pom.xml.
-    </p></dd></tr>
-  <tr id="WebApplicationException"><th>No result returned when throwing WebApplicationException</th>
-    <td><p>
-      The container has no special handling of javax.ws.rs.WebApplicationException and its subclasses.
-      All Jersey plug-ins must either be exception safe,
-      or supply the proper implementations of javax.ws.rs.ext.ExceptionMapper
-      for all exceptions which are expected to be thrown from the plug-in
-      (and annotate these with @Provider).
-    </p></td></tr>
-</table>

--- a/en/getting-started.html
+++ b/en/getting-started.html
@@ -59,7 +59,7 @@ where you can use your laptop or our <a href="https://cloud.vespa.ai/>cloud</a> 
   </ul>
   <b>Recommendation</b>
   <p>Vespa is great for search use cases, but also supports advanced real time online serving of recommender models, see how with our
-    recommendation serving with Vespa:</p>
+    recommendation serving with Vespa tutorials:</p>
   <ul>
     <li><a href="tutorials/blog-recommendation.html">Tutorial: Blog Recommendation</a> This builds on the Blog Search tutorial and uses 
   collaborative filtering to recommend blog posts.</li>

--- a/en/tutorials/blog-search.md
+++ b/en/tutorials/blog-search.md
@@ -655,10 +655,12 @@ An [_attribute_](../attributes.html) is an in-memory field - this is different
 from  _index_ fields, which may be moved to a disk-based index as more
 documents are added and the index grows.  Since attributes are kept in memory,
 they are excellent for fields which require fast access, e.g., fields used for
-sorting or grouping query results.  The downside is higher memory usage.  By
-default, no index is generated for attributes, and search over these defaults
-to a linear scan - to build an index for an attribute field, include
-`attribute:fast-search` in the field definition.
+sorting or grouping query results.  The downside is higher memory usage. 
+
+Attribute fields also supports true partial updates (in-place updates). This means that the *popularity* field can be updated with low latency (milliseconds)
+and high throughput without having to re-index the entire blog post for changes in the popularity.
+
+Attribute fields are searchable, see also [When to use fast-search option for attributes](performance/feature-tuning.html#when-to-use-fast-search). 
 
 ### Defining an attribute field
 
@@ -739,7 +741,7 @@ descending order:
 
 ### Query time data grouping
 
-_Grouping_ is the concept of looking through all matching documents at
+_Grouping_ or _faceted search_ is the concept of looking through all matching documents at
 query-time and then performing operations with specified fields across all the
 documents — some common use cases include:
 
@@ -875,15 +877,16 @@ to get a match.
 ### When to use attributes
 
 There are both advantages and drawbacks of using attributes — it enables
-sorting and grouping, but requires more memory and gives limited matching
-capabilities. When to use attributes depends on the application; in general,
+sorting and grouping and ranking, but requires more memory. See [Attributes in vespa](attributes.html). 
+
+When to use attributes depends on the application; in general,
 use attributes for:
 
+- fields which requires high volume of updates, e.g. the popularity
+- fields accessed in ranking expressions  
 - fields used for sorting, e.g., a last-update timestamp,
 - fields used for grouping, e.g., problem severity, and
 - fields that are not long string fields.
-
-Finally, all numeric fields should always be attributes.
 
 ## Clean environment by removing all documents
 
@@ -893,9 +896,6 @@ removes all documents:
 <pre data-test="exec">
 $ docker exec vespa bash -c '/opt/vespa/bin/vespa-stop-services && /opt/vespa/bin/vespa-remove-index -force && /opt/vespa/bin/vespa-start-services'
 </pre>
-
-Also see [vespa-configserver-remove-state](../cloudconfig/configuration-server.html#zookeeper-recovery).
-
 
 ## Conclusion
 

--- a/en/tutorials/text-search-ml.md
+++ b/en/tutorials/text-search-ml.md
@@ -1,5 +1,5 @@
 ---
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 title: "Improving Text Search through ML"
 ---
 
@@ -300,6 +300,14 @@ The figure below shows how frequently (over more than 5.000 test queries) those 
 
 Overall, on average, there is not much difference between those models (with respect to MRR), which was expected given the simplicity of the models described here. The point was simply to point out the importance of choosing better loss functions when dealing with LTR tasks and to give a quick start for those who want to give it a shot in their own applications. We expect the difference in MRR between pointwise and listwise loss functions to increase as we move on to more complex models.
 
+## Next steps
+In this tutorial we have looked at using a simple *linear* ranking function. 
+Vespa integrates with several popular machine learning libraries which can be used for Machine Learned Ranking: 
+
+ - [Ranking with XGBoost Models](../xgboost.html) 
+ - [Ranking with LightGBM Models](../lightgbm.html) 
+ - [Ranking with Tensorflow Models](../tensorflow.html) 
+ - [Ranking with ONNX Models](../onnx.html) 
 
 <script>
 function processFilePREs() {

--- a/en/tutorials/text-search.md
+++ b/en/tutorials/text-search.md
@@ -7,7 +7,8 @@ title: "Text Search Tutorial"
 
 In this tutorial, we will guide you through the setup of a text search application built on top of Vespa. At the end you will be able to store text documents in Vespa and search them via text queries. The application built here will be the foundation to other tutorials that will add future improvements, such as creating ranking functions based on Machine Learning (ML) models.
 
-The main goal here is to setup a text search app based on simple term-match features such as BM25 [^1] and [nativeRank](../reference/nativerank.html). We will cover how to create, deploy and feed the Vespa application. We are going to go from raw data to a fully functional text search app. In addition we will showcase how easy it is to switch and experiment with different ranking functions in Vespa.
+The main goal here is to setup a text search app based on simple term-match features such as [BM25](../reference/bm25.html) [^1] and [nativeRank](../reference/nativerank.html). 
+We will cover how to create, deploy and feed the Vespa application. We are going to go from raw data to a fully functional text search app. In addition we will showcase how easy it is to switch and experiment with different ranking functions in Vespa.
 
 ## Preamble
 
@@ -18,11 +19,12 @@ $ git clone --depth 1 https://github.com/vespa-engine/sample-apps.git
 $ cd sample-apps/text-search
 </pre>
 
-This repository contains a fully-fledged Vespa application including a front-end search UI. This tutorial however will start with the basics and develop the application over multiple parts.
+This repository contains a fully-fledged Vespa application including a front-end search UI. 
+This tutorial however will start with the basics and develop the application over multiple parts.
 
 ## Dataset
 
-We use a dataset called [MS MARCO](http://msmarco.org) throughout this tutorial. MS MARCO is a collection of large scale datasets released by Microsoft with the intent of helping the advance of deep learning research related to search. There are many tasks associated with MS MARCO datasets, but here we are interested in the task of building an end-to-end search application capable of returning relevant documents to a text query.
+We use a dataset called [MS MARCO](https://microsoft.github.io/msmarco/) throughout this tutorial. MS MARCO is a collection of large scale datasets released by Microsoft with the intent of helping the advance of deep learning research related to search. There are many tasks associated with MS MARCO datasets, but here we are interested in the task of building an end-to-end search application capable of returning relevant documents to a text query.
 
 For the purposes of this tutorial we have included a small sample of the dataset under the `msmarco/sample` directory which contains only around 1000 documents. This is sufficient for following along with this tutorial, however if you want to experiment with the entire dataset of more than 3 million documents, download the data with the following command:
 
@@ -311,6 +313,9 @@ To stop and remove the Docker container for this application:
 <pre data-test="after">
 $ docker rm -f vespa-msmarco
 </pre>
+
+## Next steps
+Check out the [Improving Text Search through ML](text-search-ml.html).
 
 
 [^1]: Robertson, Stephen and Zaragoza, Hugo and others, 2009. The probabilistic relevance framework: BM25 and beyond. Foundations and Trends in Information Retrieval.


### PR DESCRIPTION
More focused on the primary use cases, move others further down. Some more links in other doc. IMHO more aligned with messaging at vespa.ai main site. Removed debugging stuff which covered random issues and IMHO does not fit into a getting started page. 

![image](https://user-images.githubusercontent.com/20928528/106607708-eb5f6f80-6563-11eb-8a0f-85c74222066e.png)




I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
