### PR TITLE
Kkraune/annotations reference

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1050,30 +1050,74 @@ Add an annotation using <code>{}</code>:
 <pre class="urlunencode" oncopy="">
 where%20text%20contains%20(%7Bdistance%3A%205%7Dnear(%22a%22%2C%20%22b%22))
 </pre>
-
-
-<h3 id="annotations-supported-by-strings">Annotations supported by strings</h3>
 <p>
-These annotations are supported by the string arguments to functions like
-and phrase() and near() and also the string argument to the "contains" operator:
+All annotations are supported by the string arguments to functions like
+and phrase() and near() and also the string argument to the "contains" operator.
+</p>
+<p>
+  Some annotations are also supported by the functions which
+  are handled like leaf nodes internally in the query tree ("Functions" column in table below):
+  phrase(), near(), onear(), range(), equiv(), dotProduct(), weightedSet(), weakAnd(), wand() and nearestNeighbor().
+</p>
+<p>
+  Refer to <a href="https://github.com/vespa-engine/vespa/blob/master/container-search/src/test/java/com/yahoo/select/SelectTestCase.java">
+  SelectTestCase.java</a> for sample usage. <!-- ToDo: improve this a little or add examples elsewhere, from this -->
 </p>
 <table class="table">
   <thead>
   <tr>
     <th>Annotation</th>
     <th>Values</th>
+    <th>Functions</th>
     <th>Description</th>
   </tr>
   </thead>
   <tbody>
-  <tr>
-    <td>nfkc</td>
+  <tr id="accentdrop">
+    <td>accentDrop</td>
     <td>true|false</td>
-    <td>NFKC <a href="../linguistics.html#normalization">normalization</a>. Default on.</td>
+    <td>no</td>
+    <td>Remove accents from this term if it is the setting for this field, default on.</td>
+  </tr>
+  <tr id="andsegmenting">
+    <td>andSegmenting</td>
+    <td>true|false</td>
+    <td>no</td>
+    <td>Force phrase or AND operator if re-segmenting (e.g. in stemming) this term results in multiple terms.
+      Default is choosing from language settings.</td>
   </tr>
   <tr>
+    <td id="annotations-table">annotations</td>
+    <td>map</td>
+    <td>yes</td>
+    <td>Map of <code>string: string</code>. Custom annotations. No special semantics inside the YQL layer. Example:
+      <pre>annotations : {cox : "another"}</pre>
+    </td>
+  </tr>
+  <tr id="connectivity">
+    <td>connectivity</td>
+    <td>map</td>
+    <td>yes</td>
+    <td>Map of <code>id: int, weight: double</code> of explicit connectivity of this item - example:
+      <pre>connectivity: {"id": 4, "weight": 7.0}</pre>
+    </td>
+  </tr>
+  <tr id="filter">
+    <td>filter</td>
+    <td>true|false</td>
+    <td>yes</td>
+    <td>Regard this term as a "filter" term. Default false.</td>
+  </tr>
+  <tr id="id">
+    <td>id</td>
+    <td>int</td>
+    <td>yes</td>
+    <td>Unique ID used for e.g. connectivity.</td>
+  </tr>
+  <tr id="implicittransforms">
     <td>implicitTransforms</td>
     <td>true|false</td>
+    <td>no</td>
     <td>Implicit term transformations (field defaults), default on.
     If implicitTransforms is active, the settings for the field in the schema will be honored in term transforms,
     e.g. if the field has stemming, this term will be stemmed.
@@ -1083,122 +1127,84 @@ and phrase() and near() and also the string argument to the "contains" operator:
     <a href="../linguistics.html#stemming">stemming</a>, accent removal, Unicode
     <a href="../linguistics.html#normalization">normalizations</a> and so on.</td>
   </tr>
-  <tr>
-    <td>annotations</td>
-    <td>"string": "string"</td>
-    <td>Custom term annotations. This is by default empty.</td> <!-- ToDo: example -->
+  <tr id="label">
+    <td>label</td>
+    <td>string</td>
+    <td>yes</td>
+    <td>Label for referring to this term during ranking.</td>
   </tr>
