### PR TITLE
Revert "Prefetch search.html page in the page template"

### DIFF
--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -4,8 +4,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>{{ page.title | default: "Vespa Documentation" }}</title>
-    <link rel="prefetch" href="/search.html" as="document">
-    <link rel="preconnect" href="https://doc-search.vespa.oath.cloud/">
     <!-- Site icons - generated using http://realfavicongenerator.net/ -->
     <link rel="apple-touch-icon" sizes="180x180" href="{{ "/icons/apple-touch-icon.png" | prepend: site.baseurl }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ "/icons/favicon-32x32.png" | prepend: site.baseurl }}">


### PR DESCRIPTION
Reverts vespa-engine/documentation#1525

It only sort-of works. The `preconnect` works but it messes up the link checker. `preload` doesn't work properly because we send the user with a query parameter which invalidates the cached version we made the browser preload. Had we used the trick of sending the query with an anchor instead of query I think it would work.