### PR TITLE
Kkraune/monitoring test

### DIFF
--- a/en/operations/monitoring.html
+++ b/en/operations/monitoring.html
@@ -187,10 +187,16 @@ $ docker run --detach --name sample-apps-grafana \
     <p><strong>Build the Random Data Feeder:</strong></p>
     <div class="pre-parent">
       <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre data-test="exec">
+<pre>
 $ docker build album-recommendation-random-data --tag random-data-feeder
 </pre>
     </div>
+<pre data-test="exec" style="display:none">
+$ docker build album-recommendation-random-data --no-cache --tag random-data-feeder -o out
+</pre>
+<pre data-test="exec" style="display:none">
+$ ls out/usr/local/lib/app.jar
+</pre>
     <p>
       This builds the
       <a href="https://github.com/vespa-engine/sample-apps/tree/master/operations/album-recommendation-monitoring/album-recommendation-random-data">

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,7 +15,7 @@ shared:
         pip3 install -qqq -r test/requirements.txt --user
         yum install -y --setopt=skip_missing_names_on_install=False unzip openssl yum-utils
         yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-        yum install -y --setopt=skip_missing_names_on_install=False docker-ce docker-ce-cli containerd.io docker-compose
+        yum install -y --setopt=skip_missing_names_on_install=False docker-ce docker-ce-cli containerd.io
         export VESPA_CLI_VERSION=$(curl -fsSL https://api.github.com/repos/vespa-engine/vespa/releases/latest | grep -Po '"tag_name": "v\K.*?(?=")')
         curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt
         ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -49,11 +49,11 @@ jobs:
       - VESPA_TEAM_API_KEY
     image: vespaengine/vespa-pipeline
     annotations:
-      screwdriver.cd/cpu: TURBO
-      screwdriver.cd/ram: TURBO
+      screwdriver.cd/cpu: HIGH
+      screwdriver.cd/ram: HIGH
       screwdriver.cd/dockerEnabled: true
-      screwdriver.cd/dockerCpu: TURBO
-      screwdriver.cd/dockerRam: TURBO
+      screwdriver.cd/dockerCpu: HIGH
+      screwdriver.cd/dockerRam: HIGH
       screwdriver.cd/buildPeriodically: H H(0-5) * * 1-5 # some time between 12:00 AM UTC (midnight) to 5:59 AM UTC Mon-Fri
     steps:
       - *install-deps


### PR DESCRIPTION
Lets try not installing the built docker image, just build it - maybe this will keep the screwdriver docker daemon alive 