-  <tr>
-    <td>origin</td>
-    <td>"original": "string",<br/>
-    "offset": int,<br/>
-    "length": int<br/></td>
-    <td>The (sub-)string which produced this term. Default unset.</td>
-  </tr>
-  <tr>
-    <td>usePositionData</td>
+  <tr id="nfkc">
+    <td>nfkc</td>
     <td>true|false</td>
-    <td>Use position data for ranking algorithm. Default true.
-      This is <em>term</em> position, not to be confused with
-      <a href="query-api-reference.html#geographical-searches">geo searches</a></td>
+    <td>no</td>
+    <td>NFKC <a href="../linguistics.html#normalization">normalization</a>. Default on.</td>
   </tr>
-  <tr>
-    <td>stem</td>
-    <td>true|false</td>
-    <td>Stem this term if it is the setting for this field, default on.</td>
-  </tr>
-  <tr>
+  <tr id="normalizecase">
     <td>normalizeCase</td>
     <td>true|false</td>
+    <td>no</td>
     <td>Normalize casing of this term if it is the setting for this field, default on.</td>
   </tr>
-  <tr>
-    <td>accentDrop</td>
-    <td>true|false</td>
-    <td>Remove accents from this term if it is the setting for this field, default on.</td>
+  <tr id="origin">
+    <td>origin</td>
+    <td>map</td>
+    <td>no</td>
+    <td>Map of <code>original: string, offset: int, length: int</code>.
+      The (sub-)string which produced this term. Default unset. Example:
+      <pre>origin: {original: "abc", offset: 1, length: 2}</pre>
+    </td>
   </tr>
-  <tr>
-    <td>andSegmenting</td>
-    <td>true|false</td>
-    <td>Force phrase or AND operator if re-segmenting (e.g. in stemming) this term results in multiple terms.
-      Default is choosing from language settings.</td>
-  </tr>
-  <tr>
+  <tr id="prefix">
     <td>prefix</td>
     <td>true|false</td>
+    <td>no</td>
     <td>Do prefix matching for this word. Default false. ("Search for "word*".")</td>
   </tr>
-  <tr>
-    <td>suffix</td>
+  <tr id="ranked">
+    <td>ranked</td>
     <td>true|false</td>
-    <td>Do suffix matching for this word. Default false. ("Search for "*word".")</td>
+    <td>yes</td>
+    <td>Include this term for ranking calculation. Default true.
+      <a href="../ranking-expressions-features.html#dumping-rank-features-for-specific-documents">Example</a></td>
   </tr>
-  <tr>
+  <tr id="significance">
+    <td>significance</td>
+    <td>double</td>
+    <td>yes</td>
+    <td>Significance value for ranking.</td>
+  </tr>
+  <tr id="stem">
+    <td>stem</td>
+    <td>true|false</td>
+    <td>no</td>
+    <td>Stem this term if it is the setting for this field, default on.</td>
+  </tr>
+  <tr id="substring">
     <td>substring</td>
     <td>true|false</td>
+    <td>no</td>
     <td>Do substring matching for this word if available in the index.
       Default false. ("Search for "*word*".")
       Only supported for <a href="../streaming-search.html#match-mode">streaming search</a>.</td>
   </tr>
-  </tbody>
-</table>
-
-
-<h3 id="annotations-supported-by-strings-and-functions">Annotations supported by strings and functions</h3>
-<p>
-These annotations are supported by strings and by the functions which
-are handled like leaf nodes internally in the query tree:
-phrase(), near(), onear(), range(), equiv(), dotProduct(), weightedSet(), weakAnd(), wand() and nearestNeighbor():
-</p>
-<table class="table">
-  <thead>
-  <tr>
-    <th>Annotation</th>
-    <th>Values</th>
-    <th>Description</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td>id</td>
-    <td>int</td>
-    <td>Unique ID used for e.g. connectivity.</td>
-  </tr>
-  <tr>
-    <td>connectivity</td>
-    <td>"id": int,<br/>
-    "weight": double<br/></td>
-    <td>Map with the ID and weight of explicitly connectivity of this item.</td>
-  </tr>
-  <tr>
-    <td>significance</td>
-    <td>double</td>
-    <td>Significance value for ranking.</td>
-  </tr>
-  <tr>
-    <td>annotations</td>
-    <td>"string": "string"</td>
-    <td>Custom annotations. No special semantics inside the YQL layer.</td>
-  </tr>
-  <tr>
-    <td>filter</td>
+  <tr id="suffix">
+    <td>suffix</td>
     <td>true|false</td>
