### PR TITLE
rename to developer guide

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -104,10 +104,10 @@ docs:
 
   - title: DEVELOPING APPLICATIONS AND PLUGINS
     documents:
+      - page: Developer Guide
+        url: /en/developer-guide.html
       - page: Application Packages
         url: /en/cloudconfig/application-packages.html
-      - page: Writing Vespa Plugins
-        url: /en/vespa-plugins.html
       - page: Application Testing
         url: /en/testing.html
       - page: Java Serving Container

--- a/en/configuring-components.html
+++ b/en/configuring-components.html
@@ -10,7 +10,7 @@ Because of all the boilerplate code that commonly goes into classes to hold such
 this often degenerates into a collection of key-value string pairs
 (e.g. <a href="http://docs.oracle.com/javaee/6/api/javax/servlet/FilterConfig.html">javax.servlet.FilterConfig</a>).
 To avoid this, Vespa has custom, type-safe configuration to all <a href="jdisc/">Container</a> components.
-Get started with <a href="vespa-plugins.html">Vespa Plugins</a>,
+Get started with the <a href="developer-guide.html">Developer Guide</a>,
 try the <a href="https://github.com/vespa-engine/sample-apps/blob/master/vespa-cloud/album-recommendation-searcher/">
 album-recommendation-searcher</a> sample application.
 </p><p>

--- a/en/content/visiting.html
+++ b/en/content/visiting.html
@@ -240,7 +240,7 @@ public class ReProcessor extends DocumentProcessor {
     }
 }
 </pre>
-To compile this processor, see <a href="../vespa-plugins.html">Vespa Plugins</a>.
+To compile this processor, see the <a href="../developer-guide.html">Developer Guide</a>.
 For more information on document processing, refer
 to <a href="../document-processing.html">Document processor Development</a>.
 After having changed the Vespa setup, reload config:

--- a/en/developer-guide.html
+++ b/en/developer-guide.html
@@ -1,6 +1,6 @@
 ---
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "Vespa Plugins"
+title: "Developer Guide"
 ---
 
 <p>
@@ -22,7 +22,7 @@ in Vespa, such plugins (called <em>Components</em>) are run in the Stateless Jav
 </ul>
 <p>
 Find sample applications for all component types in <a href="getting-started.html">Getting Started</a>,
-where <a href="operations/admin-procedures.html#troubleshooting">Troubleshooting</a> is also found.
+also see <a href="operations/admin-procedures.html#troubleshooting">Troubleshooting</a>.
 </p>
 
 

--- a/en/getting-started.html
+++ b/en/getting-started.html
@@ -113,7 +113,7 @@ Vespa can do many things, and be deployed in many ways.
       <li><a href="https://github.com/vespa-engine/sample-apps/tree/master/vespa-cloud/album-recommendation-docproc">
       album-recommendation-docproc</a> for Document Processor development</li>
     </ul>
-    <a href="vespa-plugins.html">Vespa Plugins</a> has more details.
+    The <a href="developer-guide.html">Developer Guide</a> has more details.
     For <a href="https://cloud.vespa.ai/">Vespa Cloud</a> users, also see
     <a href="https://cloud.vespa.ai/getting-started-custom-code">Getting Started Custom Code</a>.
     </p>

--- a/en/jdisc/developing-osgi-bundles.html
+++ b/en/jdisc/developing-osgi-bundles.html
@@ -76,7 +76,7 @@ Import-Package: org.osgi.framework;version="1.3.0"
     <h2>Building an OSGi bundle</h2>
     <p>
       As long as the project was created by following steps in the
-      <a href="../vespa-plugins.html">Vespa Plugins</a> guide,
+      <a href="../developer-guide.html">Developer Guide</a>,
       the code is already being packaged into an OSGi bundle by the
       <a href="../bundle-plugin.html">Maven bundle plugin</a>.
       However, if migrating an existing Maven project, change the packaging statement to:

--- a/en/jdisc/http-api-tutorial.html
+++ b/en/jdisc/http-api-tutorial.html
@@ -143,7 +143,7 @@ Review the application's configuration in
 
 <h2 id="try-it">Try it!</h2>
 <p>
-Build the project, then <a href="../vespa-plugins.html">run a test</a>,
+Build the project, then <a href="../developer-guide.html">run a test</a>,
 querying <a href="http://localhost:8080/demo?terms=1%202%203%204">
 http://localhost:8080/demo?terms=1%202%203%204</a> gives:
 <pre>

--- a/en/jdisc/http-server-and-filters.html
+++ b/en/jdisc/http-server-and-filters.html
@@ -5,7 +5,7 @@ title: "Configuring Http Servers and Filters"
 
 <p>
 This document explains how to set up http servers and filters in the JDisc Container.
-Before proceeding, familiarize with <a href="../vespa-plugins.html">Vespa Plugins</a>.
+Before proceeding, familiarize with the <a href="../developer-guide.html">Developer Guide</a>.
 </p>
 
 
@@ -183,7 +183,7 @@ Example where a security filter is excluded from an inherited chain for <em>stat
 
 <h3 id="creating-a-custom-filter">Creating a custom Filter</h3>
 <p>
