### PR TITLE
Fix pre elements in .md

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,6 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  universal-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  universal-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/css/style.scss
+++ b/css/style.scss
@@ -299,6 +299,12 @@ code {
     border-radius: 4px;
 }
 
+/* Rouge-generated pre elements have code inside, make look like rest of pre */
+/* Change the foreground color later for proper code highlighting (i.e. add rouge-made stylesheet) */
+pre > code {
+    color: #e8e8e8;
+    background-color: #000000;
+}
 
 
 /* Sidebar */


### PR DESCRIPTION
The "rouge" (default on github) code highlighter inserts code elements in pre for highlighting. Code is used in text elsewhere, so style code if child of pre . This is on the way for proper code highlight (hope to fix that soon), making the markdown files' pre elements look like the others