### PR TITLE
Add expect command type to documentation testing

### DIFF
--- a/test/pseudo_terminal.py
+++ b/test/pseudo_terminal.py
@@ -82,3 +82,16 @@ class PseudoTerminal:
             raise RuntimeError("Timeout in execution of {}".format(command))
         raise RuntimeError("Unexpected state")
 
+    def run_expect(self, command, expect, timeout, verbose):
+        self._log.reset_log(verbose)
+        self._pty.sendline(command)
+
+        index = self._pty.expect([expect, pexpect.EOF, pexpect.TIMEOUT], timeout=int(timeout))
+        if index == 0:
+            return 0, self._log.get_log()
+        if index == 1:
+            raise RuntimeError("Unexpected EOF in pseudo-terminal")
+        if index == 2:
+            raise RuntimeError("Timeout in execution of {}".format(command))
+        raise RuntimeError("Unexpected state")
+

--- a/test/test.py
+++ b/test/test.py
@@ -85,6 +85,19 @@ def exec_file(cmd, pty):
     print("Wrote " + str(len(cmd["content"])) + " chars to " + path)
 
 
+def exec_expect(cmd, pty):
+    command = cmd["$"]
+    expect = cmd["expect"]
+    timeout = cmd["timeout"]
+    print_cmd_header(command, "Expecting '{0}'".format(expect))
+
+    exit_code, output = pty.run_expect(command, expect, timeout, verbose)
+    if exit_code != 0:
+        if not verbose:
+            print(output)
+        raise RuntimeError("Command '{0}' returned code {1}".format(command, exit_code))
+
+
 def exec_default(cmd, pty):
     command = cmd["$"]
     print_cmd_header(command)
@@ -145,6 +158,8 @@ def parse_cmd(cmd, attrs):
         return { "$" : cmd, "type":"wait", "wait-for":attrs["data-test-wait-for"] }
     if "data-test-assert-contains" in attrs:
         return { "$" : cmd, "type":"assert", "contains":attrs["data-test-assert-contains"] }
+    if "data-test-expect" in attrs:
+        return { "$" : cmd, "type":"expect", "expect":attrs["data-test-expect"], "timeout":attrs["data-test-timeout"] }
     return { "$" : cmd, "type":"default" }
 
 


### PR DESCRIPTION
@jobergum @kkraune Please review. 

Adds a new command type for waiting for an exact match in the log before continuing, e.g.:

```
<pre data-test="exec" data-test-expect="BUILD SUCCESS" data-test-timeout="120">
$ mvn clean package -U
</pre>
```

This will continue the test script after maven outputs `BUILD SUCCESS` - or timeout after 120 seconds if not seen.