### PR TITLE
some more searcher pointers / vespa chain

### DIFF
--- a/en/query-api.html
+++ b/en/query-api.html
@@ -170,7 +170,13 @@ the query phase might involve multiple phases or roundtrips between the containe
   </li><li>
     Query pre-processing, like <a href="linguistics.html">linguistic processing</a>
     and <a href="query-rewriting.html">query rewriting</a>,
-    is done in built-in and custom <a href="chained-components.html">chains</a>.
+    is done in built-in and custom <a href="chained-components.html">chains</a> -
+    see <a href="searcher-development.html">searcher development</a>.
+    The default search chain is <em>vespa</em> -
+    find installed components in this chain by inspecting <code>ApplicationStatus</code>
+    like in the <a href="vespa-quick-start.html">quick-start</a>.
+    Adding <code>&amp;tracelevel=4</code> (or higher) to the query will
+    emit the components invoked in the query, and is useful to analyze ordering.
   </li><li>
     <p>
     The query is sent from the container to


### PR DESCRIPTION
The context is the new WeakAndReplacementSearcher (we will want to highlight this in next product update blog post as contribution)

There is little doc on default searchers, and I don't want to add much either - users can find out by just tracing and javadoc. 

Maybe we should link to https://github.com/vespa-engine/vespa/blob/master/container-search/src/main/java/com/yahoo/search/searchchain/model/VespaSearchers.java as these are the searchers in the vespa chain (?) and people can look up javadoc for searchers easily from there? 

I think we could highlight searchers a bit more in the entry level doc like this one, Searcher is probably the first API they will use when developing on Vespa - open for ideas !


