### PR TITLE
Add highlighting style, apply in one .md file

### DIFF
--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -31,4 +31,7 @@
     <!-- MathJax for formulas -->
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
+    <!-- pre Highlight style, ref https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting -->
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/native.css">
 </head>

--- a/css/native.css
+++ b/css/native.css
@@ -1,0 +1,71 @@
+.highlight pre { background-color: #404040 }
+.highlight .hll { background-color: #404040 }
+.highlight .c { color: #999999; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .g { color: #d0d0d0 } /* Generic */
+.highlight .k { color: #6ab825; font-weight: bold } /* Keyword */
+.highlight .l { color: #d0d0d0 } /* Literal */
+.highlight .n { color: #d0d0d0 } /* Name */
+.highlight .o { color: #d0d0d0 } /* Operator */
+.highlight .x { color: #d0d0d0 } /* Other */
+.highlight .p { color: #d0d0d0 } /* Punctuation */
+.highlight .cm { color: #999999; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #cd2828; font-weight: bold } /* Comment.Preproc */
+.highlight .c1 { color: #999999; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #e50808; font-weight: bold; background-color: #520000 } /* Comment.Special */
+.highlight .gd { color: #d22323 } /* Generic.Deleted */
+.highlight .ge { color: #d0d0d0; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #d22323 } /* Generic.Error */
+.highlight .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #589819 } /* Generic.Inserted */
+.highlight .go { color: #cccccc } /* Generic.Output */
+.highlight .gp { color: #aaaaaa } /* Generic.Prompt */
+.highlight .gs { color: #d0d0d0; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #ffffff; text-decoration: underline } /* Generic.Subheading */
+.highlight .gt { color: #d22323 } /* Generic.Traceback */
+.highlight .kc { color: #6ab825; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #6ab825; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #6ab825; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #6ab825 } /* Keyword.Pseudo */
+.highlight .kr { color: #6ab825; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #6ab825; font-weight: bold } /* Keyword.Type */
+.highlight .ld { color: #d0d0d0 } /* Literal.Date */
+.highlight .m { color: #3677a9 } /* Literal.Number */
+.highlight .s { color: #ed9d13 } /* Literal.String */
+.highlight .na { color: #bbbbbb } /* Name.Attribute */
+.highlight .nb { color: #24909d } /* Name.Builtin */
+.highlight .nc { color: #447fcf; text-decoration: underline } /* Name.Class */
+.highlight .no { color: #40ffff } /* Name.Constant */
+.highlight .nd { color: #ffa500 } /* Name.Decorator */
+.highlight .ni { color: #d0d0d0 } /* Name.Entity */
+.highlight .ne { color: #bbbbbb } /* Name.Exception */
+.highlight .nf { color: #447fcf } /* Name.Function */
+.highlight .nl { color: #d0d0d0 } /* Name.Label */
+.highlight .nn { color: #447fcf; text-decoration: underline } /* Name.Namespace */
+.highlight .nx { color: #d0d0d0 } /* Name.Other */
+.highlight .py { color: #d0d0d0 } /* Name.Property */
+.highlight .nt { color: #6ab825; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #40ffff } /* Name.Variable */
+.highlight .ow { color: #6ab825; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #666666 } /* Text.Whitespace */
+.highlight .mf { color: #3677a9 } /* Literal.Number.Float */
+.highlight .mh { color: #3677a9 } /* Literal.Number.Hex */
+.highlight .mi { color: #3677a9 } /* Literal.Number.Integer */
+.highlight .mo { color: #3677a9 } /* Literal.Number.Oct */
+.highlight .sb { color: #ed9d13 } /* Literal.String.Backtick */
+.highlight .sc { color: #ed9d13 } /* Literal.String.Char */
+.highlight .sd { color: #ed9d13 } /* Literal.String.Doc */
+.highlight .s2 { color: #ed9d13 } /* Literal.String.Double */
+.highlight .se { color: #ed9d13 } /* Literal.String.Escape */
+.highlight .sh { color: #ed9d13 } /* Literal.String.Heredoc */
+.highlight .si { color: #ed9d13 } /* Literal.String.Interpol */
+.highlight .sx { color: #ffa500 } /* Literal.String.Other */
+.highlight .sr { color: #ed9d13 } /* Literal.String.Regex */
+.highlight .s1 { color: #ed9d13 } /* Literal.String.Single */
+.highlight .ss { color: #ed9d13 } /* Literal.String.Symbol */
+.highlight .bp { color: #24909d } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #40ffff } /* Name.Variable.Class */
+.highlight .vg { color: #40ffff } /* Name.Variable.Global */
+.highlight .vi { color: #40ffff } /* Name.Variable.Instance */
+.highlight .il { color: #3677a9 } /* Literal.Number.Integer.Long */
+

--- a/css/style.scss
+++ b/css/style.scss
@@ -271,6 +271,7 @@ code, kbd, pre, samp {
     font-size: 90%;
 }
 
+/* #404040 for background makes it less pitch black and is the same used in code highlighter */
 pre {
     -webkit-font-smoothing: auto;
     overflow: auto;
@@ -280,12 +281,11 @@ pre {
     color: #e8e8e8;
     word-break: break-all;
     word-wrap: break-word;
-    border: 1px solid #000000;
+    border: 1px solid #404040;
     white-space: pre-wrap;
-    background-color: #000000;
+    background-color: #404040;
     border-radius: 4px;
-    padding: 14px !important;
-    margin-bottom: 10px;
+    padding: 14px;
 }
 
 .pre-hilite {
@@ -301,9 +301,11 @@ code {
 
 /* Rouge-generated pre elements have code inside, make look like rest of pre */
 /* Change the foreground color later for proper code highlighting (i.e. add rouge-made stylesheet) */
+/* Revert the padding from <code< elements in text, no pad in <pre> */
 pre > code {
     color: #e8e8e8;
-    background-color: #000000;
+    background-color: #404040;
+    padding: 0px;
 }
 
 

--- a/en/xgboost.md
+++ b/en/xgboost.md
@@ -1,5 +1,5 @@
 ---
-# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 title: "Ranking with XGBoost Models"
 ---
 
@@ -16,7 +16,7 @@ and users can specify the feature names to be used in `fmap`.
 
 Here is an example of an XGBoost JSON model dump with 2 trees and maximum depth 1:
 
-```
+```json
 [
   { "nodeid": 0, "depth": 0, "split": "fieldMatch(title).completeness", "split_condition": 0.772132337, "yes": 1, "no": 2, "missing": 1, "children": [
     { "nodeid": 1, "leaf": 0.673938096 },
@@ -30,7 +30,7 @@ Here is an example of an XGBoost JSON model dump with 2 trees and maximum depth 
 ```
 Notice the 'split' attribute which represents the feature name. The above model was produced using the XGBoost python api:
 
-```
+```python
 #!/usr/local/bin/python3
 import xgboost as xgb
 
@@ -48,8 +48,8 @@ where features are named based on the index in the array  as in the example abov
 To convert the XGBoost features we need to map feature indexes to actual Vespa features
 (native features or custom defined features):
  
-```
-cat feature-map.txt |egrep "fieldMatch\(title\).completeness|fieldMatch\(title\).importance"
+```shell
+$ cat feature-map.txt |egrep "fieldMatch\(title\).completeness|fieldMatch\(title\).importance"
 36  fieldMatch(title).completeness q
 39  fieldMatch(title).importance q
 ```
@@ -73,7 +73,7 @@ model to your application package under a specific directory named `models`.
 For instance, if you would like to call the model above as `my_model`,
 you would add it to the application package resulting in a directory structure like this:
 
-```
+```text
 ├── models
 │   └── my_model.json
 ├── schemas
@@ -93,7 +93,7 @@ Vespa has a special [ranking feature](reference/rank-features.html) called `xgbo
 This ranking feature specifies the model to use in a ranking expression.
 Consider the following example:
 
-```
+```text
 schema xgboost {
     rank-profile prediction inherits default {
         first-phase {
@@ -124,7 +124,7 @@ but the base_score should be set 0 as the base_score used during the training ph
 
 An example model using the sklearn toy datasets is given below:
 
-```
+```python
 from sklearn import datasets
 import xgboost as xgb
 breast_cancer = datasets.load_breast_cancer()
@@ -137,7 +137,7 @@ c.predict_proba(breast_cancer.data)[:,1]
 To represent the ```predict_proba``` function of XGBoost for the binary classifier in Vespa,
 we need to use the [sigmoid function](reference/ranking-expressions.html):
 
-```
+```text
 schema xgboost {
     rank-profile prediction-binary inherits default {
         first-phase {


### PR DESCRIPTION
Note: Highlighting for &lt;pre&gt; elements needs special care, as the content of these is used in doc auto-testing. E.g.

````
{% highlight shell %}
$ docker info | grep "Total Memory"
{% endhighlight %}

<figure class="highlight">
    <pre>
        <code class="language-shell" data-lang="shell">
            <span class="nv">$ </span>
            docker info | 
            <span class="nb">grep</span> 
            <span class="s2">"Total Memory"</span>
        </code>
    </pre>
</figure>
````

For now, test this on elements not used in auto testing, sp we can get the visuals right

so we need to modify test/test.py to eliminate highlighting liquid macros (unless we device another clever way to invoke the highlighter on pre elements)
