### PR TITLE
Kkraune/auto test fixes

### DIFF
--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -1,7 +1,7 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 urls:
-    - "http://docs.vespa.ai/en/vespa-quick-start.html"
+    - "file:../en/vespa-quick-start.html"
     - "http://docs.vespa.ai/en/tutorials/text-search.html"
     - "http://docs.vespa.ai/en/getting-started-ranking.html"
     - "https://cloud.vespa.ai/en/getting-started-java"

--- a/test/test.py
+++ b/test/test.py
@@ -248,6 +248,7 @@ def create_work_dir():
 
 
 def run_url(url):
+    print_cmd_header("Testing", url)
     html = urllib.request.urlopen(url).read()
     process_page(html, url)
 


### PR DESCRIPTION
The first commit will make it easier to find the problem when docs or sample apps move, printing the resource before download attempt:

********************************************************************************
* Testing
* (http://docs.vespa.ai/en/tutorials/text-search.htmll)
********************************************************************************
ERROR: HTTP Error 404: Not Found

The second will run the test on the source file instead of the rendered file. I think that is OK for this purpose (get the commands from the <pre> elements). The rendered file can be mangled by code highlighting

