### PR TITLE
Use weakAnd in Doc Search

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -48,7 +48,7 @@ const handleLocationQuery = () => {
     document.getElementById("searchinput").value = query;
     result.innerHTML = `Searching for '${query}' ...`;
     fetch(
-      `https://doc-search.vespa.oath.cloud/search/?yql=select%20*%20from%20doc%20where%20userInput(@input)%3B&hits=25&ranking=documentation&locale=en-US&input=${escape(query)}`
+      `https://doc-search.vespa.oath.cloud/search/?yql=select%20*%20from%20doc%20where%20userInput(@input)%3B&hits=25&ranking=documentation&type=weakAnd&locale=en-US&input=${escape(query)}`
     )
           .then((res) => res.json())
           .then((res) => handleResults(res.root.children))


### PR DESCRIPTION
example diff:

````
$ curl 'https://doc-search.vespa.oath.cloud/search/?query=rank+profile+feature+inherits+xgboost&ranking=documentation' | jq '.root.children[] | .id' 

"id:open:doc::open/en/xgboost.html"
"id:open:doc::open/en/learning-to-rank.html"
"id:open:doc::open/en/lightgbm.html"
"id:open:doc::open/en/phased-ranking.html"
"id:open:doc::open/en/tutorials/text-search-ml.html"
"id:blog:doc::blog/parent-child-joins-tensors-content-recommendation/"
````

````
$ curl 'https://doc-search.vespa.oath.cloud/search/?query=rank+profile+feature+inherits+xgboost&ranking=documentation&type=weakAnd' | jq '.root.children[] | .id' 
"id:open:doc::open/en/xgboost.html"
"id:open:doc::open/en/learning-to-rank.html"
"id:open:doc::open/en/lightgbm.html"
"id:open:doc::open/en/reference/rank-feature-configuration.html"
"id:open:doc::open/en/phased-ranking.html"
"id:open:doc::open/en/reference/rank-features.html"
"id:open:doc::open/en/ranking.html"
"id:open:doc::open/en/tutorials/text-search-ml.html"
"id:open:doc::open/en/reference/rank-types.html"
"id:open:doc::open/en/schemas.html"

````
