### PR TITLE
Try to make distance-metrics section clearer

### DIFF
--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -1614,11 +1614,12 @@ this high level guide</a> based on
 section 3.1 Order Preserving Transformations in this paper</a>. 
 The downside of this transformation is that maximum length or magnitude 
 needs to be known prior to indexing the vectors in Vespa, making it only practical for batch oriented vector indexing.</p>
-
+<p>
 The <a href="https://github.com/vespa-engine/sample-apps/tree/master/dense-passage-retrieval-with-ann">Dense passage retrieval sample app</a>
 uses the mentioned transformation as the original text to vector model was trained using MIP. 
-The <a href="https://github.com/vespa-engine/sample-apps/tree/master/msmarco-ranking">Ms Marco ranking app</a> uses
-a text to vector model which used cosine similarity during training so no transformation required.
+The <a href="https://github.com/vespa-engine/sample-apps/tree/master/msmarco-ranking">MS Marco ranking sample app</a> uses
+a text to vector model which used cosine similarity during training so no transformation was required. 
+</p>
 
 <pre>
 distance-metric: [metric]

--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -1595,18 +1595,18 @@ must obey all the defining properties of a <a href="https://en.wikipedia.org/wik
 <p>The distance metric used must match the distance metric used during metric representation learning (model). 
 If you are using an "off-the-shelf" model to vectorize your data, please ensure that the distance metric matches
 the distance metric suggested used with the model. Different type