-Create an <a href="../vespa-plugins.html">application package</a>
+Create an <a href="../developer-guide.html">application package</a>
 with artifactId <code>filter-bundle</code>.
 Create a new file <code>filter-bundle/components/src/main/java/com/yahoo/demo/TestRequestFilter.java</code>:
 <pre>

--- a/en/jdisc/processing.html
+++ b/en/jdisc/processing.html
@@ -28,7 +28,7 @@ To use processing, add this dependency to <em>pom.xml</em>:
   &lt;scope&gt;provided&lt;/scope&gt;
 &lt;/dependency&gt;
 </pre>
-Or read <a href="../vespa-plugins.html">how to start a deployable project from scratch</a>.
+Or read <a href="../developer-guide.html">how to start a deployable project from scratch</a>.
 </p>
 
 

--- a/en/jdisc/server-tutorial.html
+++ b/en/jdisc/server-tutorial.html
@@ -5,7 +5,7 @@ title: "Server Tutorial"
 
 <p>
 How to run an arbitrary server in the container.
-Familiarity with <a href="../vespa-plugins.html">Vespa Plugins</a> is assumed.
+Familiarity with the <a href="../developer-guide.html">Developer Guide</a> is assumed.
 </p>
 
 
@@ -20,7 +20,7 @@ about what a service is.</p>
 
 <h1 id="server">The server class</h1>
 <p>
-Set up a project as in the <a href="../vespa-plugins.html">tutorials</a>,
+Set up a project as in the <a href="../developer-guide.html">Developer Guide</a>,
 then create <code>hello_world/components/src/main/java/com/mydomain/demo/HelloWorldServer.java</code>:
 <pre>
 package com.mydomain.demo;

--- a/en/overview.html
+++ b/en/overview.html
@@ -171,7 +171,7 @@ whether it specifies a large system with hundreds of nodes or a single node runn
 The only change needed is to the lists of nodes making up the cluster.
 The container clusters may also be started within a single Java VM by "deploying" the application package from a method call.
 This is useful for testing applications in an IDE and in unit tests.
-Application packages with components can be <a href="vespa-plugins.html">developed</a>
+Application packages with components can be <a href="developer-guide.html">developed</a>
 in an IDE using Maven starting from sample applications.
 </p>
 

--- a/en/reference/component-reference.html
+++ b/en/reference/component-reference.html
@@ -7,7 +7,7 @@ title: "Container Component Reference"
 <h2 id="component-types">Component Types</h2>
 <p>
   The container has a large number of different types of plug-ins available to a developer.
-  To start creating components, see <a href="../vespa-plugins.html">Vespa Plugins</a>.
+  To start creating components, see the <a href="../developer-guide.html">Developer Guide</a>.
 </p><p>
 <img src="../img/container_components.svg">
 </p><p>

--- a/en/result-rendering.html
+++ b/en/result-rendering.html
@@ -11,8 +11,8 @@ Renderers should not be used to implement business logic -
 that should go in <a href="searcher-development.html">Searchers</a>,
 <a href="jdisc/developing-request-handlers.html">Handlers</a> or
 <a href="jdisc/processing.html">Processors</a>.
-This guide assumes familiarity with
-<a href="vespa-plugins.html">Vespa Plugins</a>.
+This guide assumes familiarity with the
+<a href="developer-guide.html">Developer Guide</a>.
 </p><p>
 Renderers are implemented by subclassing one of:
 <ul>

--- a/en/searcher-development.html
+++ b/en/searcher-development.html
@@ -12,7 +12,7 @@ components developed by multiple development teams into a functional whole.
 </p><p>
 This document describes how to develop and deploy Searcher components.
 To get started with development,
-see <a href="vespa-plugins.html">Vespa Plugins</a>.
+see the <a href="developer-guide.html">Developer Guide</a>.
 For reference, see the <a href="http://javadoc.io/page/com.yahoo.vespa/container-search/latest/com/yahoo/search/package-summary.html">
 Container javadoc</a>,
 and the <a href="reference/services-processing.html#chain">services.xml reference</a>.
@@ -228,8 +228,8 @@ the framework will simply return an empty result, which is what happens in this 
 A test adding a mock searcher producing results are shown in
 <a href="federation.html#unit-testing-the-result-processor">federation</a>.
 </p><p>
-To write unit tests of the whole application package, see
-<a href="vespa-plugins.html">unit testing</a> under application development.
+To write unit tests of the whole application package, see the
+<a href="developer-guide.html">Developer Guide</a>.
 </p>
 
 

--- a/en/testing.html
+++ b/en/testing.html
@@ -51,7 +51,7 @@ public class ApplicationMain {
 <h2 id="unit-testing-configurable-components">Unit Testing Configurable Components</h2>
 <p>
 How to programmatically build configuration instances for unit testing.
-Read <a href="vespa-plugins.html">Vespa Plugins</a> first.
+Read the <a href="developer-guide.html">Developer Guide</a> first.
 </p><p>
 To be able to write self-contained unit tests using configuration classes
 generated from a schema, it is necessary to instantiate the configuration


### PR DESCRIPTION
ref the other link change. this is the closest we have to a developer guide, so please take a look at what is missing for next PR, too
