### PR TITLE
Set MathJax config, then load script. Smaller equations

### DIFF
--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -32,8 +32,7 @@
 
     <!-- MathJax for formulas -->
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-
+    <script src="/js/load-mathjax.js" async></script>
     <!-- pre Highlight style, ref https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting -->
     <link rel="stylesheet" href="{{ site.baseurl }}/css/native.css">
 </head>

--- a/en/reference/rank-features.html
+++ b/en/reference/rank-features.html
@@ -1075,7 +1075,8 @@ They are cheap to compute even if the query is large.</td></tr>
 <tr><td colspan="3" class="divider" style="background-color: lightgrey;">
 <strong>Utility features</strong></td></tr>
 
-<tr id="foreach(dimension,variable,feature,condition,operation)"><td>foreach(<em>dimension</em>,<em>variable</em>,<em>feature</em>,<em>condition</em>,<em>operation</em>)</td>
+<tr id="foreach(dimension,variable,feature,condition,operation)">
+  <td>foreach(<em>dimension</em>, <em>variable</em>, <em>feature</em>, <em>condition</em>, <em>operation</em>)</td>
   <td>n/a</td>
   <td>
         <p>
@@ -1115,7 +1116,7 @@ They are cheap to compute even if the query is large.</td></tr>
         Lets say you want to calculate the average score of the <em>fieldMatch</em> feature for all index fields,
         but only consider the scores larger than 0. Then you can use the following setup of the <em>foreach</em> feature:
         </p><p>
-        <code>foreach(fields,N,fieldMatch(N),"&gt;0",average)</code>.
+        <code>foreach(fields,N,fieldMatch(N), "&gt;0", average)</code>.
         </p><p>
         Note that when using the conditions <em>&gt;a</em> and <em>&lt;a</em>
         the arguments must be quoted.
@@ -1126,7 +1127,7 @@ They are cheap to compute even if the query is large.</td></tr>
         Let's say you want to calculate the average score of the squared <em>fieldMatch</em> feature score for all index fields.
         Then you can use the following setup of the <em>foreach</em> feature:
         </p><p>
-        <code>foreach(fields,N,rankingExpression("fieldMatch(N)*fieldMatch(N)"),true,average)</code>
+        <code>foreach(fields, N, rankingExpression("fieldMatch(N)*fieldMatch(N)"), true, average)</code>
         </p><p>
         Note that you must quote the expression passed in to the <em>rankingExpression</em> feature.
         </p>

--- a/js/load-mathjax.js
+++ b/js/load-mathjax.js
@@ -1,0 +1,19 @@
+
+window.MathJax = {
+    //chtml: {
+    //    scale: 0.75,
+    //    minScale: .5
+    //},
+    svg: {  // http://docs.mathjax.org/en/latest/options/output/svg.html
+        scale: 0.75,
+        minScale: .5
+    }
+};
+
+(function () {
+    let script = document.createElement('script');
+    //script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js';
+    script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js';
+    script.async = true;
+    document.head.appendChild(script);
+})();


### PR DESCRIPTION
- Equations look better with somewhat smaller text, now easy to configure.
- Using SVG instead of CommonHTML - will see how it looks on smaller screens / load times.

The table in reference/rank-features.html is still too wide, need to debug more to find the offending element