### PR TITLE
Set default title when not set in document

### DIFF
--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -3,7 +3,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>{{ page.title }}</title>
+    <title>{{ page.title | default: "Vespa Documentation" }}</title>
     <!-- Site icons - generated using http://realfavicongenerator.net/ -->
     <link rel="apple-touch-icon" sizes="180x180" href="{{ "/icons/apple-touch-icon.png" | prepend: site.baseurl }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ "/icons/favicon-32x32.png" | prepend: site.baseurl }}">


### PR DESCRIPTION
Prefer to not have an empty `<title>` tag – especially on the front page.

@kkraune : Please review.