-    <td>Regard this term as a "filter" term. Default false.</td>
+    <td>no</td>
+    <td>Do suffix matching for this word. Default false. ("Search for "*word".")</td>
   </tr>
-  <tr>
-    <td>ranked</td>
+  <tr id="usepositiondata">
+    <td>usePositionData</td>
     <td>true|false</td>
-    <td>Include this term for ranking calculation. Default true.
-      <a href="../ranking-expressions-features.html#dumping-rank-features-for-specific-documents">Example</a></td>
+    <td>no</td>
+    <td>Use position data for ranking algorithm. Default true.
+      This is <em>term</em> position, not to be confused with
+      <a href="query-api-reference.html#geographical-searches">geo searches</a></td>
   </tr>
-  <tr>
-    <td>label</td>
-    <td>"string"</td>
-    <td>Label for referring to this term during ranking.</td>
-  </tr>
-  <tr>
+  <tr id="weight">
     <td>weight</td>
     <td>int</td>
+    <td>yes</td>
     <td>Term weight (default 100), used in some ranking calculations.
 <pre class="urlunencode" oncopy="">
 where%20title%20contains%20(%7Bweight%3A200%7D"heads")%20and%20album%20contains%20"tails"

--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1086,12 +1086,25 @@ and phrase() and near() and also the string argument to the "contains" operator.
     <td>Force phrase or AND operator if re-segmenting (e.g. in stemming) this term results in multiple terms.
       Default is choosing from language settings.</td>
   </tr>
-  <tr>
-    <td id="annotations-table">annotations</td>
+  <tr id="annotations-table">
+    <td>annotations</td>
     <td>map</td>
     <td>yes</td>
     <td>Map of <code>string: string</code>. Custom annotations. No special semantics inside the YQL layer. Example:
       <pre>annotations : {cox : "another"}</pre>
+    </td>
+  </tr>
+  <tr id="bounds">
+    <td>bounds</td>
+    <td></td>
+    <td></td>
+    <td>ToDo:
+    <!--
+BOUNDS = "bounds";
+BOUNDS_LEFT_OPEN = "leftOpen";
+BOUNDS_OPEN = "open";
+BOUNDS_RIGHT_OPEN = "rightOpen";
+    -->
     </td>
   </tr>
   <tr id="connectivity">
@@ -1102,11 +1115,64 @@ and phrase() and near() and also the string argument to the "contains" operator.
       <pre>connectivity: {"id": 4, "weight": 7.0}</pre>
     </td>
   </tr>
+  <tr id="distance">
+    <td>distance</td>
+    <td></td>
+    <td></td>
+    <td>ToDo:
+      <!--
+DISTANCE = "distance";
+DISTANCE_THRESHOLD = "distanceThreshold";
+      -->
+    </td>
+  </tr>
+  <tr id="endanchor">
+    <td>endAnchor</td>
+    <td></td>
+    <td></td>
+    <td>ToDo:
+      <!--
+END_ANCHOR = "endAnchor";
+      -->
+    </td>
+  </tr>
   <tr id="filter">
     <td>filter</td>
     <td>true|false</td>
     <td>yes</td>
     <td>Regard this term as a "filter" term. Default false.</td>