-of vectorization models uses different type of distance metrics.</p>
+of vectorization models use different type of distance metrics.</p>
 
 {% include note.html content="
-Some vectorization models, including matrix factorization, uses \"maximum inner product\" (MIP),
-with vectors that aren't normalized to unit vectors. These models uses both direction and magnitude. 
+Some vectorization models, including matrix factorization, use \"maximum inner product\" (MIP),
+with vectors that aren't normalized to unit vectors. These models use both direction and magnitude. 
 <strong>MIP</strong> cannot directly be represented using nearest neighbor search distance metrics 
 as it does not obey the metric space properties (triangle inequality). 
 Post processing vectors from a MIP similarity model to
 unit length vectors will cause information loss which will impact the accuracy.  
 "%}
 <p>
-It's possible to do a order preserving transformation of a maximum inner product space  
+It's possible to do an order preserving transformation of a maximum inner product space  
 to metric space by knowing the maximum vector length (max norm).  
 See <a href="https://towardsdatascience.com/maximum-inner-product-search-using-nearest-neighbor-search-algorithms-c125d24777ef">
 this high level guide</a> based on 

--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -1580,8 +1580,46 @@ sorting {
 <p>
 Contained in <code><a href="#attribute">attribute</a></code>.
 Specifies the distance metric to use with the <a href="query-language-reference.html#nearestneighbor">nearestNeighbor</a>
-query operator to calculate the distance between document positions and the query position.
+query operator to calculate the distance between document positions and the query position. 
 Only relevant for tensor attribute fields.
+
+Distance metrics used with <a href="../approximate-nn-hnsw.html">HNSW</a> 
+must obey all the defining properties of a <a href="https://en.wikipedia.org/wiki/Metric_space">metric space</a>:</p>
+
+<ul>
+  <li>Distance is symmetric: <code>distance(q,d) = distance(d,q)</code></li> 
+  <li>Distance is larger than 0 and the distance from any point to itself is zero. <code>distance(q,q) = 0</code></li> 
+  <li>Distance obeys the <a href="https://en.wikipedia.org/wiki/Triangle_inequality">triangle inequality</a>:
+ <code>distance(q,d) &gt;= distance(q,r) + distance(r,d)</code>  
+</ul>
+<p>The distance metric used must match the distance metric used during metric representation learning (model). 
+If you are using an "off-the-shelf" model to vectorize your data, please ensure that the distance metric matches
+the distance metric suggested used with the model. Different type
+of vectorization models uses different type of distance metrics.</p>
+
+{% include note.html content="
+Some vectorization models, including matrix factorization, uses \"maximum inner product\" (MIP),
+with vectors that aren't normalized to unit vectors. These models uses both direction and magnitude. 
+<strong>MIP</strong> cannot directly be represented using nearest neighbor search distance metrics 
+as it does not obey the metric space properties (triangle inequality). 
+Post processing vectors from a MIP similarity model to
+unit length vectors will cause information loss which will impact the accuracy.  
+"%}
+<p>
+It's possible to do a order preserving transformation of a maximum inner product space  
+to metric space by knowing the maximum vector length (max norm).  
+See <a href="https://towardsdatascience.com/maximum-inner-product-search-using-nearest-neighbor-search-algorithms-c125d24777ef">
+this high level guide</a> based on 
+<a href="https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/XboxInnerProduct.pdf">
+section 3.1 Order Preserving Transformations in this paper</a>. 
+The downside of this transformation is that maximum length or magnitude 
+needs to be known prior to indexing the vectors in Vespa, making it only practical for batch oriented vector indexing.</p>
+
+The <a href="https://github.com/vespa-engine/sample-apps/tree/master/dense-passage-retrieval-with-ann">Dense passage retrieval sample app</a>
+uses the mentioned transformation as the original text to vector model was trained using MIP. 
+The <a href="https://github.com/vespa-engine/sample-apps/tree/master/msmarco-ranking">Ms Marco ranking app</a> uses
+a text to vector model which used cosine similarity during training so no transformation required.
+
 <pre>
 distance-metric: [metric]
 </pre>
@@ -1593,9 +1631,11 @@ distance-metric: [metric]
   <tr>
     <td><code>euclidean</code></td>
     <td>
-    The usual <code>sqrt(sum(x^2))</code>
+    The squared euclidean distance. Calculated by  
+    <code>distance(q,d) = sqrt(sum((q - d)^2))</code>. 
+    The
     <a href="https://en.wikipedia.org/wiki/Euclidean_distance">Euclidean distance</a> metric.
-    This is the default.
+    This is the default distance-metric used if not specified.
     </td>
   </tr>
   <tr>
@@ -1606,27 +1646,34 @@ distance-metric: [metric]
     Note that this is closely related to the
     <a href="https://en.wikipedia.org/wiki/Cosine_similarity">cosine similarity</a>
     which is just <code>cos(angle)</code>.
-    If possible, it's better for performance to normalize the vectors to unit length
-    and use the <code>innerproduct</code> metric instead.
+    If possible, it's slightly better for performance to normalize both query and document vectors to unit vectors 
+    and use the <code>innerproduct</code> metric instead. 
     </td>
   </tr>
   <tr>
     <td><code>innerproduct</code></td>
     <td>
-    Should only be used when all tensors are normalized vectors to unit length (ensure that <code>sqrt(sum(x^2)) == 1</code>).
-    This computes the
+    <strong>
+    <p>Must only be used</strong> when query and document vectors are normalized to unit vectors. 
+     There is no runtime 
+     validation which checks that vectors are unit vectors as it would impact performance negatively. 
+     Using <em>innerproduct</em> with vectors that are not unit vectors violates the mentioned metric space properties
+     and causes unpredictable nearest neighbor search</a>.
+     </p> 
+    <p>
+    The length, magnitude, or norm of a vector <em>x</em> is calculated as <code>sqrt(sum(power(x,2)))</code>.
+    The unit length normalized
+    vector is given by <code>x/sqrt(sum(power(x,2)))</code>.
+    </p>
+    <p>
+    The Vespa <em>innerproduct</em> computes the
     <a href="https://en.wikipedia.org/wiki/Cosine_similarity">cosine similarity</a>
     and uses <code>1.0 - cos(angle)</code> as the distance metric.
-    In this case, it gives exactly the same ordering as <code>angular</code> distance,
-    but with a distance in the range [0,2] (since cosine similarity has range [1,-1],
+
+    It gives exactly the same ordering as <code>angular</code> distance,
+    but with a distance in the range [0,2], since cosine similarity has range [1,-1],
     so the end result is 0.0 for same direction vectors,
-    1.0 for a right angle, and 2.0 for vectors with exactly opposite directions).
-    {% include note.html content="
-      Some applications will search for \"maximal inner product\",
-      with vectors that aren't normalized
-      (where a vector of length 10 will give a double score compared to a vector of length 5 in the same direction).
-      But this is impossible using Nearest-Neighbor search,
-      since this type of inner product cannot be used as (or transformed into) a distance metric."%}
+    1.0 for a right angle, and 2.0 for vectors with exactly opposite directions.</p>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
An attempt at making the distance-metric section clearer. I hope you can review this carefully. 

Main points

- Some attempt to use innerproduct distance-metric without normalizing vectors to unit vectors. This breaks metric space properties. 
- Some attempt to transform maximum inner product models (MIP) to unit vectors just by a post-processing step, a transformation that does not preserve the order. 



I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
