### PR TITLE
Remove org.json as example from bundle plugin documentation

### DIFF
--- a/en/bundle-plugin.html
+++ b/en/bundle-plugin.html
@@ -73,9 +73,10 @@ configuring-components.html</a>
 Include external dependencies into the bundle by specifying them as dependencies:
 <pre>
 &lt;dependency&gt;
-  &lt;groupId&gt;org.json&lt;/groupId&gt;
-  &lt;artifactId&gt;json&lt;/artifactId&gt;
-  &lt;version&gt;20090211&lt;/version&gt;
+  &lt;groupId&gt;org.apache.httpcomponents.client5&lt;/groupId&gt;
+  &lt;artifactId&gt;httpclient5&lt;/artifactId&gt;
+  &lt;version&gt;5.0.3&lt;/version&gt;
+  &lt;scope&gt;compile&lt;/scope&gt;
 &lt;/dependency&gt;
 </pre>
 All packages in the library will then be available for use.
@@ -85,9 +86,9 @@ provided:
 </p>
 <pre>
 &lt;dependency&gt;
-  &lt;groupId&gt;org.json&lt;/groupId&gt;
-  &lt;artifactId&gt;json&lt;/artifactId&gt;
-  &lt;version&gt;20090211&lt;/version&gt;
+  &lt;groupId&gt;org.apache.httpcomponents.client5&lt;/groupId&gt;
+  &lt;artifactId&gt;httpclient5-osgi&lt;/artifactId&gt;
+  &lt;version&gt;5.0-beta2&lt;/version&gt;
   <strong>&lt;scope&gt;provided&lt;/scope&gt;</strong>
 &lt;/dependency&gt;
 </pre>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
