### PR TITLE
Add cluster-controller to at least one and slobrok to every single node

### DIFF
--- a/en/vespa-quick-start-multinode-aws.html
+++ b/en/vespa-quick-start-multinode-aws.html
@@ -222,6 +222,18 @@ $ cd sample-apps/album-recommendation-selfhosted
     &lt;configservers&gt;
       &lt;configserver hostalias="admin0"/&gt;
     &lt;/configservers&gt;
+
+	&lt;cluster-controllers standalone-zookeeper="true"&gt;
+	  &lt;cluster-controller hostalias="stateless0" /&gt;
+	&lt;/cluster-controllers&gt;
+
+	&lt;slobroks&gt;
+	  &lt;slobrok hostalias="admin0" /&gt;
+	  &lt;slobrok hostalias="stateless0" /&gt;
+	  &lt;slobrok hostalias="stateless1" /&gt;
+	  &lt;slobrok hostalias="content0" /&gt;
+	  &lt;slobrok hostalias="content1" /&gt;
+	&lt;/slobroks&gt;
   &lt;/admin&gt;
 
   &lt;container id="container" version="1.0"&gt;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## Summary

I set-up Vespa on 3 Google Compute Engine instances. According to this guide, I designated one of them as config0, the "config" node, one as stateless0, a "stateless" node and one as content0, the "content" node. At this step `Configure and Deploy > 3  Ensure the application is active - wait for a 200 OK response:`, I was not able to confirm that the cluster was active.

After some investigation and reading through some of the documentation, I fixed the issue by running a cluster-controller on the stateless0 node and running a slobrok on every single node. I am adding the final config that worked for me in this PR.

### Timeline

As I said, I followed the guide up to step 3 in `Configure and Deploy`. At this point, I was getting an empty response at `container0:8080/ApplicationStatus`.

I ran `vespa-get-cluster-state`. Here is the output after removing hostnames:

```sh
$ vespa-get-cluster-state
Failed to fetch cluster state of content cluster 'music':
500 Can't connect to <<config-node-hostname>>.internal:19050
(Connection refused)
Content-Type: text/plain
Client-Date: Thu, 25 Mar 2021 04:21:22 GMT
Client-Warning: Internal response

Can't connect to <<config-node-hostname>>.internal:19050
(Connection refused)

LWP::Protocol::http::Socket: connect: Connection refused at
/usr/share/perl5/LWP/Protocol/http.pm line 51.
```

I realized that a `cluster-controller` is required after scouring through the documentation and finding this paragraph:

> Container for one or more cluster-controller elements. When having one or more content clusters, configuring at least one cluster controller is required
> -- https://docs.vespa.ai/en/reference/services-admin.html#cluster-controller

Here, I started running a cluster controller on `stateless0`.

```xml
	<cluster-controllers standalone-zookeeper="true">
	  <cluster-controller hostalias="stateless0" />
	</cluster-controllers>
```

After making this change, preparing and deploying, the `get-cluster-state` output at least recognized that the cluster was down.

```
$ vespa-get-cluster-state -v
Cluster music is down. Too few nodes available.
music/distributor/0: down
music/storage/0: down
```

I tailed `/opt/vespa/logs/vespa/vespa.log` in the content0 node and found an error saying something like `slobrok could not be found`. So, I started running a "slobrok" on every single node using this config:

```
<slobroks>                          
  <slobrok hostalias="admin0" />    
  <slobrok hostalias="stateless0" />
  <slobrok hostalias="content0" />  
</slobroks>
```

Preparing and deploying this finally brought the application up and I was able to add documents and get a `200 OK` response on `container0:8080/ApplicationStatus`. ✅ 