### PR TITLE
Document tensor format argument and Vespa 8 change

### DIFF
--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -907,7 +907,8 @@ or <a href="schema-reference.html#summary">summary: dynamic</a>.
         </tr>
   </table>
   
-</td></tr>
+</td>
+</tr>
 <tr><td>Default</td><td>default</td></tr>
 </table>
 
@@ -946,6 +947,16 @@ Whether a result renderer should try to add optional timing information
 to the rendered page.
 </p>
 
+<h3 id="format.tensor">presentation.format.tensors</h3>
+<table class="table table-striped">
+  <tr><td>Alias</td><td>format.tensors</td></tr>
+  <tr><td>Values</td><td>short, long</td></tr>
+  <tr><td>Default</td><td>long</td></tr>
+</table>
+<p>
+  Whether tensors should be rendered in the long, regular format, or in the short form appropriate for their type
+  (if any), see the <a href="reference/document-json-format.html#tensor">tensor JSON format</a>.
+</p>
 
 
 <h2 id="grouping-and-aggregation">Grouping and Aggregation</h2>

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -120,6 +120,18 @@ The following defaults have changed:
     </td>
   </tr>
 
+  <tr>
+    <td>
+      The default value of <code>format.tensors</code> has changed from 'long' to 'short':
+      Tensors in query and document API responses are rendered in the short form appropriate for thir type
+      (if any), documented <a href="reference/document-json-format.html#tensor">here</a>.
+    </td>
+    <td>
+      Explicitly pass <a href="reference/query-api-reference.html#format.tensors">format.tensors</a>=long in queries,
+      or set this parameter in the relevant <a href="query-profiles.html">query profiles</a>.
+    </td>
+  </tr>
+
 </table>
 
 


### PR DESCRIPTION
If this looks right to you we also need to implement it in document/v1.