+  </tr>
+  <tr id="function">
+    <td>function</td>
+    <td></td>
+    <td></td>
+    <td>ToDo:
+      <!--
+SORTING_FUNCTION = "function";
+SORTING_LOCALE = "locale";
+SORTING_STRENGTH = "strength";
+      -->
+    </td>
+  </tr>
+  <tr id="hitlimit">
+    <td>hitLimit</td>
+    <td></td>
+    <td></td>
+    <td>ToDo:
+      <!--
+HIT_LIMIT = "hitLimit";
+      -->
+    </td>
+  </tr>
+  <tr id="hnsw-exploreadditionalhits">
+    <td>hnsw.exploreAdditionalHits</td>
+    <td></td>
+    <td></td>
+    <td>ToDo:
+      <!--
+HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
+      -->
+    </td>
   </tr>
   <tr id="id">
     <td>id</td>
@@ -1167,11 +1233,31 @@ and phrase() and near() and also the string argument to the "contains" operator.
     <td>Include this term for ranking calculation. Default true.
       <a href="../ranking-expressions-features.html#dumping-rank-features-for-specific-documents">Example</a></td>
   </tr>
+  <tr id="scorethreshold">
+    <td>scoreThreshold</td>
+    <td>double</td>
+    <td>yes</td>
+    <td>ToDo:
+    <!--
+SCORE_THRESHOLD = "scoreThreshold";
+    -->
+    </td>
+  </tr>
   <tr id="significance">
     <td>significance</td>
     <td>double</td>
     <td>yes</td>
     <td>Significance value for ranking.</td>
+  </tr>
+  <tr id="startanchor">
+    <td>startAnchor</td>
+    <td></td>
+    <td></td>
+    <td>ToDo:
+      <!--
+END_ANCHOR = "endAnchor";
+      -->
+    </td>
   </tr>
   <tr id="stem">
     <td>stem</td>
@@ -1193,6 +1279,16 @@ and phrase() and near() and also the string argument to the "contains" operator.
     <td>no</td>
     <td>Do suffix matching for this word. Default false. ("Search for "*word".")</td>
   </tr>
+  <tr id="targethits">
+    <td>targetHits</td>
+    <td>true|false</td>
+    <td>no</td>
+    <td>ToDo:
+    <!--
+TARGET_HITS = "targetHits";
+    -->
+    </td>
+  </tr>
   <tr id="usepositiondata">
     <td>usePositionData</td>
     <td>true|false</td>
@@ -1201,6 +1297,14 @@ and phrase() and near() and also the string argument to the "contains" operator.
       This is <em>term</em> position, not to be confused with
       <a href="query-api-reference.html#geographical-searches">geo searches</a></td>
   </tr>
+
+  <!-- These are documented in userInput section above - integrate
+  USER_INPUT_ALLOW_EMPTY = "allowEmpty";
+USER_INPUT_DEFAULT_INDEX = "defaultIndex";
+USER_INPUT_GRAMMAR = "grammar";
+USER_INPUT_LANGUAGE = "language";
+  -->
+
   <tr id="weight">
     <td>weight</td>
     <td>int</td>

--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1067,6 +1067,7 @@ and phrase() and near() and also the string argument to the "contains" operator.
   <thead>
   <tr>
     <th>Annotation</th>
+    <th>Default</th>
     <th>Values</th>
     <th>Functions</th>
     <th>Description</th>
@@ -1075,12 +1076,14 @@ and phrase() and near() and also the string argument to the "contains" operator.
   <tbody>
   <tr id="accentdrop">
     <td>accentDrop</td>
-    <td>true|false</td>
+    <td>true</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Remove accents from this term if it is the setting for this field, default on.</td>
+    <td>Remove accents from this term if it is the setting for this field.</td>
   </tr>
   <tr id="andsegmenting">
     <td>andSegmenting</td>
+    <td></td>
     <td>true|false</td>
     <td>no</td>
     <td>Force phrase or AND operator if re-segmenting (e.g. in stemming) this term results in multiple terms.
@@ -1088,6 +1091,7 @@ and phrase() and near() and also the string argument to the "contains" operator.
   </tr>
   <tr id="annotations-table">
     <td>annotations</td>
