### PR TITLE
Correct default group sort which requires -/neg() for descending

### DIFF
--- a/en/grouping.html
+++ b/en/grouping.html
@@ -523,7 +523,8 @@ Notes on ordering in the example above:
 <ul>
 <li>
     The <code>order</code> clause is a directive for <em>group</em> ordering, not <em>hit</em> ordering.
-    Here, there is no order clause on the groups, hence default ordering <code>max(relevance())</code> is used.
+    Here, there is no order clause on the groups, hence default ordering <code>-max(relevance())</code> is used. The <em>-</em>
+    denotes the sorting order, <em>-</em> means descending (higher score first).
     In this case, the query is "all documents", hence all groups are equally relevant and the group order is random.
 </li><li>
     To order hits inside groups, use ranking. Add <code>ranking=pricerank</code> to the query

--- a/en/reference/grouping-syntax.html
+++ b/en/reference/grouping-syntax.html
@@ -104,7 +104,7 @@ returning only first <em>n</em> groups as specified by <code>order</code>:
     <code>order</code> <strong>will not</strong> change ordering of groups after a merge operation
     when <code>max</code> or <code>min</code> is used
 </li><li>
-    Default order, <code>max(relevance())</code>, <strong>does not</strong> require use of
+    Default order, <code>-max(relevance())</code>, <strong>does not</strong> require use of
     <code><a href="#precision">precision</a></code>
 </li></ul>
 </p>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
