### PR TITLE
Kkraune/sidebar

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -52,8 +52,6 @@ docs:
         url: /en/indexing.html
       - page: Document API
         url: /en/document-api-guide.html
-      - page: Document Processing
-        url: /en/document-processing.html
 
   - title: QUERIES
     documents:

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -148,8 +148,6 @@ docs:
         url: /en/jdisc/injecting-components.html
       - page: Chained Components
         url: /en/chained-components.html
-      - page: The Chain Builder
-        url: /en/jdisc/chain-builder.html
       - page: Configuring Java components
         url: /en/configuring-components.html
       - page: Building OSGi Bundles

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -6,8 +6,12 @@ docs:
         url: /
       - page: Vespa Overview
         url: /en/overview.html
+      - page: Features
+        url: /en/features.html
       - page: Getting Started
         url: /en/getting-started.html
+      - page: Getting Started with Ranking
+        url: /en/getting-started-ranking.html
       - page: Quick Start
         url: /en/vespa-quick-start.html
       - page: Frequently Asked Questions
@@ -24,6 +28,8 @@ docs:
         url: /en/use-case-question-answering.html
       - page: "Use case: Text-Image Search"
         url: /en/use-case-text-image-search.html
+      - page: Build and install Vespa
+        url: /en/build-install-vespa.html
 
   - title: DOCUMENTS AND SCHEMAS
     documents:
@@ -35,6 +41,8 @@ docs:
         url: /en/parent-child.html
       - page: Annotations API
         url: /en/annotations.html
+      - page: Concrete document types
+        url: /en/concrete-documents.html
 
   - title: READS AND WRITES
     documents:
@@ -140,8 +148,14 @@ docs:
         url: /en/jdisc/injecting-components.html
       - page: Chained Components
         url: /en/chained-components.html
+      - page: The Chain Builder
+        url: /en/jdisc/chain-builder.html
+      - page: Configuring Java components
+        url: /en/configuring-components.html
       - page: Building OSGi Bundles
         url: /en/jdisc/developing-osgi-bundles.html
+      - page: Bundle Troubleshooting
+        url: /en/jdisc/bundle-troubleshooting.html
       - page: OSGi Bundle Maven Plugin
         url: /en/bundle-plugin.html
       - page: Versioning in the Container
@@ -161,6 +175,16 @@ docs:
         url: /en/cloudconfig/configapi-dev.html
       - page: Developing Config Model Plugins
         url: /en/cloudconfig/cloudconfig-model-plugins.html
+      - page: Developing with the Java Cloud Config API
+        url: /en/cloudconfig/configapi-dev-java.html
+      - page: Using the C++ Cloud config API
+        url: /en/cloudconfig/configapi-dev-cpp.html
+      - page: Configuration Servers
+        url: /en/cloudconfig/configuration-server.html
+      - page: Tenant API
+        url: /en/cloudconfig/tenant-rest-api.html
+      - page: Cloud config generic services
+        url: /en/configapi-dev-genericservices.html
 
   - title: RESULT FORMATS
     documents:
@@ -208,6 +232,8 @@ docs:
         url: /en/performance/rate-limiting-searcher.html
       - page: HTTP/2
         url: /en/performance/http2.html
+      - page: Graceful Search Coverage Degradation
+        url: /en/graceful-degradation.html
 
   - title: OPERATIONS AND PROCEDURES
     documents:
@@ -229,6 +255,10 @@ docs:
         url: /en/docker-containers-in-production.html
       - page: Securing a Vespa installation
         url: /en/securing-your-vespa-installation.html
+      - page: Access Logging
+        url: /en/access-logging.html
+      - page: Config sentinel
+        url: /en/config-sentinel.html
 
   - title: CONFIGURATION REFERENCE
     documents:
@@ -293,6 +323,11 @@ docs:
         url: /en/reference/document-field-path.html
       - page: Document Selector Language
         url: /en/reference/document-select-language.html
+
+  - title: UTIL AND LIBRARIES
+    documents:
+      - page: Predicate Search Java Library
+        url: /en/boolean-library.html
 
   - title: ABOUT THIS SITE
     documents:


### PR DESCRIPTION
- Add a few more links
- The next set is lots of jdisc / components documents - far too many to add to sidebar as-is
-- Some docs can be collapsed into one
-- The rest can be linked from a new index page that focuses on how to write the different components. @gv for ideas and direction for this

@bjormel please merge