### PR TITLE
deploy using REST API

### DIFF
--- a/en/vespa-quick-start.html
+++ b/en/vespa-quick-start.html
@@ -44,7 +44,7 @@ Make sure you see at minimum 6Gb.
     <a href="https://github.com/vespa-engine/sample-apps">github</a>:</strong></p>
 <pre data-test="exec">
 $ git clone https://github.com/vespa-engine/sample-apps.git
-$ export VESPA_SAMPLE_APPS=`pwd`/sample-apps
+$ cd sample-apps/album-recommendation-selfhosted
 </pre>
 </li>
 
@@ -52,7 +52,7 @@ $ export VESPA_SAMPLE_APPS=`pwd`/sample-apps
     <p><strong>Start a Vespa Docker container:</strong></p>
 <pre data-test="exec">
 $ docker run --detach --name vespa --hostname vespa-container \
-  --volume $VESPA_SAMPLE_APPS:/vespa-sample-apps --publish 8080:8080 vespaengine/vespa
+  --publish 8080:8080 --publish 19071:19071 vespaengine/vespa
 </pre>
 <p>
     The <samp>volume</samp> option makes the previously downloaded source code available
@@ -70,21 +70,24 @@ $ docker run --detach --name vespa --hostname vespa-container \
 <li>
     <p><strong>Wait for the configuration server to start - wait for a 200 OK response:</strong></p>
 <pre data-test="exec" data-test-wait-for="200 OK">
-$ docker exec vespa bash -c 'curl -s --head http://localhost:19071/ApplicationStatus'
+$ curl -s --head http://localhost:19071/ApplicationStatus
 </pre>
 </li>
 
 <li>
     <p><strong>Deploy and activate a sample application:</strong></p>
 <pre data-test="exec">
-$ docker exec vespa bash -c '/opt/vespa/bin/vespa-deploy prepare \
-  /vespa-sample-apps/album-recommendation-selfhosted/src/main/application/ &amp;&amp; \
-  /opt/vespa/bin/vespa-deploy activate'
+$ tar -C src/main/application -cf - . | gzip | \
+  curl --header Content-Type:application/x-gzip --data-binary @- localhost:19071/application/v2/tenant/default/session
+$ curl -X PUT localhost:19071/application/v2/tenant/default/session/2/prepared
+$ curl -X PUT localhost:19071/application/v2/tenant/default/session/2/active
 </pre>
-    <p>More sample applications can be found in
-    <a href="https://github.com/vespa-engine/sample-apps/tree/master">sample-apps</a>.
-    Read more on applications in
-    <a href="cloudconfig/application-packages.html">Application packages</a>.</p>
+    <p>
+    The session id (here: 2) is returned in the first call -
+    this increments with subsequent calls, for use in <em>prepared</em> and <em>active</em> calls.
+    Read more on deploying applications in
+    <a href="cloudconfig/application-packages.html">Application packages</a>.
+    </p>
 </li>
 
 <li>
@@ -97,11 +100,11 @@ $ curl -s --head http://localhost:8080/ApplicationStatus
 <li>
     <p><strong>Feed documents:</strong></p>
 <pre data-test="exec">
-$ curl -H "Content-Type:application/json" --data-binary @${VESPA_SAMPLE_APPS}/album-recommendation-selfhosted/src/test/resources/A-Head-Full-of-Dreams.json \
+$ curl -H Content-Type:application/json --data-binary @src/test/resources/A-Head-Full-of-Dreams.json \
   http://localhost:8080/document/v1/mynamespace/music/docid/1
-$ curl -H "Content-Type:application/json" --data-binary @${VESPA_SAMPLE_APPS}/album-recommendation-selfhosted/src/test/resources/Love-Is-Here-To-Stay.json \
+$ curl -H Content-Type:application/json --data-binary @src/test/resources/Love-Is-Here-To-Stay.json \
   http://localhost:8080/document/v1/mynamespace/music/docid/2
-$ curl -H "Content-Type:application/json" --data-binary @${VESPA_SAMPLE_APPS}/album-recommendation-selfhosted/src/test/resources/Hardwired...To-Self-Destruct.json \
+$ curl -H Content-Type:application/json --data-binary @src/test/resources/Hardwired...To-Self-Destruct.json \
   http://localhost:8080/document/v1/mynamespace/music/docid/3
 </pre>
     <p>This uses <a href="reference/document-v1-api-reference.html">/document/v1/</a> -
@@ -136,5 +139,8 @@ $ docker rm -f vespa
 </li>
 </ol>
 
+
 <h2 id="next-steps">Next steps</h2>
+<p>
 Check out <a href="getting-started.html">getting started</a> for more tutorials and use cases which Vespa is great for.
+</p>


### PR DESCRIPTION
- eliminates the need to mount the app package into the Docker container
- complicates a little if the user deploys twice, as the session id is required. It is _possible_ to parse this from the json response, but will make the steps uglier and less informative. instead added a little note in doc on this
- there are a few more guides that deploy from inside the Docker container, can update once this is final
