### PR TITLE
Remove search button on small screen

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -4,9 +4,6 @@
     <div class="nav-left">
         <span class="nav-item hide-small-desktop-up" onclick="toggleMenu()"><i class="d-icon d-menu-hamburger"></i></span>
         <a href="https://vespa.ai/"><img class="nav-brand" src="{{ site.baseurl }}/assets/{{include.logo}}" alt="Vespa logo"/></a>
-        <div class="float-right hide-small-desktop-up">
-            <a class="nav-item" href="{{ site.baseurl }}/search.html"><i class="d-icon d-search"></i></a>
-        </div>
     </div>
     <div id="navMenu" class="nav-responsive">
 


### PR DESCRIPTION
This does not work anyway. now only thing clickable in header on small screen is the burger to the left, which has the search input