### PR TITLE
Update references to jdisc_http_service -> container-core

### DIFF
--- a/en/jdisc/http-server-and-filters.html
+++ b/en/jdisc/http-server-and-filters.html
@@ -54,7 +54,7 @@ Configuration settings for the server can be modified by setting values for the
 Note that it is not allowed to set the <code>listenPort</code> in the http-server config,
 as it conflicts with the port that is set in the <em>port</em> attribute in the <em>server</em> element.
 For a complete list of configuration fields that can be set, refer to the config definition schema in
-<a href="https://github.com/vespa-engine/vespa/blob/master/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.connector.def">
+<a href="https://github.com/vespa-engine/vespa/blob/master/container-core/src/main/resources/configdefinitions/jdisc.http.connector.def">
 jdisc.http.connector.def</a>.
 </p>
 

--- a/en/jdisc/http-server-and-filters.html
+++ b/en/jdisc/http-server-and-filters.html
@@ -54,7 +54,7 @@ Configuration settings for the server can be modified by setting values for the
 Note that it is not allowed to set the <code>listenPort</code> in the http-server config,
 as it conflicts with the port that is set in the <em>port</em> attribute in the <em>server</em> element.
 For a complete list of configuration fields that can be set, refer to the config definition schema in
-<a href="https://github.com/vespa-engine/vespa/blob/master/container-core/src/main/resources/configdefinitions/jdisc.http.connector.def">
+<a href="https://github.com/vespa-engine/vespa/blob/master/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def">
 jdisc.http.connector.def</a>.
 </p>
 

--- a/en/reference/services-http.html
+++ b/en/reference/services-http.html
@@ -7,7 +7,7 @@ title: "services.xml - http"
 This is the reference for the <code>http</code> subelement of
 <a href="services-container.html">container</a> in <a href="services.html">services.xml</a>.
 The http block is used to configure http servers and filters -
-when this element is present, the default http server is disabled.</a>
+when this element is present, the default http server is disabled.</p>
 <pre>
 http
   <a href="#server">server [id, port]</a>
@@ -41,7 +41,7 @@ http
 </pre>
 Most elements takes optional <a href="config-files.html#generic-configuration-in-services-xml">config</a> elements,
 see example in <a href="#server">server</a>.
-</p><p>
+<p>
 Note: To bind the search handler port (i.e. queries),
 refer to <a href="services-search.html#binding">search bindings</a>.
 </p><p>
@@ -78,7 +78,7 @@ Example:
 <p>
 The definition of a http server.
 Configure the server using
-<a href="https://github.com/vespa-engine/vespa/blob/master/jdisc_http_service/src/main/resources/configdefinitions/jdisc.http.connector.def">
+<a href="https://github.com/vespa-engine/vespa/blob/master/container-core/src/main/resources/configdefinitions/jdisc.http.connector.def">
   jdisc.http.connector.def</a>.
 Attributes:
 <table class="table">
@@ -154,7 +154,7 @@ Example:
 
 <h2 id="ssl-provider">ssl-provider</h2>
 <p>
-  Setup TLS on the HTTP server through a programmatic Java interface. The specified class must implement the <a href="https://javadoc.io/doc/com.yahoo.vespa/jdisc_http_service/latest/com/yahoo/jdisc/http/ssl/SslContextFactoryProvider.html">SslContextFactoryProvider</a> interface. The programmatic interface allows the application to provide an instance of <a href="https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/util/ssl/SslContextFactory.html">org.eclipse.jetty.util.ssl.SslContextFactory</a>. See <a href="https://www.eclipse.org/jetty/documentation/9.4.x/configuring-ssl.html#configuring-sslcontextfactory">Configuring the Jetty SslContextFactory</a> for details.
+  Setup TLS on the HTTP server through a programmatic Java interface. The specified class must implement the <a href="https://javadoc.io/doc/com.yahoo.vespa/container-core/latest/com/yahoo/jdisc/http/ssl/SslContextFactoryProvider.html">SslContextFactoryProvider</a> interface. The programmatic interface allows the application to provide an instance of <a href="https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/util/ssl/SslContextFactory.html">org.eclipse.jetty.util.ssl.SslContextFactory</a>. See <a href="https://www.eclipse.org/jetty/documentation/9.4.x/configuring-ssl.html#configuring-sslcontextfactory">Configuring the Jetty SslContextFactory</a> for details.
   Attributes:
   <table class="table">
     <thead>

--- a/en/reference/services-http.html
+++ b/en/reference/services-http.html
@@ -78,7 +78,7 @@ Example:
 <p>
 The definition of a http server.
 Configure the server using
-<a href="https://github.com/vespa-engine/vespa/blob/master/container-core/src/main/resources/configdefinitions/jdisc.http.connector.def">
+<a href="https://github.com/vespa-engine/vespa/blob/master/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def">
   jdisc.http.connector.def</a>.
 Attributes:
 <table class="table">


### PR DESCRIPTION
Please note that the real name of the connector.def file is `jdisc.http.jdisc.http.connector.def`. We should try to rename it in a separate PR. If we can't rename for whatever reason, we must update these links again.