### PR TITLE
Fix documentation suggesting that max can be unary

### DIFF
--- a/en/reference/ranking-expressions.html
+++ b/en/reference/ranking-expressions.html
@@ -637,7 +637,6 @@ but are not necessarily so for performance reasons.
     <td>
         <code>reduce(t, max, dim)</code> <br />
         Reduce the tensor with the <code>max</code> aggregator along dimension <code>dim</code>.
-        If the dimension argument is omitted, this reduces over all dimensions.
     </td>
 </tr>
 <tr>
@@ -660,7 +659,6 @@ If the dimension argument is omitted, this reduces over all dimensions.
     <td>
         <code>reduce(t, min, dim)</code> <br />
         Reduce the tensor with the <code>min</code> aggregator along dimension <code>dim</code>.
-        If the dimension argument is omitted, this reduces over all dimensions.
     </td>
 </tr>
 <tr>

--- a/en/tensor-examples.html
+++ b/en/tensor-examples.html
@@ -48,7 +48,7 @@ startTime and endTime are epoch timestamps.
 
 <p>And we can retrieve the currently valid price by the expression</p>
 <pre>
-max((attribute(startTime) < now) * (attribute(endTime) > now) * attribute(price))
+reduce((attribute(startTime) < now) * (attribute(endTime) > now) * attribute(price), max)
 </pre>
 
 <p>This will return 0 if there is no matching interval, so a full expression will probably


### PR DESCRIPTION
@bratseth Please review.

Also goes for `min` of course.