### PR TITLE
Simplify YQL queries

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -13,11 +13,11 @@ Human input is parsed heuristically, while application queries are formulated in
 A query URL looks like:
 </p>
 <pre>
-http://myhost.mydomain.com:8080/search/?yql=select%20%2A%20from%20sources%20%2A%20where%20text%20contains%20%22blues%22%3B
+http://myhost.mydomain.com:8080/search/?yql=select%20%2A%20from%20sources%20%2A%20where%20text%20contains%20%22blues%22
 </pre>
 In other words, <em>yql</em> contains:
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20sources%20%2A%20where%20text%20contains%20%22blues%22%3B
+select%20%2A%20from%20sources%20%2A%20where%20text%20contains%20%22blues%22
 </pre>
 <p>
 This <a href="schema-reference.html#match">matches</a> all documents
@@ -28,6 +28,7 @@ where the field named <em>text</em> contains the word <em>blues</em>.
 </p>
 {% include note.html content="There is no way to query for a field equals <code>null</code> or <code>NaN</code>.
 Work around using a <code>not</code> clause."%}
+{% include note.html content="Since Vespa 7.520.3, YQL queries do not require a semicolon at the end."%}
 
 
 
@@ -38,14 +39,14 @@ Work around using a <code>not</code> clause."%}
 Vespa will hide other fields in the matching documents.
 </p>
 <pre class="urlunencode" oncopy="">
-select%20price,isbn%20from%20sources%20%2A%20where%20title%20contains%20%22madonna%22%3B
+select%20price,isbn%20from%20sources%20%2A%20where%20title%20contains%20%22madonna%22
 </pre>
 <p>
   The above explicitly requests the fields "price" and "isbn" (from all sources).
   To request all fields, use an asterisk as field selection:
 </p>
 <pre class="urlunencode" oncopy="">
-select%20*%20from%20sources%20%2A%20where%20title%20contains%20%22madonna%22%3B
+select%20*%20from%20sources%20%2A%20where%20title%20contains%20%22madonna%22
 </pre>
 
 
@@ -57,7 +58,7 @@ select%20*%20from%20sources%20%2A%20where%20title%20contains%20%22madonna%22%3B
   <a href="query-api-reference.html#model.sources">sources</a> to query. Example:
 </p>
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20music%20where%20title%20contains%20%22madonna%22%3B
+select%20%2A%20from%20music%20where%20title%20contains%20%22madonna%22
 </pre>
 <p>
   queries all document types in the <em>music</em> content cluster or federation source. Query in:
@@ -94,10 +95,10 @@ select%20%2A%20from%20music%20where%20title%20contains%20%22madonna%22%3B
     The following numeric operators are available:
     <em>=, &lt;, &gt;, &lt;=, &gt;=, range(field, lower bound, upper bound)</em>
 <pre class="urlunencode" oncopy="">
-where%20500%20%3E%3D%20price%3B
+where%20500%20%3E%3D%20price
 </pre>
 <pre class="urlunencode" oncopy="">
-where%20range%28fieldname%2C%200%2C%205000000000L%29%3B
+where%20range%28fieldname%2C%200%2C%205000000000L%29
 </pre>
     <p>Numbers must be in the signed 32-bit range, or the string "Infinity"/"-Infinity".
     Input 64-bit signed numbers using <em>L</em> as suffix.
@@ -113,7 +114,7 @@ where%20range%28fieldname%2C%200%2C%205000000000L%29%3B
     is always using a positive number of hits
     (as a negative number of hits does not make much sense)
     and combine this with either of the boolean annotations "ascending" and "descending" (but not both).
-    Then "[{"hitLimit": 38, "descending": true}]" would be equivalent to setting it to -38,
+    Then <code>{hitLimit: 38, descending: true}</code> would be equivalent to setting it to -38,
     i.e. only populate with 38 hits and start from upper boundary, i.e. descending order. Note that hitLimit will limit
     the number of documents that are considered. It is dangerous to use if you have other filters too. This is a powerful optimisation
     that must be used with care. The set of documents to be considered will be limited upfront by only selecting the N best according to
@@ -133,7 +134,7 @@ where%20range%28fieldname%2C%200%2C%205000000000L%29%3B
     <p>
     The boolean operator is: =
 <pre class="urlunencode" oncopy="">
-where%20alive%20%3D%20true%3B
+where%20alive%20%3D%20true
 </pre>
   </td></tr>
 
@@ -148,7 +149,7 @@ where%20alive%20%3D%20true%3B
     to be done depends on the field settings in the schema.
     </p>
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%3B
+where%20title%20contains%20%22madonna%22
 </pre>
     <p>
     The matched field must be an
@@ -161,9 +162,9 @@ where%20title%20contains%20%22madonna%22%3B
     to match the field(s) searched.
     Explicitly control tokenization by using annotations:
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%28%5B%7B%22stem%22%3A%20false%7D%5D%22madonna%22%29%3B
+where%20title%20contains%20(%7Bstem%3A%20false%7D%22madonna%22)
 </pre>
-    <p>Note the use of parentheses to control precedence.</p>
+    <p>Note the use of parentheses to control precedence when using annotations.</p>
 
     <table class="table">
       <tr id="and"><th>and</th><td>
@@ -172,7 +173,7 @@ where%20title%20contains%20%28%5B%7B%22stem%22%3A%20false%7D%5D%22madonna%22%29%
         <a href="#userquery">userQuery</a>, logically inverted statements -
         and contains statements as arguments:
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%20and%20title%20contains%20%22saint%22%3B
+where%20title%20contains%20%22madonna%22%20and%20title%20contains%20%22saint%22
 </pre>
       </td></tr>
       <tr id="or"><th>or</th><td>
@@ -180,7 +181,7 @@ where%20title%20contains%20%22madonna%22%20and%20title%20contains%20%22saint%22%
         <em>or</em> accepts other <em>or</em> statements, <em>and</em> statements,
         <a href="#userquery">userQuery</a> - and contains statements as arguments:
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%20or%20title%20contains%20%22saint%22%3B
+where%20title%20contains%20%22madonna%22%20or%20title%20contains%20%22saint%22
 </pre>
 
       </td></tr>
@@ -188,21 +189,14 @@ where%20title%20contains%20%22madonna%22%20or%20title%20contains%20%22saint%22%3
         <p>
         Use the <em>!</em> operator to match document that does <i>not</i> satisfy some condition
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%20and%20%21%28title%20contains%20%22saint%22%29%3B
+where%20title%20contains%20%22madonna%22%20and%20%21%28title%20contains%20%22saint%22%29
 </pre>
       </td></tr>
 
       <tr id="phrase"><th>phrase</th><td>
           <p>Phrases are expressed as a function</p>
-
 <pre class="urlunencode" oncopy="">
-where%20text%20contains%20phrase%28%22st%22%2C%20%22louis%22%2C%20%22blues%22%29%3B
-</pre>
-        It can be necessary to pass along extra information about a search term,
-        for instance when specifying a term should not be stemmed before matching.
-        This is done by using YQL annotations:
-<pre class="urlunencode" oncopy="">
-where%20text%20contains%20%28%5B%7B%22stem%22%3A%20false%7D%5D%22blues%22%29%3B
+where%20text%20contains%20phrase%28%22st%22%2C%20%22louis%22%2C%20%22blues%22%29
 </pre>
         <p>
       </td></tr>
@@ -213,15 +207,15 @@ where%20text%20contains%20%28%5B%7B%22stem%22%3A%20false%7D%5D%22blues%22%29%3B
         to count as a match.
         The default distance is 2, meaning match if the words have up to one separating word.
 <pre class="urlunencode" oncopy="">
-where%20text%20contains%20%28%5B%20%7B%22distance%22%3A%205%7D%20%5Dnear%28%22a%22%2C%20%22b%22%29%29%3B
+where%20text%20contains%20%28%7Bdistance%3A%205%7Dnear%28%22a%22%2C%20%22b%22%29%29
 </pre>
       </td></tr>
       <tr id="onear"><th>onear</th><td>
         <p>
         <em>onear()</em> (ordered near) is like <em>near()</em>,
         but also requires the terms in the document having the same order
-        as given in the function (i.e. it is a phrase allowing other words interleaved). With distance 1 <em>onear()</em> has the same 
-                semantics as <em>phrase()</em>.
+        as given in the function (i.e. it is a phrase allowing other words interleaved).
+        With distance 1 <em>onear()</em> has the same semantics as <em>phrase()</em>.
         </p>
       </td></tr>
       <tr id="sameelement"><th>sameElement</th><td>
@@ -259,8 +253,7 @@ field identities type map&lt;string, person&gt; {
         However, that is what <em>sameElement</em> ensures.
         </p>
 <pre class="urlunencode" oncopy="">
-where%20persons%20contains%20sameElement%28first_name%20contains%20'Joe',
-%20last_name%20contains%20'Smith',%20year_of_birth%20%3C%201940%29%3B
+where%20persons%20contains%20sameElement%28first_name%20contains%20'Joe',%20last_name%20contains%20'Smith',%20year_of_birth%20%3C%201940%29
 </pre>
         <p>
         The above returns all documents containing Joe Smith born before 1940 in the <em>persons</em> array.
@@ -270,8 +263,7 @@ where%20persons%20contains%20sameElement%28first_name%20contains%20'Joe',
         The above example with the <em>identities</em> map looks like this:
         </p>
 <pre class="urlunencode" oncopy="">
-where%20identities%20contains%20sameElement%28key%20contains%20'father',
-%20value.first_name%20contains%20'Joe',%20value.last_name%20contains%20'Smith',%20value.year_of_birth%20%3C%201940%29%3B
+where%20identities%20contains%20sameElement%28key%20contains%20'father',%20value.first_name%20contains%20'Joe',%20value.last_name%20contains%20'Smith',%20value.year_of_birth%20%3C%201940%29
 </pre>
         <p>
         The above returns all documents that have tagged Joe Smith born before 1940 as a 'father'.
@@ -285,7 +277,7 @@ where%20identities%20contains%20sameElement%28key%20contains%20'father',
         the <em>equiv()</em> operator behaves like a special case of "or".
         </p>
 <pre class="urlunencode" oncopy="">
-where%20fieldName%20contains%20equiv%28%22A%22%2C%22B%22%29%3B
+where%20fieldName%20contains%20equiv%28%22A%22%2C%22B%22%29
 </pre>
         <p>
         In many cases, the OR operator will give the same results as an EQUIV.
@@ -318,7 +310,7 @@ where%20fieldName%20contains%20equiv%28%22A%22%2C%22B%22%29%3B
           <p>Used to search for urls indexed using the
             <a href="schema-reference.html#type:uri">uri field type</a>.</p>
           <pre class="urlunencode" oncopy="">
-where%20myUrlField%20contains%20uri(%22vespa.ai%2Ffoo%22)%3B
+where%20myUrlField%20contains%20uri(%22vespa.ai%2Ffoo%22)
 </pre>
           <p>Various subfields are supported to search components of the URL, see the field type definition.
               The <code>hostname</code> subfield supports anchoring to the start and/or end of the hostname,
@@ -326,11 +318,11 @@ where%20myUrlField%20contains%20uri(%22vespa.ai%2Ffoo%22)%3B
               Anchoring to the end is on by default while anchoring to the start is not. Hence
           </p>
           <pre class="urlunencode" oncopy="">
-where%20myUrlField.hostname%20contains%20uri(%5C%22vespa.ai%5C%22)%3B
+where%20myUrlField.hostname%20contains%20uri(%5C%22vespa.ai%5C%22)
 </pre>
           <p>will match vespa.ai and docs.vespa.ai and so on, while</p>
           <pre class="urlunencode" oncopy="">
-where%20myUrlField.hostname%20contains%20(%5B%7B%22startAnchor%22%3A%20true%20%7D%5D%20uri(%22vespa.ai%22))%3B
+where%20myUrlField.hostname%20contains%20(%7BstartAnchor%3A%20true%7Duri(%22vespa.ai%22))
 </pre>
         <p>will only match vespa.ai.</p>
       </td></tr>
@@ -345,7 +337,7 @@ where%20myUrlField.hostname%20contains%20(%5B%7B%22startAnchor%22%3A%20true%20%7
     This example becomes a substring search:
     </p>
 <pre class="urlunencode" oncopy="">
-where%20title%20matches%20%22madonna%22%3B
+where%20title%20matches%20%22madonna%22
 </pre>
     <p>This example matches both <code>madonna</code>, <code>madona</code> and with any number of <code>n</code>s:</p>
 <pre class="urlunencode" oncopy="">
@@ -353,7 +345,7 @@ where%20title%20matches%20%22mado%5Bn%5D%2Ba%22%3B
 </pre>
     <p>Here you match any string starting with <code>mad</code>:</p>
 <pre class="urlunencode" oncopy="">
-where%20title%20matches%20%22^mad%22%3B
+where%20title%20matches%20%22^mad%22
 </pre>
     <p>
     <strong>Note:</strong> Only <a href="schema-reference.html#attribute">attribute</a>
@@ -370,44 +362,40 @@ where%20title%20matches%20%22^mad%22%3B
     whether it should simply be segmented or parsed as a query.
     </p>
 <pre class="urlunencode" oncopy="">
-yql=select%20%2A%20from%20sources%20%2A%20where%20userInput%28%40animal%29%3B&amp;animal=panda
+yql=select%20%2A%20from%20sources%20%2A%20where%20userInput%28%40animal%29&amp;animal=panda
 </pre>
     <p>
     Here, the userInput() function will access the query property "animal",
     and parse the property value as an "ALL" query, resulting in the following expression:
     </p>
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20sources%20%2A%20where%20default%20contains%20%22panda%22%3B
+select%20%2A%20from%20sources%20%2A%20where%20default%20contains%20%22panda%22
 </pre>
     Now, if we changed the value of "animal" without changing the rest of the expression:
 <pre class="urlunencode" oncopy="">
-yql=select%20%2A%20from%20sources%20%2A%20where%20userInput%28%40animal%29%3B&amp;animal=panda%20smokey
+yql=select%20%2A%20from%20sources%20%2A%20where%20userInput%28%40animal%29&amp;animal=panda%20smokey
 </pre>
     The result would be:
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20sources%20%2A%20where%20default%20contains%20%22panda%22%20and%20default%20contains%20%22smokey%22%3B
+select%20%2A%20from%20sources%20%2A%20where%20default%20contains%20%22panda%22%20and%20default%20contains%20%22smokey%22
 </pre>
     Now, let's assume we want to combine multiple query properties and have a more complex expression as well:
 <pre class="urlunencode" oncopy="">
-yql=select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29
-%20and%20%28userInput%28%40animal%29%20or%20userInput%28%40teddy%29%29%3B&amp;animal=panda&amp;teddy=bear%20roosevelt
+yql=select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29%20and%20%28userInput%28%40animal%29%20or%20userInput%28%40teddy%29%29&amp;animal=panda&amp;teddy=bear%20roosevelt
 </pre>
     The resulting YQL expression will be:
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29
-%20and%20%28default%20contains%20%22panda%22%20or%20%28default%20contains%20%22bear%22%20and%20default%20contains%20%22roosevelt%22%29%29%3B
+select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29%20and%20%28default%20contains%20%22panda%22%20or%20%28default%20contains%20%22bear%22%20and%20default%20contains%20%22roosevelt%22%29%29
 </pre>
     Now, consider we do not want the "teddy" field to be treated as its own query segment,
     it should only be segmented with the linguistic libraries to get recall.
     We can do this by adding a "grammar" annotation to the userInput() call:
 <pre class="urlunencode" oncopy="">
-yql=select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29
-%20and%20%28userInput%28%40animal%29%20or%20%5B%7B%22grammar%22%3A%20%22segment%22%7D%5DuserInput%28%40teddy%29%29%3B&amp;animal=panda&amp;teddy=bear%20roosevelt
+yql=select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29%20and%20%28userInput%28%40animal%29%20or%20%7Bgrammar%3A%20%22segment%22%7DuserInput%28%40teddy%29%29&amp;animal=panda&amp;teddy=bear%20roosevelt
 </pre>
     Then, the linguistic library will split on space, and the resulting expression is:
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29
-%20and%20%28default%20contains%20%22panda%22%20or%20default%20contains%20phrase%28%22bear%22%2C%20%22roosevelt%22%29%29%3B
+select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29%20and%20%28default%20contains%20%22panda%22%20or%20default%20contains%20phrase%28%22bear%22%2C%20%22roosevelt%22%29%29
 </pre>
     <p>
     Instead of a variable reference,
@@ -492,13 +480,8 @@ select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%2
     </p><p>
     The user query is first parsed,
     then the resulting tree is inserted into the corresponding place in the YQL query tree. Example:
-
-    query=abc def -ghi&amp;
-    type=all&amp;
-    yql=select * from sources * where vendor contains "brick and mortar" AND price &lt; 50 AND userQuery();
-    
 <pre class="urlunencode" oncopy="">
-query%3Dabc%20def%20-ghi%26%0Atype%3Dall%26%0Ayql%3Dselect%20%2A%20from%20sources%20%2A%20where%20vendor%20contains%20%22brick%20and%20mortar%22%20AND%20price%20%3C%2050%20AND%20userQuery%28%29%3B
+query%3Dabc%20def%20-ghi%26%0Atype%3Dall%26%0Ayql%3Dselect%20%2A%20from%20sources%20%2A%20where%20vendor%20contains%20%22brick%20and%20mortar%22%20AND%20price%20%3C%2050%20AND%20userQuery%28%29
 </pre>
     <p>This evaluates to a query where:</p>
     <ul>
@@ -515,7 +498,7 @@ query%3Dabc%20def%20-ghi%26%0Atype%3Dall%26%0Ayql%3Dselect%20%2A%20from%20source
     but all arguments are used for calculating rank score.
     </p>
 <pre class="urlunencode" oncopy="">
-where%20rank%28a%20contains%20%22A%22%2C%20b%20contains%20%22B%22%29%3B
+where%20rank%28a%20contains%20%22A%22%2C%20b%20contains%20%22B%22%29
 </pre>
   </td></tr>
   <tr id="dotproduct"><th>dotProduct</th><td>
@@ -524,7 +507,7 @@ where%20rank%28a%20contains%20%22A%22%2C%20b%20contains%20%22B%22%29%3B
     in the query and a weighted set field in the document as its rank score contribution:
     </p>
 <pre class="urlunencode" oncopy="">
-where%20dotProduct%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29%3B
+where%20dotProduct%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29
 </pre>
     <p>
     The result is stored as a <a href="../multivalue-query-operators.html#raw-scores-and-query-item-labeling">raw score</a>.
@@ -538,7 +521,8 @@ where%20dotProduct%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29%3B
     for a discussion of usage and examples.
     </p>
     <p>
-    The list of terms may also be specified as a separate parameter: <code>where dotProduct(description, @myterms);</code>,
+    The list of terms may also be specified as a separate parameter:
+    <code>where dotProduct(description, @myterms)</code>,
     where a separate parameter "myterms" must then be passed containing the terms as a string.
     Passing the terms as a separate parameter is <b>much faster</b> when the term list is long.
     </p>
@@ -584,7 +568,7 @@ where%20dotProduct%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29%3B
     Each matched weight will be represented as a standard occurrence on position 0 in element 0.
     </p>
 <pre class="urlunencode" oncopy="">
-where%20weightedSet%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29%3B
+where%20weightedSet%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29
 </pre>
     <p>
     <em>weightedSet</em> has similar semantics to <a href="#equiv">equiv</a>,
@@ -599,7 +583,8 @@ where%20weightedSet%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29%3B
     Also see <a href="../performance/feature-tuning.html#multi-lookup-set-filtering">multi-lookup set filtering</a>.
     </p>
     <p>
-    The list of terms may also be specified as a separate parameter: <code>where weightedSet(description, @myterms);</code>,
+    The list of terms may also be specified as a separate parameter:
+    <code>where weightedSet(description, @myterms)</code>,
     where a separate parameter "myterms" must then be passed containing the terms as a string.
     Passing the terms as a separate parameter is <b>much faster</b> when the term list is long.
     </p>
@@ -649,21 +634,21 @@ where%20weightedSet%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29%3B
     <em>wand</em> also allows numeric arguments, then the search argument is an array of arrays of length two.
     In each pair, the first number is the search term, the second its weight:
 <pre class="urlunencode" oncopy="">
-where%20wand%28description%2C%20%5B%5B11%2C1%5D%2C%20%5B37%2C2%5D%5D%29%3B
+where%20wand%28description%2C%20%5B%5B11%2C1%5D%2C%20%5B37%2C2%5D%5D%29
 </pre>
     <p>
     Both <a href="#wand">wand</a> and <em>weakAnd</em> support the annotations <em>scoreThreshold</em>,
     which is a double for wand and an integer for weakAnd. This threshold specifies the minimum rank score for hits to include. 
     The <em>targetHits</em> annotation sets the wanted number of hits exposed
     to the real first-phase ranking function per content node.
-    [Note: this parameter was previously named <em>targetNumHits</em> - the old variant still works for backwards
-    compatibility until Vespa 8.]
+    {% include note.html content="<em>targetHits</em> was previously named <em>targetNumHits</em> -
+      the old variant still works for backwards compatibility until Vespa 8."%}
     The wand/weakAnd operator will both
     expose candidates that were evaluated to the first-phase and not only the top-k. 
     By default, <em>targetHits</em> is 100. Note that total hit count becomes inaccurate when using wand/weakAnd.
     </p>
     <p>
-    The list of terms may also be specified as a separate parameter: <code>where wand(description, @myterms);</code>,
+    The list of terms may also be specified as a separate parameter: <code>where wand(description, @myterms)</code>,
     where a separate parameter "myterms" must then be passed containing the terms as a string.
     Passing the terms as a separate parameter is <b>much faster</b> when the term list is long.
     </p>
@@ -677,7 +662,7 @@ where%20wand%28description%2C%20%5B%5B11%2C1%5D%2C%20%5B37%2C2%5D%5D%29%3B
     do not set <em>targetHits</em> less than the configured rank-profile's rerank-count.
     </p>
 <pre class="urlunencode" oncopy="">
-where%20%5B%20%7B%22scoreThreshold%22%3A%200.13%2C%20%22targetHits%22%3A%207%7D%20%5Dwand%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29%3B
+where%20(%7BscoreThreshold%3A%200.13%2C%20targetHits%3A%207%7Dwand(description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D))
 </pre>
     <p>
      Refer to <a href="../using-wand-with-vespa.html">using wand</a> for a usage and examples.
@@ -728,21 +713,21 @@ where%20%5B%20%7B%22scoreThreshold%22%3A%200.13%2C%20%22targetHits%22%3A%207%7D%
     This function can be seen as an optimized <a href="#or">or</a>:
     </p>
 <pre class="urlunencode" oncopy="">
-where%20weakAnd%28a%20contains%20%22A%22%2C%20b%20contains%20%22B%22%29%3B
+where%20weakAnd%28a%20contains%20%22A%22%2C%20b%20contains%20%22B%22%29
 </pre>
     <p>
     Both <a href="#wand">wand</a> and <em>weakAnd</em> support the annotations <em>scoreThreshold</em>,
     which is a double for wand and an integer for weakAnd. This threshold specifies the minimum rank score for hits to include. 
     The <em>targetHits</em> annotation sets the wanted number of hits exposed
     to the real first-phase ranking function per content node.
-    [Note: this parameter was previously named <em>targetNumHits</em> - the old variant still works for backwards
-    compatibility until Vespa 8.]
+    {% include note.html content="<em>targetHits</em> was previously named <em>targetNumHits</em> -
+      the old variant still works for backwards compatibility until Vespa 8."%}
     The wand/weakAnd operator will both
     expose candidates that were evaluated to the first-phase and not only the top-k.
     By default, <em>targetHits</em> is 100. Note that total hit count becomes inaccurate when using wand/weakAnd.
     </p>
 <pre class="urlunencode" oncopy="">
-where%20%5B%7B%22scoreThreshold%22%3A%200%2C%20%22targetHits%22%3A%207%7D%5DweakAnd%28a%20contains%20%22A%22%2C%20b%20contains%20%22B%22%29%3B
+where%20(%7BscoreThreshold%3A%200%2C%20targetHits%3A%207%7DweakAnd(a%20contains%20%22A%22%2C%20b%20contains%20%22B%22))
 </pre>
     <p>
     Unlike <a href="#wand">wand</a>, <em>weakAnd</em> can be used
@@ -799,7 +784,7 @@ where%20%5B%7B%22scoreThreshold%22%3A%200%2C%20%22targetHits%22%3A%207%7D%5Dweak
     Example:
     </p>
 <pre class="urlunencode" oncopy="">
-where%20geoLocation%28myfieldname%2C%2063.5%2C%2010.5%2C%20%22200%20km%22%29%3B
+where%20geoLocation%28myfieldname%2C%2063.5%2C%2010.5%2C%20%22200%20km%22%29
 </pre>
     <p>
     In this example we search for documents near 63.5° north, 10.5° east,
@@ -828,7 +813,7 @@ field myfieldname type array&lt;position&gt; {
 }
 </pre>
     <p>
-    Only the "label" annotation is currently supported for geoLocation.
+    Only the "label" annotation is currently supported for geoLocation. <!-- ToDo: add a link -->
     <table class="table">
     <thead></thead><tbody>
     <tr>
@@ -868,7 +853,7 @@ field myfieldname type array&lt;position&gt; {
     is specified on the tensor, the approximate nearest neighbors are returned instead. Example:
     </p>
 <pre class="urlunencode" oncopy="">
-where%20%5B%7B%22targetHits%22%3A%2010%7D%5D%20nearestNeighbor%28doc_vector%2C%20query_vector%29%3B&amp;ranking.features.query%28query_vector%29=%5B3%2C5%2C7%5D
+where%20(%7BtargetHits%3A%2010%7DnearestNeighbor(doc_vector%2C%20query_vector))&amp;ranking.features.query%28query_vector%29=%5B3%2C5%2C7%5D
 </pre>
     <p>
     In this example we search for the top 10 nearest neighbors in a 3-dimensional vector space.
@@ -982,11 +967,11 @@ yql=select%20%2A%20from%20sources%20%2A%20where%20bar%20contains%20%22a%22%20and
     It takes three arguments: the predicate field to search, a map of attributes, and a map of range attributes:
     </p>
 <pre class="urlunencode" oncopy="">
-where%20predicate(predicate_field%2C%7B%22gender%22%3A%22Female%22%7D%2C%7B%22age%22%3A20L%7D)%3B
+where%20predicate(predicate_field%2C%7B%22gender%22%3A%22Female%22%7D%2C%7B%22age%22%3A20L%7D)
 </pre>
     <p>Due to a quirk in YQL-parsing, one cannot specify an empty map, use the number 0 instead.</p>
 <pre class="urlunencode" oncopy="">
-where%20predicate(predicate_field%2C0%2C%7B%22age%22%3A20L%7D)%3B
+where%20predicate(predicate_field%2C0%2C%7B%22age%22%3A20L%7D)
 </pre>
   </td></tr>
   <tr id="literal.true"><th>true</th><td>
@@ -1017,20 +1002,16 @@ Add <code>asc</code> or <code>desc</code> after the name of an
 ascending order is default.
 </p>
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%20order%20by%20price%20asc%2C%20releasedate%20desc%3B
+where%20title%20contains%20%22madonna%22%20order%20by%20price%20asc%2C%20releasedate%20desc
 </pre>
 <p>
   Sorting function, locale and strength are defined using the annotations "function", "locale" and "strength", as in:
 </p>
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%20order%20by%20%5B%7B%22function%22%3A%20%22uca%22%2C%20%22locale%22%3A%20%22en_US%22%2C%20%22strength%22%3A%20%22IDENTICAL%22%7D%5Dother%20desc%2C
-%20%5B%7B%22function%22%3A%20%22lowercase%22%7D%5Dsomething%3B
+where%20title%20contains%20%22madonna%22%20order%20by%20%7Bfunction%3A%20%22uca%22%2C%20locale%3A%20%22en_US%22%2C%20strength%3A%20%22IDENTICAL%22%7Dother%20desc%2C%20%7Bfunction%3A%20%22lowercase%22%7Dsomething
 </pre>
-<p>
-<strong>Note: </strong> <a href="schema-reference.html#match-phase">match-phase</a>
-is enabled when sorting - refer to the <a href="sorting.html">sorting reference</a>.
-</p>
-
+{% include note.html content="<a href='schema-reference.html#match-phase'>match-phase</a>
+is enabled when sorting - refer to the <a href='sorting.html'>sorting reference</a>."%}
 
 
 <h2 id="limit-offset">limit / offset</h2>
@@ -1039,7 +1020,7 @@ To specify a slice / limit the number of hits returned / do pagination,
 use <code>limit</code> and/or <code>offset</code>:
 </p>
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%20limit%2031%20offset%2029%3B
+where%20title%20contains%20%22madonna%22%20limit%2031%20offset%2029
 </pre>
 <p>
 The above will return two hits (if there are sufficiently many hits matching the query),
@@ -1053,7 +1034,7 @@ skipping the 29 first documents.
 Set query timeout in milliseconds using <code>timeout</code>:
 </p>
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20%22madonna%22%20timeout%2070%3B
+where%20title%20contains%20%22madonna%22%20timeout%2070
 </pre>
 <p>
 Only literal numbers are valid, i.e. setting another unit is not supported.
@@ -1064,124 +1045,176 @@ Only literal numbers are valid, i.e. setting another unit is not supported.
 <h2 id="annotations">Annotations</h2>
 <p>
 Terms and phrases can be annotated to manipulate the behavior.
-Add an annotation using <code>[]</code>, like:
+Add an annotation using <code>{}</code>:
 </p>
 <pre class="urlunencode" oncopy="">
-where%20text%20contains%20%28%5B%20%7B%22distance%22%3A%205%7D%20%5Dnear%28%22a%22%2C%20%22b%22%29%29%3B
+where%20text%20contains%20(%7Bdistance%3A%205%7Dnear(%22a%22%2C%20%22b%22))
 </pre>
 
 
-<h3>Annotations supported by strings</h3>
+<h3 id="annotations-supported-by-strings">Annotations supported by strings</h3>
 <p>
 These annotations are supported by the string arguments to functions like
-and phrase() and near() and also the string argument to the "contains" operator.
+and phrase() and near() and also the string argument to the "contains" operator:
 </p>
 <table class="table">
-<tr><td>"nfkc": true|false</td>
+  <thead>
+  <tr>
+    <th>Annotation</th>
+    <th>Values</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>nfkc</td>
+    <td>true|false</td>
     <td>NFKC <a href="../linguistics.html#normalization">normalization</a>. Default on.</td>
-</tr>
-<tr><td style="white-space:nowrap;">"implicitTransforms": true|false</td>
+  </tr>
+  <tr>
+    <td>implicitTransforms</td>
+    <td>true|false</td>
     <td>Implicit term transformations (field defaults), default on.
-    If implicitTransforms is active, the settings for the field in the schema
-    will be honored in term transforms, e.g. if the field has stemming, this term will be stemmed.
+    If implicitTransforms is active, the settings for the field in the schema will be honored in term transforms,
+    e.g. if the field has stemming, this term will be stemmed.
     If implicitTransforms are turned off,
     the search backend will receive the term exactly as written in the initial YQL expression.
     This is in other words a top level switch to turn off all other
     <a href="../linguistics.html#stemming">stemming</a>, accent removal, Unicode
     <a href="../linguistics.html#normalization">normalizations</a> and so on.</td>
-</tr>
-<tr><td>"annotations": {<br/>
-    &nbsp;&nbsp;"string": "string"<br/>}</td>
-    <td>Custom term annotations. This is by default empty.</td>
-</tr>
-<tr><td>"origin": {<br/>
-    &nbsp;&nbsp;"original": "string",<br/>
-    &nbsp;&nbsp;"offset": int,<br/>
-    &nbsp;&nbsp;"length": int<br/>}</td>
+  </tr>
+  <tr>
+    <td>annotations</td>
+    <td>"string": "string"</td>
+    <td>Custom term annotations. This is by default empty.</td> <!-- ToDo: example -->
+  </tr>
+  <tr>
+    <td>origin</td>
+    <td>"original": "string",<br/>
+    "offset": int,<br/>
+    "length": int<br/></td>
     <td>The (sub-)string which produced this term. Default unset.</td>
-</tr>
-<tr><td>"usePositionData": true|false</td>
+  </tr>
+  <tr>
+    <td>usePositionData</td>
+    <td>true|false</td>
     <td>Use position data for ranking algorithm. Default true.
       This is <em>term</em> position, not to be confused with
       <a href="query-api-reference.html#geographical-searches">geo searches</a></td>
-</tr>
-<tr><td>"stem": true|false</td>
+  </tr>
+  <tr>
+    <td>stem</td>
+    <td>true|false</td>
     <td>Stem this term if it is the setting for this field, default on.</td>
-</tr>
-<tr><td>"normalizeCase": true|false</td>
+  </tr>
+  <tr>
+    <td>normalizeCase</td>
+    <td>true|false</td>
     <td>Normalize casing of this term if it is the setting for this field, default on.</td>
-</tr>
-<tr><td>"accentDrop": true|false</td>
+  </tr>
+  <tr>
+    <td>accentDrop</td>
+    <td>true|false</td>
     <td>Remove accents from this term if it is the setting for this field, default on.</td>
-</tr>
-<tr><td>"andSegmenting": true|false</td>
-    <td>Force phrase or AND operator if re-segmenting (e.g. in stemming) this
-        term results in multiple terms. Default is choosing from language
-        settings.</td>
-</tr>
-<tr><td>"prefix": true|false</td>
-    <td>Do prefix matching for this word. Default false.  ("Search for
-        "word*".")</td>
-</tr>
-<tr><td>"suffix": true|false</td>
-    <td>Do suffix matching for this word. Default false. ("Search for
-        "*word".")</td>
-</tr>
-<tr><td>"substring": true|false</td>
-    <td>Do substring matching for this word if available in the index. Default
-        false. ("Search for "*word*".")
-        Only supported for <a href="../streaming-search.html#match-mode">streaming search</a>.</td>
-</tr>
+  </tr>
+  <tr>
+    <td>andSegmenting</td>
+    <td>true|false</td>
+    <td>Force phrase or AND operator if re-segmenting (e.g. in stemming) this term results in multiple terms.
+      Default is choosing from language settings.</td>
+  </tr>
+  <tr>
+    <td>prefix</td>
+    <td>true|false</td>
+    <td>Do prefix matching for this word. Default false. ("Search for "word*".")</td>
+  </tr>
+  <tr>
+    <td>suffix</td>
+    <td>true|false</td>
+    <td>Do suffix matching for this word. Default false. ("Search for "*word".")</td>
+  </tr>
+  <tr>
+    <td>substring</td>
+    <td>true|false</td>
+    <td>Do substring matching for this word if available in the index.
+      Default false. ("Search for "*word*".")
+      Only supported for <a href="../streaming-search.html#match-mode">streaming search</a>.</td>
+  </tr>
+  </tbody>
 </table>
 
-<h3>Annotations supported by strings and functions</h3>
+
+<h3 id="annotations-supported-by-strings-and-functions">Annotations supported by strings and functions</h3>
 <p>
 These annotations are supported by strings and by the functions which
 are handled like leaf nodes internally in the query tree:
-phrase(), near(), onear(), range(), equiv(), dotProduct(), weightedSet(), weakAnd(), wand() and nearestNeighbor().
+phrase(), near(), onear(), range(), equiv(), dotProduct(), weightedSet(), weakAnd(), wand() and nearestNeighbor():
 </p>
 <table class="table">
-<tr><td>"id": int</td>
+  <thead>
+  <tr>
+    <th>Annotation</th>
+    <th>Values</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>id</td>
+    <td>int</td>
     <td>Unique ID used for e.g. connectivity.</td>
-</tr>
-<tr><td>"connectivity": {<br/>
-    &nbsp;&nbsp;"id": int,<br/>
-    &nbsp;&nbsp;"weight": double<br/>}</td>
+  </tr>
+  <tr>
+    <td>connectivity</td>
+    <td>"id": int,<br/>
+    "weight": double<br/></td>
     <td>Map with the ID and weight of explicitly connectivity of this item.</td>
-</tr>
-<tr><td>"significance": double</td>
+  </tr>
+  <tr>
+    <td>significance</td>
+    <td>double</td>
     <td>Significance value for ranking.</td>
-</tr>
-<tr><td>"annotations": {<br/>
-    &nbsp;&nbsp;"string": "string"<br/>}</td>
+  </tr>
+  <tr>
+    <td>annotations</td>
+    <td>"string": "string"</td>
     <td>Custom annotations. No special semantics inside the YQL layer.</td>
-</tr>
-<tr><td>"filter": true|false</td>
+  </tr>
+  <tr>
+    <td>filter</td>
+    <td>true|false</td>
     <td>Regard this term as a "filter" term. Default false.</td>
-</tr>
-<tr><td>"ranked": true|false</td>
+  </tr>
+  <tr>
+    <td>ranked</td>
+    <td>true|false</td>
     <td>Include this term for ranking calculation. Default true.
-        <a href="../ranking-expressions-features.html#dumping-rank-features-for-specific-documents">Example</a></td>
-</tr>
-<tr><td>"label": "string"</td>
+      <a href="../ranking-expressions-features.html#dumping-rank-features-for-specific-documents">Example</a></td>
+  </tr>
+  <tr>
+    <td>label</td>
+    <td>"string"</td>
     <td>Label for referring to this term during ranking.</td>
-</tr>
-<tr><td>"weight": int</td>
+  </tr>
+  <tr>
+    <td>weight</td>
+    <td>int</td>
     <td>Term weight (default 100), used in some ranking calculations.
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20(%5B%7B"weight"%3A200%7D%5D"heads")%20and%20album%20contains%20"tails"%3B
+where%20title%20contains%20(%7Bweight%3A200%7D"heads")%20and%20album%20contains%20"tails"
 </pre>
     </td>
-</tr>
+  </tr>
+  </tbody>
 </table>
+
 
 <h3 id="annotations-of-sub-expressions">Annotations of sub-expressions</h3>
 <p>
 Consider the following query:
 </p>
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20sources%20%2A%20where%20%28%5B%7B%22stem%22%3A%20false%7D%5D%28foo%20contains%20%22a%22%20and%20bar%20contains%20%22b%22%29%29
-%20or%20foo%20contains%20%28%5B%7B%22stem%22%3A%20false%7D%5D%22c%22%29%3B
+select%20%2A%20from%20sources%20%2A%20where%20%28%7Bstem%3A%20false%7D%28foo%20contains%20%22a%22%20and%20bar%20contains%20%22b%22%29%29%20or%20foo%20contains%20%7Bstem%3A%20false%7D%22c%22
 </pre>
 <p>
 The "stem" annotation controls whether a given term should be stemmed if its
@@ -1225,15 +1258,14 @@ As an example, look at a query with a YQL argument, and the properties
 <em>animal</em> and <em>syntaxExample</em>:
 </p>
 <pre class="urlunencode" oncopy="">
-yql=select%20%2A%20from%20sources%20%2A%20where%20foo%20contains%20%40animal
-%20and%20foo%20contains%20phrase%28%40animal%2C%20%40syntaxExample%2C%20%40animal%29%3B&amp;animal=panda&amp;syntaxExample=syntactic
+yql=select%20%2A%20from%20sources%20%2A%20where%20foo%20contains%20%40animal%20and%20foo%20contains%20phrase%28%40animal%2C%20%40syntaxExample%2C%20%40animal%29&amp;animal=panda&amp;syntaxExample=syntactic
 </pre>
 <p>
 This YQL expression will then access the query properties <em>animal</em> and
 <em>syntaxExample</em> and evaluate to:
 </p>
 <pre class="urlunencode" oncopy="">
-select%20%2A%20from%20sources%20%2A%20where%20%28foo%20contains%20%22panda%22%20AND%20foo%20contains%20phrase%28%22panda%22%2C%20%22syntactic%22%2C%20%22panda%22%29%29%3B
+select%20%2A%20from%20sources%20%2A%20where%20%28foo%20contains%20%22panda%22%20AND%20foo%20contains%20phrase%28%22panda%22%2C%20%22syntactic%22%2C%20%22panda%22%29%29
 </pre>
 
 
@@ -1249,7 +1281,7 @@ To add a default query profile, add <em>search/query-profiles/default.xml</em> t
 </p>
 <pre>
 &lt;query-profile id="default"&gt;
-  &lt;field name="yql"&gt;select * from sources * where default contains "latest" or userQuery();&lt;/field&gt;
+    &lt;field name="yql"&gt;select * from sources * where default contains "latest" or userQuery()&lt;/field&gt;
 &lt;/query-profile&gt;
 </pre>
 <p>
@@ -1263,9 +1295,9 @@ They operate independently of the HTTP parsing as such.
 <h2 id="query-rewriting-in-searchers">Query rewriting in Searchers</h2>
 <p>
 Searchers which modifies the textual YQL statement (not recommended)
-should be annotated with <em>@Before("ExternalYql")</em>.
+should be annotated with <code>@Before("ExternalYql")</code>.
 Searchers modifying query tree produced from an input YQL statement
-should annotate with <em>@After("ExternalYql")</em>.
+should annotate with <code>@After("ExternalYql")</code>.
 </p>
 
 
@@ -1276,7 +1308,7 @@ Group / aggregate results by adding a grouping expression after a <code>|</code>
 <a href="../grouping.html">read more</a>.
 </p>
 <pre class="urlunencode" oncopy="">
-select%20*%20from%20sources%20*%20where%20sddocname%20contains%20%27purchase%27%20%7C%20all(group(customer)%20each(output(sum(price))))%3B
+select%20*%20from%20sources%20*%20where%20sddocname%20contains%20%27purchase%27%20%7C%20all(group(customer)%20each(output(sum(price))))
 </pre>
 
 <script src="/js/copy_urlencoded.js"></script>


### PR DESCRIPTION
This PR simplifies query examples from
````
where album contains ([{"stem": false}]"head");
````
to
````
where album contains ({stem: false}"head")
````
i.e. remove "" from annotation name, remove [] and no ; at end

Hence non-functional changes to doc.

Rewrote table of annotations (Added a column) to prep for next PR: not all annotations are documented, and the different annotation are documented all over the doc - better have in one table and link.

Modified some notes to using note style