+    <td></td>
     <td>map</td>
     <td>yes</td>
     <td>Map of <code>string: string</code>. Custom annotations. No special semantics inside the YQL layer. Example:
@@ -1096,6 +1100,7 @@ and phrase() and near() and also the string argument to the "contains" operator.
   </tr>
   <tr id="bounds">
     <td>bounds</td>
+    <td></td>
     <td></td>
     <td></td>
     <td>ToDo:
@@ -1109,6 +1114,7 @@ BOUNDS_RIGHT_OPEN = "rightOpen";
   </tr>
   <tr id="connectivity">
     <td>connectivity</td>
+    <td></td>
     <td>map</td>
     <td>yes</td>
     <td>Map of <code>id: int, weight: double</code> of explicit connectivity of this item - example:
@@ -1117,6 +1123,7 @@ BOUNDS_RIGHT_OPEN = "rightOpen";
   </tr>
   <tr id="distance">
     <td>distance</td>
+    <td></td>
     <td></td>
     <td></td>
     <td>ToDo:
@@ -1130,6 +1137,7 @@ DISTANCE_THRESHOLD = "distanceThreshold";
     <td>endAnchor</td>
     <td></td>
     <td></td>
+    <td></td>
     <td>ToDo:
       <!--
 END_ANCHOR = "endAnchor";
@@ -1138,12 +1146,14 @@ END_ANCHOR = "endAnchor";
   </tr>
   <tr id="filter">
     <td>filter</td>
-    <td>true|false</td>
+    <td>false</td>
+    <td>boolean</td>
     <td>yes</td>
-    <td>Regard this term as a "filter" term. Default false.</td>
+    <td>Regard this term as a "filter" term.</td>
   </tr>
   <tr id="function">
     <td>function</td>
+    <td></td>
     <td></td>
     <td></td>
     <td>ToDo:
@@ -1158,6 +1168,7 @@ SORTING_STRENGTH = "strength";
     <td>hitLimit</td>
     <td></td>
     <td></td>
+    <td></td>
     <td>ToDo:
       <!--
 HIT_LIMIT = "hitLimit";
@@ -1168,6 +1179,7 @@ HIT_LIMIT = "hitLimit";
     <td>hnsw.exploreAdditionalHits</td>
     <td></td>
     <td></td>
+    <td></td>
     <td>ToDo:
       <!--
 HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
@@ -1176,15 +1188,17 @@ HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
   </tr>
   <tr id="id">
     <td>id</td>
+    <td></td>
     <td>int</td>
     <td>yes</td>
     <td>Unique ID used for e.g. connectivity.</td>
   </tr>
   <tr id="implicittransforms">
     <td>implicitTransforms</td>
-    <td>true|false</td>
+    <td>true</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Implicit term transformations (field defaults), default on.
+    <td>Implicit term transformations (field defaults).
     If implicitTransforms is active, the settings for the field in the schema will be honored in term transforms,
     e.g. if the field has stemming, this term will be stemmed.
     If implicitTransforms are turned off,
@@ -1195,24 +1209,28 @@ HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
   </tr>
   <tr id="label">
     <td>label</td>
+    <td></td>
     <td>string</td>
     <td>yes</td>
     <td>Label for referring to this term during ranking.</td>
   </tr>
   <tr id="nfkc">
     <td>nfkc</td>
-    <td>true|false</td>
+    <td>true</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>NFKC <a href="../linguistics.html#normalization">normalization</a>. Default on.</td>
+    <td>NFKC <a href="../linguistics.html#normalization">normalization</a>.</td>
   </tr>
   <tr id="normalizecase">
     <td>normalizeCase</td>
-    <td>true|false</td>
+    <td>true</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Normalize casing of this term if it is the setting for this field, default on.</td>
+    <td>Normalize casing of this term if it is the setting for this field.</td>
   </tr>
   <tr id="origin">
     <td>origin</td>
