### PR TITLE
Use more resources

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -49,11 +49,11 @@ jobs:
       - VESPA_TEAM_API_KEY
     image: vespaengine/vespa-pipeline
     annotations:
-      screwdriver.cd/cpu: HIGH
-      screwdriver.cd/ram: HIGH
+      screwdriver.cd/cpu: TURBO
+      screwdriver.cd/ram: TURBO
       screwdriver.cd/dockerEnabled: true
-      screwdriver.cd/dockerCpu: HIGH
-      screwdriver.cd/dockerRam: HIGH
+      screwdriver.cd/dockerCpu: TURBO
+      screwdriver.cd/dockerRam: TURBO
       screwdriver.cd/buildPeriodically: H H(0-5) * * 1-5 # some time between 12:00 AM UTC (midnight) to 5:59 AM UTC Mon-Fri
     steps:
       - *install-deps


### PR DESCRIPTION
@lesters This is familiar:

````
20:48:21 [INFO] Building jar: /home/app/target/album-recommendation-random-data-1.0-SNAPSHOT-jar-with-dependencies.jar
20:48:21 unexpected EOF
20:48:21 sentinel-111591> exit code: 1
20:48:21 
20:48:21 ERROR: Command 'docker build album-recommendation-random-data --tag random-data-feeder' returned code 1
````

I seem to remember a problem with the doc testing script and using mvn, but I don't remember if it was a memory problem or if there was a code fix you did / workaround. We were working on one of @jobergum 's sample apps. Will look deeper into git history
