### PR TITLE
Pri navbar > sidebar and search > navbar

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -104,6 +104,7 @@ $color-brand-500: #FF9750;
 /* Navbar */
 .nav {
     font-weight: 700;
+    z-index: 5;
 }
 
 // Responsive design; downscaled nav bar for small desktop screens
@@ -147,6 +148,7 @@ button.section-searchbar {
 
 .nav-item.section-searchbar {
     padding-top: 14px;
+    z-index: 9;
 }
 
 /* Cover */
@@ -346,7 +348,7 @@ pre > code {
     top: 60px;
     bottom: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 3;
 }
 
 
@@ -389,6 +391,7 @@ table {
 
 .dropdown.show {
     display: inline-block;
+    z-index: 7;
 }
 
 .dropdown.hide {
@@ -405,7 +408,7 @@ table {
     display: block;
     user-select: none;
     margin: 0;
-    border: 0
+    border: 0;
 }
 
 .dropdown > p:hover {


### PR DESCRIPTION
work note: the hard part was realizing that nav required a z-index to dominate the sidebar once the suggestions (which is a child inside nav) dropped down over sidebar in medium-sized view. for mobile view, just set search input high than nav to dominate over the links behind ...

thanks to @jobergum for reporting!