+    <td></td>
     <td>map</td>
     <td>no</td>
     <td>Map of <code>original: string, offset: int, length: int</code>.
@@ -1222,19 +1240,22 @@ HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
   </tr>
   <tr id="prefix">
     <td>prefix</td>
-    <td>true|false</td>
+    <td>false</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Do prefix matching for this word. Default false. ("Search for "word*".")</td>
+    <td>Do prefix matching for this word. ("Search for "word*".")</td>
   </tr>
   <tr id="ranked">
     <td>ranked</td>
-    <td>true|false</td>
+    <td>true</td>
+    <td>boolean</td>
     <td>yes</td>
-    <td>Include this term for ranking calculation. Default true.
+    <td>Include this term for ranking calculation.
       <a href="../ranking-expressions-features.html#dumping-rank-features-for-specific-documents">Example</a></td>
   </tr>
   <tr id="scorethreshold">
     <td>scoreThreshold</td>
+    <td></td>
     <td>double</td>
     <td>yes</td>
     <td>ToDo:
@@ -1245,12 +1266,14 @@ SCORE_THRESHOLD = "scoreThreshold";
   </tr>
   <tr id="significance">
     <td>significance</td>
+    <td></td>
     <td>double</td>
     <td>yes</td>
     <td>Significance value for ranking.</td>
   </tr>
   <tr id="startanchor">
     <td>startAnchor</td>
+    <td></td>
     <td></td>
     <td></td>
     <td>ToDo:
@@ -1261,28 +1284,31 @@ END_ANCHOR = "endAnchor";
   </tr>
   <tr id="stem">
     <td>stem</td>
-    <td>true|false</td>
+    <td>true</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Stem this term if it is the setting for this field, default on.</td>
+    <td>Stem this term if it is the setting for this field.</td>
   </tr>
   <tr id="substring">
     <td>substring</td>
-    <td>true|false</td>
+    <td>false</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Do substring matching for this word if available in the index.
-      Default false. ("Search for "*word*".")
+    <td>Do substring matching for this word if available in the index. ("Search for "*word*".")
       Only supported for <a href="../streaming-search.html#match-mode">streaming search</a>.</td>
   </tr>
   <tr id="suffix">
     <td>suffix</td>
-    <td>true|false</td>
+    <td>false</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Do suffix matching for this word. Default false. ("Search for "*word".")</td>
+    <td>Do suffix matching for this word. ("Search for "*word".")</td>
   </tr>
   <tr id="targethits">
     <td>targetHits</td>
-    <td>true|false</td>
-    <td>no</td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>ToDo:
     <!--
 TARGET_HITS = "targetHits";
@@ -1291,9 +1317,10 @@ TARGET_HITS = "targetHits";
   </tr>
   <tr id="usepositiondata">
     <td>usePositionData</td>
-    <td>true|false</td>
+    <td>true</td>
+    <td>boolean</td>
     <td>no</td>
-    <td>Use position data for ranking algorithm. Default true.
+    <td>Use position data for ranking algorithm.
       This is <em>term</em> position, not to be confused with
       <a href="query-api-reference.html#geographical-searches">geo searches</a></td>
   </tr>
@@ -1307,9 +1334,10 @@ USER_INPUT_LANGUAGE = "language";
 
   <tr id="weight">
     <td>weight</td>
+    <td>100</td>
     <td>int</td>
     <td>yes</td>
-    <td>Term weight (default 100), used in some ranking calculations.
+    <td>Term weight, used in some ranking calculations.
 <pre class="urlunencode" oncopy="">
 where%20title%20contains%20(%7Bweight%3A200%7D"heads")%20and%20album%20contains%20"tails"
 </pre>


### PR DESCRIPTION
To review, do by each commit, the first is just rearranging. This gist of it is, create one table (with more columns) of annotations, add the missing annotations with ToDos, so next PR can move the reference doc into this table (many annotations are documented elsewhere or missing) and link here instead. Also, link to to guides from here for examples.

Maybe easier to review once I am fully done, this makes it a little better with few changes to actual content. This is a mess now ...
