### PR TITLE
Document more YQL annotations

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -93,36 +93,37 @@ select%20%2A%20from%20music%20where%20title%20contains%20%22madonna%22
   <tr id="numeric"><th>numeric</th><td>
     <p>
     The following numeric operators are available:
-    <em>=, &lt;, &gt;, &lt;=, &gt;=, range(field, lower bound, upper bound)</em>
+    <code>= &lt; &gt; &lt;= &gt;= range(field, lower bound, upper bound)</code>.
+    </p>
 <pre class="urlunencode" oncopy="">
 where%20500%20%3E%3D%20price
 </pre>
 <pre class="urlunencode" oncopy="">
 where%20range%28fieldname%2C%200%2C%205000000000L%29
 </pre>
-    <p>Numbers must be in the signed 32-bit range, or the string "Infinity"/"-Infinity".
-    Input 64-bit signed numbers using <em>L</em> as suffix.
-    </p><p>
-    The interval is by default a closed interval.
-    If the lower bound is exclusive, set the annotation "bounds" to "leftOpen". <!-- ToDo annotation -->
-    If the upper bound is exclusive, set the same annotation to "rightOpen".
-    If both bounds are exclusive, set the annotation to "open". <!-- ToDo: example here! -->
-    </p><p>
-    The number operations support an extra annotation, the integer "hitLimit".
-    This is used for <em>capped range search</em>.
-    An alternative to using negative and positive values for "hitLimit"
-    is always using a positive number of hits
-    (as a negative number of hits does not make much sense)
-    and combine this with either of the boolean annotations "ascending" and "descending" (but not both).
-    Then <code>{hitLimit: 38, descending: true}</code> would be equivalent to setting it to -38,
-    i.e. only populate with 38 hits and start from upper boundary, i.e. descending order. Note that hitLimit will limit
-    the number of documents that are considered. It is dangerous to use if you have other filters too. This is a powerful optimisation
-    that must be used with care. The set of documents to be considered will be limited upfront by only selecting the N best according to
-    the range query and the hitLimit annotation, for further query evaluation. The hitLimit is not exact, but 'at least'. In addition, the
-    optimisation will only kick in if the attribute has <a href="schema-reference.html#attribute">fast-search</a>. It will look up
-    the upper or lower bound in the range in the dictionary and scan in ascending or descending order and select entries until it has satisfied hitLimit.
-    You will get all documents for all the dictionary entries selected.
-    </p><p>
+    <p>
+      Numbers must be in the signed 32-bit range, or the string <code>Infinity</code> or <code>-Infinity</code>.
+    Input 64-bit signed numbers using <code>L</code> as suffix.
+    </p>
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Annotation</th>
+        <th>Effect</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><a href="#bounds">bounds</a></td>
+        <td>Range: open or closed interval.</td>
+      </tr>
+      <tr>
+        <td><a href="#hitlimit">hitLimit</a></td>
+        <td>Used for <em>capped range search</em>.</td>
+      </tr>
+      </tbody>
+    </table>
+    <p>
     The <a href="schema-reference.html#type:weightedset">weightedset</a> field does not support filtering on weight.
     Solve this using the <a href="schema-reference.html#type:map">map</a> type and
     <a href="#sameelement">sameElement</a> query operator -
@@ -131,8 +132,7 @@ where%20range%28fieldname%2C%200%2C%205000000000L%29
   </td></tr>
 
   <tr id="boolean"><th>boolean</th><td>
-    <p>
-    The boolean operator is: =
+    <p>The boolean operator is: <code>=</code></p>
 <pre class="urlunencode" oncopy="">
 where%20alive%20%3D%20true
 </pre>
@@ -151,25 +151,37 @@ where%20alive%20%3D%20true
 <pre class="urlunencode" oncopy="">
 where%20title%20contains%20%22madonna%22
 </pre>
+    <table class="table">
+      <thead>
+      <tr>
+        <th>String literal annotation</th>
+        <th>Effect</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><a href="#stem">stem</a></td>
+        <td>
+          By default, the string literal is <a href="../linguistics.html#tokenization">tokenized</a>
+          to match the field(s) searched.
+          Explicitly control tokenization by using <a href="#stem">stem</a>:
+          <pre class="urlunencode" oncopy="">
+where%20title%20contains%20(%7Bstem%3A%20false%7D%22madonna%22)
+</pre></td>
+      </tr>
+      </tbody>
+    </table>
     <p>
     The matched field must be an
     <a href="../schemas.html#indexing">indexed field or attribute</a>.
     </p><p>
     Fields inside structs are referenced using dot notation -
     e.g <code>mystruct.mystructfield</code>.
-    </p><p>
-    By default, the string will be <a href="../linguistics.html#tokenization">tokenized</a>
-    to match the field(s) searched.
-    Explicitly control tokenization by using annotations:
-<pre class="urlunencode" oncopy="">
-where%20title%20contains%20(%7Bstem%3A%20false%7D%22madonna%22)
-</pre>
-    <p>Note the use of parentheses to control precedence when using annotations.</p>
-
+    </p>
     <table class="table">
       <tr id="and"><th>and</th><td>
         <p>
-        <em>and</em> accepts other <em>and</em> statements, <em>or</em> statements,
+        <code>and</code> accepts other <code>and</code> statements, <code>or</code> statements,
         <a href="#userquery">userQuery</a>, logically inverted statements -
         and contains statements as arguments:
 <pre class="urlunencode" oncopy="">
@@ -178,7 +190,7 @@ where%20title%20contains%20%22madonna%22%20and%20title%20contains%20%22saint%22
       </td></tr>
       <tr id="or"><th>or</th><td>
         <p>
-        <em>or</em> accepts other <em>or</em> statements, <em>and</em> statements,
+        <code>or</code> accepts other <code>or</code> statements, <code>and</code> statements,
         <a href="#userquery">userQuery</a> - and contains statements as arguments:
 <pre class="urlunencode" oncopy="">
 where%20title%20contains%20%22madonna%22%20or%20title%20contains%20%22saint%22
@@ -187,7 +199,7 @@ where%20title%20contains%20%22madonna%22%20or%20title%20contains%20%22saint%22
       </td></tr>
       <tr id="not"><th>not</th><td>
         <p>
-        Use the <em>!</em> operator to match document that does <i>not</i> satisfy some condition
+        Use the <code>!</code> operator to match document that does <i>not</i> satisfy some condition
 <pre class="urlunencode" oncopy="">
 where%20title%20contains%20%22madonna%22%20and%20%21%28title%20contains%20%22saint%22%29
 </pre>
@@ -202,21 +214,44 @@ where%20text%20contains%20phrase%28%22st%22%2C%20%22louis%22%2C%20%22blues%22%29
       </td></tr>
       <tr id="near"><th>near</th><td>
         <p>
-        <em>near()</em> matches if all argument terms occur close to each other in the same document.
-        It supports the <em>distance</em>-annotation which sets the maximum position difference
-        to count as a match.
-        The default distance is 2, meaning match if the words have up to one separating word.
-<pre class="urlunencode" oncopy="">
-where%20text%20contains%20%28%7Bdistance%3A%205%7Dnear%28%22a%22%2C%20%22b%22%29%29
-</pre>
+        <code>near()</code> matches if all argument terms occur close to each other in the same document.
+        </p>
+        <table class="table">
+          <thead>
+          <tr>
+            <th>Annotation</th>
+            <th>Effect</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td><a href="#distance">distance</a></td>
+            <td>Tune closeness using <em>distance</em>.</td>
+          </tr>
+          </tbody>
+        </table>
       </td></tr>
       <tr id="onear"><th>onear</th><td>
         <p>
-        <em>onear()</em> (ordered near) is like <em>near()</em>,
+        <code>onear()</code> (ordered near) is like <code>near()</code>,
         but also requires the terms in the document having the same order
         as given in the function (i.e. it is a phrase allowing other words interleaved).
-        With distance 1 <em>onear()</em> has the same semantics as <em>phrase()</em>.
+        With distance 1, <code>onear()</code> has the same semantics as <code>phrase()</code>.
         </p>
+        <table class="table"> <!-- ToDo: Assuming near and onear support the same annotations -->
+          <thead>
+          <tr>
+            <th>Annotation</th>
+            <th>Effect</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td><a href="#distance">distance</a></td>
+            <td>Tune closeness using <em>distance</em>.</td>
+          </tr>
+          </tbody>
+        </table>
       </td></tr>
       <tr id="sameelement"><th>sameElement</th><td>
         <p>
@@ -274,7 +309,7 @@ where%20identities%20contains%20sameElement%28key%20contains%20'father',%20value
       <tr id="equiv"><th>equiv</th><td>
         <p>
         If two terms in the same field should give exactly the same behavior when matched,
-        the <em>equiv()</em> operator behaves like a special case of "or".
+        the <code>equiv()</code> operator behaves like a special case of <code>or</code>.
         </p>
 <pre class="urlunencode" oncopy="">
 where%20fieldName%20contains%20equiv%28%22A%22%2C%22B%22%29
@@ -295,12 +330,12 @@ where%20fieldName%20contains%20equiv%28%22A%22%2C%22B%22%29
           <li>Items inside the EQUIV are not directly visible to ranking features,
               so weight and connectivity on those will have no effect</li>
         </ul>
-        <p>Limitations on how <em>equiv</em> can be used in a query:</p>
+        <p>Limitations on how <code>equiv</code> can be used in a query:</p>
         <ul>
-          <li><em>equiv</em> may not appear inside a phrase</li>
+          <li><code>equiv</code> may not appear inside a phrase</li>
           <li>It may only contain <code>TermItem</code> and <code>PhraseItem</code> instances.
-            Operators like <em>and</em> cannot be placed inside <em>equiv</em></li>
-          <li><code>PhraseItems</code> inside <em>equiv</em> will rank like as if they have size 1</li>
+            Operators like <code>and</code> cannot be placed inside <code>equiv</code></li>
+          <li><code>PhraseItems</code> inside <code>equiv</code> will rank like as if they have size 1</li>
         </ul>
         <p>
         Learn how to use <a href="../query-rewriting.html#equiv">equiv</a>.
@@ -312,19 +347,25 @@ where%20fieldName%20contains%20equiv%28%22A%22%2C%22B%22%29
           <pre class="urlunencode" oncopy="">
 where%20myUrlField%20contains%20uri(%22vespa.ai%2Ffoo%22)
 </pre>
-          <p>Various subfields are supported to search components of the URL, see the field type definition.
-              The <code>hostname</code> subfield supports anchoring to the start and/or end of the hostname,
-              controlled by the <code>startAnchor</code> and <code>endAnchor</code> boolean annotations.
-              Anchoring to the end is on by default while anchoring to the start is not. Hence
-          </p>
-          <pre class="urlunencode" oncopy="">
-where%20myUrlField.hostname%20contains%20uri(%5C%22vespa.ai%5C%22)
-</pre>
-          <p>will match vespa.ai and docs.vespa.ai and so on, while</p>
-          <pre class="urlunencode" oncopy="">
-where%20myUrlField.hostname%20contains%20(%7BstartAnchor%3A%20true%7Duri(%22vespa.ai%22))
-</pre>
-        <p>will only match vespa.ai.</p>
+        <p>Various subfields are supported to search components of the URL, see the field type definition.</p>
+        <table class="table">
+          <thead>
+          <tr>
+            <th>Annotation</th>
+            <th>Effect</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td><a href="#startanchor">startAnchor</a></td>
+            <td>Anchor uri.hostname at start.</td>
+          </tr>
+          <tr>
+            <td><a href="#endanchor">endAnchor</a></td>
+            <td>Anchor uri.hostname at end.</td>
+          </tr>
+          </tbody>
+        </table>
       </td></tr>
     </table></td>
   </tr>
@@ -347,12 +388,10 @@ where%20title%20matches%20%22mado%5Bn%5D%2Ba%22%3B
 <pre class="urlunencode" oncopy="">
 where%20title%20matches%20%22^mad%22
 </pre>
-    <p>
-    <strong>Note:</strong> Only <a href="schema-reference.html#attribute">attribute</a>
-    fields in <a href="services-content.html#document">documents</a> that have <code>mode="index"</code> is supported.
+    {% include important.html content="Only <a href='schema-reference.html#attribute'>attribute</a>
+    fields in <a href='services-content.html#document'>documents</a> that have <code>mode=\"index\"</code> is supported.
     It is also not optimized.
-    Having a prefix using the <code>^</code> will be faster than not having one.
-    </p>
+    Having a prefix using the <code>^</code> will be faster than not having one."%}
   </td></tr>
   <tr id="userinput"><th>userInput</th><td>
     <p>
@@ -402,74 +441,51 @@ select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%2
     the <em>userInput()</em> function also accepts raw strings as arguments,
     but this would obviously not be suited for parametrizing the query from a query profile.
     It is mostly intended as test feature.
-    </p><p>
-    <em>userInput()</em> control annotations:</p>
+    </p>
     <table class="table">
-    <thead>
-    <tr>
-        <th>Name</th><th>Default</th><th>Values</th><th>Effect</th>
-    </tr>
-    </thead>
-    <tr>
-        <td>grammar</td>
-        <td><code>all</code></td>
-        <td><code>raw</code>, <code>segment</code> and all values accepted for the
-            <a href="query-api-reference.html#model.type">model.type</a> argument
-            in the search API.
+      <thead>
+      <tr>
+        <th>Annotation</th>
+        <th>Effect</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><a href="#grammar">grammar</a></td>
+        <td>
+          How to parse the user input.
+          The query parsing mechanism has currently certain limitations for propagating annotations,
+          therefore, for any value of <code>grammar</code> other than <code>raw</code> or <code>segment</code>,
+          only the following annotations will take effect:
+          <ul>
+            <li><a href="#ranked">ranked</a></li>
+            <li><a href="#filter">filter</a></li>
+            <li><a href="#stem">stem</a></li>
+            <li><a href="#normalizecase">normalizeCase</a></li>
+            <li><a href="#accentdrop">accentDrop</a></li>
+            <li><a href="#usepositiondata">usePositionData</a></li>
+          </ul>
         </td>
-        <td>How to parse the user input. "raw" will treat the user input as a
-            string to be matched without any processing, "segment" will do a
-            first pass through the linguistic libraries, while the rest of the
-            values will treat the string as a query to be parsed. If query parsing
-            fails, an error message will be returned.
-        </td>
-    </tr>
-    <tr>
-        <td>defaultIndex</td>
-        <td><code>default</code></td>
-        <td>Any searchable field in the schema.</td>
-        <td>Same as <a
-            href="query-api-reference.html#model.defaultIndex">model.defaultIndex</a>
-            in the search API. If "grammar" is set to "raw" or "segment",
-            this will be the field searched.
-        </td>
-    </tr>
-    <tr>
-        <td>language</td>
-        <td><em>Autodetect</em></td>
-        <td>RFC 3066 language code</td>
-        <td>Language setting for the linguistics treatment of this userInput() call,
-            also see <a
-            href="query-api-reference.html#model.language">model.language</a> in
-            the search API reference.
-        </td>
-    </tr>
-    <tr>
-        <td>allowEmpty</td>
-        <td><code>false</code></td>
-        <td>Boolean true or false.</td>
-        <td>Whether to allow empty input for query parsing and search terms.
-            If this is true, a NullItem instance is inserted in the proper place in the query tree.
-            If "allowEmpty" is false, the query will fail
-            if the user provided data can not be parsed or is empty.
-        </td>
-    </tr>
+      </tr>
+      <tr>
+        <td><a href="#defaultindex">defaultIndex</a></td>
+        <td>Same as <a href="query-api-reference.html#model.defaultIndex">model.defaultIndex</a>
+          in the query API.</td>
+      </tr>
+      <tr>
+        <td><a href="#language">language</a></td>
+        <td>Language setting for the linguistics treatment of this userInput() call.</td>
+      </tr>
+      <tr>
+        <td><a href="#allowempty">allowEmpty</a></td>
+        <td>Whether to allow empty input for query parsing and search terms.</td>
+      </tr>
+      </tbody>
     </table>
     <p>
-    In addition, other annotations, like <em>stem</em> or <em>ranked</em>, will take effect as normal.
-    </p><p>
-    The query parsing mechanism has currently certain limitations for propagating annotation,
-    therefore, for any value of <em>grammar</em> other than <em>raw</em> or <em>segment</em>,
-    only the following annotations will take effect:
+      In addition, other annotations, like <a href="#stem">stem</a> or <a href="#ranked">ranked</a>,
+      will take effect as normal.
     </p>
-    <ul>
-      <li><code>ranked</code></li>
-      <li><code>filter</code></li>
-      <li><code>stem</code></li>
-      <li><code>normalizeCase</code></li>
-      <li><code>accentDrop</code></li>
-      <li><code>usePositionData</code></li>
-    </ul>
   </td></tr>
   <tr id="userquery"><th>userQuery</th><td>
     <p>
@@ -622,31 +638,22 @@ where%20weightedSet%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29
   </td></tr>
   <tr id="wand"><th>wand</th><td>
     <p>
-    <em>wand</em> can be used to search for documents
+    <code>wand</code> can be used to search for documents
     where weighted tokens in a field matches a subset of weighted tokens in the query.
     At the same time, it internally calculates the dot product between token weights in the query and the field.
-    <em>wand</em> is guaranteed to return the top-k hits according to its internal dot product rank score.
+    <code>wand</code> is guaranteed to return the top-k hits according to its internal dot product rank score.
     It is an operator that scales adaptively from <a href="#or">or</a> to <a href="#and">and</a>.
-    </p><p>
-    <em>wand</em> optimizes the performance of using multiple threads per search in the backend,
+    </p>
+    <p>Note that total hit count becomes inaccurate when using wand.</p>
+    <p>
+    <code>wand</code> optimizes the performance of using multiple threads per search in the backend,
     and is also called <em>Parallel Wand</em>.
     </p><p>
-    <em>wand</em> also allows numeric arguments, then the search argument is an array of arrays of length two.
+    <code>wand</code> also allows numeric arguments, then the search argument is an array of arrays of length two.
     In each pair, the first number is the search term, the second its weight:
 <pre class="urlunencode" oncopy="">
 where%20wand%28description%2C%20%5B%5B11%2C1%5D%2C%20%5B37%2C2%5D%5D%29
 </pre>
-    <p>
-    Both <a href="#wand">wand</a> and <em>weakAnd</em> support the annotations <em>scoreThreshold</em>,
-    which is a double for wand and an integer for weakAnd. This threshold specifies the minimum rank score for hits to include. 
-    The <em>targetHits</em> annotation sets the wanted number of hits exposed
-    to the real first-phase ranking function per content node.
-    {% include note.html content="<em>targetHits</em> was previously named <em>targetNumHits</em> -
-      the old variant still works for backwards compatibility until Vespa 8."%}
-    The wand/weakAnd operator will both
-    expose candidates that were evaluated to the first-phase and not only the top-k. 
-    By default, <em>targetHits</em> is 100. Note that total hit count becomes inaccurate when using wand/weakAnd.
-    </p>
     <p>
     The list of terms may also be specified as a separate parameter: <code>where wand(description, @myterms)</code>,
     where a separate parameter "myterms" must then be passed containing the terms as a string.
@@ -657,15 +664,29 @@ where%20wand%28description%2C%20%5B%5B11%2C1%5D%2C%20%5B37%2C2%5D%5D%29
     or map form: {key: value, ...}. Keys must be single or double quoted if passed inline in YQL. Quotes can be skipped
     when passing a separate parameter unless the keys contains "," or ":".
     </p>
-    <p>
-    If additional second phase ranking with rerank-count is used,
-    do not set <em>targetHits</em> less than the configured rank-profile's rerank-count.
-    </p>
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Annotation</th>
+        <th>Effect</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><a href="#scorethreshold">scoreThreshold</a></td>
+        <td>Minimum rank score for hits to include.</td>
+      </tr>
+      <tr>
+        <td><a href="#targethits">targetHits</a></td>
+        <td>Wanted number of hits exposed to the real first-phase ranking function per content node.</td>
+      </tr>
+      </tbody>
+    </table>
 <pre class="urlunencode" oncopy="">
 where%20(%7BscoreThreshold%3A%200.13%2C%20targetHits%3A%207%7Dwand(description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D))
 </pre>
     <p>
-     Refer to <a href="../using-wand-with-vespa.html">using wand</a> for a usage and examples.
+     Refer to <a href="../using-wand-with-vespa.html">using wand</a> for usage and examples.
     </p>
     <table class="table">
     <thead></thead><tbody>
@@ -706,7 +727,7 @@ where%20(%7BscoreThreshold%3A%200.13%2C%20targetHits%3A%207%7Dwand(description%2
   </td></tr>
   <tr id="weakand"><th>weakAnd</th><td>
     <p>
-    <em>weakAnd</em> is sometimes called <em>Vespa Wand</em>.
+    <code>weakAnd</code> is sometimes called <em>Vespa Wand</em>.
     Unlike <a href="#wand">wand</a>, it accepts arbitrary word matches (across arbitrary fields) as arguments.
     Only a limited number of documents are returned for ranking (default is 100),
     but it does not guarantee to return the best k hits.
@@ -715,22 +736,29 @@ where%20(%7BscoreThreshold%3A%200.13%2C%20targetHits%3A%207%7Dwand(description%2
 <pre class="urlunencode" oncopy="">
 where%20weakAnd%28a%20contains%20%22A%22%2C%20b%20contains%20%22B%22%29
 </pre>
-    <p>
-    Both <a href="#wand">wand</a> and <em>weakAnd</em> support the annotations <em>scoreThreshold</em>,
-    which is a double for wand and an integer for weakAnd. This threshold specifies the minimum rank score for hits to include. 
-    The <em>targetHits</em> annotation sets the wanted number of hits exposed
-    to the real first-phase ranking function per content node.
-    {% include note.html content="<em>targetHits</em> was previously named <em>targetNumHits</em> -
-      the old variant still works for backwards compatibility until Vespa 8."%}
-    The wand/weakAnd operator will both
-    expose candidates that were evaluated to the first-phase and not only the top-k.
-    By default, <em>targetHits</em> is 100. Note that total hit count becomes inaccurate when using wand/weakAnd.
-    </p>
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Annotation</th>
+        <th>Effect</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><a href="#scorethreshold">scoreThreshold</a></td>
+        <td>Minimum rank score for hits to include.</td>
+      </tr>
+      <tr>
+        <td><a href="#targethits">targetHits</a></td>
+        <td>Wanted number of hits exposed to the real first-phase ranking function per content node.</td>
+      </tr>
+      </tbody>
+    </table>
 <pre class="urlunencode" oncopy="">
 where%20(%7BscoreThreshold%3A%200%2C%20targetHits%3A%207%7DweakAnd(a%20contains%20%22A%22%2C%20b%20contains%20%22B%22))
 </pre>
     <p>
-    Unlike <a href="#wand">wand</a>, <em>weakAnd</em> can be used
+    Unlike <a href="#wand">wand</a>, <code>weakAnd</code> can be used
     to search across several fields of various types,
     but it does NOT guarantee to return the top-k best number of hits.
     It can however be combined with any ranking expression.
@@ -779,7 +807,7 @@ where%20(%7BscoreThreshold%3A%200%2C%20targetHits%3A%207%7DweakAnd(a%20contains%
 
   <tr id="geolocation"><th>geoLocation</th><td>
     <p>
-    <em>geoLocation</em> matches a <a href="schema-reference.html#type:position">position</a>
+    <code>geoLocation</code> matches a <a href="schema-reference.html#type:position">position</a>
     inside a geographical circle, specified as latitude, longitude, and a maximum distance (radius).
     Example:
     </p>
@@ -799,6 +827,8 @@ where%20geoLocation%28myfieldname%2C%2063.5%2C%2010.5%2C%20%22200%20km%22%29
     (so "deg" gives radius the same units as latitude).
     Any negative number for radius (e.g. "-1 m") is interpreted as an "infinite" radius,
     letting any geographical position at all match the geoLocation operator.
+    </p>
+    <p>
     The position attribute in the schema could look like:
     </p>
 <pre>
@@ -812,8 +842,23 @@ field myfieldname type array&lt;position&gt; {
     indexing: attribute
 }
 </pre>
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Annotation</th>
+        <th>Effect</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><a href="#label">label</a></td>
+        <td>Label for referring to this term during ranking.</td>
+      </tr>
+      </tbody>
+    </table>
     <p>
-    Only the "label" annotation is currently supported for geoLocation. <!-- ToDo: add a link -->
+      Properties:
+    </p>
     <table class="table">
     <thead></thead><tbody>
     <tr>
@@ -841,7 +886,7 @@ field myfieldname type array&lt;position&gt; {
 
   <tr id="nearestneighbor"><th>nearestNeighbor</th><td>
     <p>
-    <em>nearestNeighbor</em> matches the top-k nearest neighbors in a multi-dimensional vector space.
+    <code>nearestNeighbor</code> matches the top-k nearest neighbors in a multi-dimensional vector space.
     Points in the vector space are specified as
     <a href="../tensor-user-guide.html">tensors</a> with one indexed dimension,
     where the size of that dimension is equal to the dimensionality of the vector space.
@@ -877,30 +922,55 @@ field doc_vector type tensor&lt;float&gt;(x[3]) {
     <a href="../approximate-nn-hnsw.html">Approximate Nearest Neighbor Search using HNSW Index</a>
     for more detailed examples.
     </p>
-    <p>These annotations are supported:</p>
-    <ul>
-      <li> The <em>targetHits</em> annotation is required, and specifies the number of hits the operator should aim to produce.
-           Note that you may get both more or less hits actually produced.</li>
-      <li> The optional <em>approximate</em> annotation may be set to "false" to disallow usage of an approximate
-           <a href="schema-reference.html#index-hnsw">HNSW index</a>.
-           This is especially useful to compare exact and approximate results in order to perform
-           tuning of other parameters.
-           This annotation is default "true" when an HNSW index is specified, otherwise it is always "false".</li>
-      <li> When using an
-           <a href="schema-reference.html#index-hnsw">HNSW index</a>,
-           the optional <em>hnsw.exploreAdditionalHits</em> annotation may be used to
-           tune how many extra nodes in the graph (in addition to <em>targetHits</em>) should be explored before
-           selecting the best hits.  Using a greater number here gives better quality but worse performance.</li>
-      <li> The standard <em>label</em> annotation may be used to mark the query operator with a label that can be
-           referred to from the ranking expression in the rank profile. See the documentation for the
-           <a href="rank-features.html#closeness(dimension,name)">closeness</a> rank feature.</li>
-      <li> The <em>distanceThreshold</em> annotation may be used to filter away hits with a higher distance
-           than the given threshold from the results.  Note that you will never get more hits with
-           <em>distanceThreshold</em> than you would get without it; if you want more hits you need to
-           increase the <em>targetHits</em> value also.  The units for the threshold depends on the
-	   <a href="schema-reference.html#distance-metric">distance metric</a> used.
-    </ul>
-
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Annotation</th>
+        <th>Effect</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><a href="#targethits">targetHits</a></td>
+        <td>
+          This annotation is required, and specifies the number of hits nearestNeighbor aims to produce.
+          Note that more or less hits might actually be produced.
+        </td>
+      </tr>
+      <tr>
+        <td><a href="#approximate">approximate</a></td>
+        <td>
+          The optional <code>approximate</code> annotation may be set to <code>false</code>
+          to not use an approximate <a href="schema-reference.html#index-hnsw">HNSW index</a>.
+          This is especially useful to compare exact and approximate results in order to perform
+          tuning of other parameters.
+          This annotation is default "true" when an HNSW index is specified, otherwise it is always "false".
+        </td>
+      </tr>
+      <tr>
+        <td><a href="#hnsw-exploreadditionalhits">hnsw.exploreAdditionalHits</a></td>
+        <td>
+          Tune how many extra nodes in the graph (in addition to <code>targetHits</code>)
+          that should be explored before selecting the best hits.
+        </td>
+      </tr>
+      <tr>
+        <td><a href="#label">label</a></td>
+        <td>
+          Use to mark the query operator with a label
+          that can be referred to from the ranking expression in the rank profile.
+          See the <a href="rank-features.html#closeness(dimension,name)">closeness</a> rank feature.
+        </td>
+      </tr>
+      <tr>
+        <td><a href="#distancethreshold">distanceThreshold</a></td>
+        <td>
+          Use to filter out hits with a higher distance than the given threshold.
+        </td>
+      </tr>
+      </tbody>
+    </table>
+    <p>Properties:</p>
     <table class="table">
     <thead></thead><tbody>
     <tr>
@@ -1013,6 +1083,22 @@ where%20title%20contains%20%22madonna%22%20order%20by%20%7Bfunction%3A%20%22uca%
 {% include note.html content="<a href='schema-reference.html#match-phase'>match-phase</a>
 is enabled when sorting - refer to the <a href='sorting.html'>sorting reference</a>."%}
 
+<table class="table">
+  <thead>
+  <tr>
+    <th>Annotation</th>
+    <th>Effect</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><a href="#function">function</a></td>
+    <td>
+
+    </td>
+  </tr>
+  </tbody>
+</table>
 
 <h2 id="limit-offset">limit / offset</h2>
 <p>
@@ -1081,6 +1167,17 @@ and phrase() and near() and also the string argument to the "contains" operator.
     <td>no</td>
     <td>Remove accents from this term if it is the setting for this field.</td>
   </tr>
+  <tr id="allowempty">
+    <td>allowEmpty</td>
+    <td>false</td>
+    <td>boolean</td>
+    <td>yes</td>
+    <td>
+      Whether to allow empty input for query parsing and query terms in <a href="#userinput">userInput</a>.
+      If <code>true</code>, a NullItem instance is inserted in the proper place in the query tree.
+      If <code>false</code>, the query will fail if the user provided inout can not be parsed or is empty.
+    </td>
+  </tr>
   <tr id="andsegmenting">
     <td>andSegmenting</td>
     <td></td>
@@ -1098,18 +1195,40 @@ and phrase() and near() and also the string argument to the "contains" operator.
       <pre>annotations : {cox : "another"}</pre>
     </td>
   </tr>
+  <tr id="approximate">
+    <td>approximate</td>
+    <td></td>
+    <td>boolean</td>
+    <td></td>
+    <td>
+      Used in <a href="#nearestneighbor">nearestNeighbor</a>.
+      The optional <em>approximate</em> annotation may be set to <code>false</code> to disallow usage of an approximate
+      <a href="schema-reference.html#index-hnsw">HNSW index</a>.
+      This is especially useful to compare exact and approximate results in order to perform tuning of other parameters.
+      This annotation is default <code>true</code> when an HNSW index is specified,
+      otherwise it is always <code>false</code>.
+    </td>
+  </tr>
+  <tr id="ascending">
+    <td>ascending</td>
+    <td></td>
+    <td>boolean</td>
+    <td></td>
+    <td>
+      Ascending hit order. Used by <a href="#hitlimit">hitLimit</a>.
+    </td>
+  </tr>
   <tr id="bounds">
     <td>bounds</td>
+    <td>closed</td>
+    <td>enum</td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td>ToDo:
-    <!--
-BOUNDS = "bounds";
-BOUNDS_LEFT_OPEN = "leftOpen";
-BOUNDS_OPEN = "open";
-BOUNDS_RIGHT_OPEN = "rightOpen";
-    -->
+    <td>
+      A <a href="#numeric">numeric</a> interval is by default a closed interval.
+      If the lower bound is exclusive, set the annotation "bounds" to "leftOpen".
+      If the upper bound is exclusive, set the same annotation to "rightOpen".
+      If both bounds are exclusive, set the annotation to "open".
+      <!-- ToDo: example here! -->
     </td>
   </tr>
   <tr id="connectivity">
@@ -1121,27 +1240,75 @@ BOUNDS_RIGHT_OPEN = "rightOpen";
       <pre>connectivity: {"id": 4, "weight": 7.0}</pre>
     </td>
   </tr>
+  <tr id="descending">
+    <td>descending</td>
+    <td></td>
+    <td>boolean</td>
+    <td></td>
+    <td>
+      Descending hit order. Used by <a href="#hitlimit">hitLimit</a>.
+    </td>
+  </tr>
+  <tr id="defaultindex">
+    <td>defaultIndex</td>
+    <td><code>default</code></td>
+    <td>Any searchable field in the schema.</td>
+    <td>yes</td>
+    <td>
+      Used by <a href="#userinput">userInput</a>.
+      Same as <a href="query-api-reference.html#model.defaultIndex">model.defaultIndex</a> in the query API.
+      If <a href="#grammar">grammar</a> is set to <code>raw</code> or <code>segment</code>,
+      this will be the field searched.
+    </td>
+  </tr>
   <tr id="distance">
     <td>distance</td>
+    <td>2</td>
+    <td>int</td>
     <td></td>
+    <td>
+      The <em>distance</em>-annotation sets the maximum position difference to count as a match.
+      The default distance is 2, meaning match if the words have up to one separating word.
+<pre class="urlunencode" oncopy="">
+where%20text%20contains%20%28%7Bdistance%3A%205%7Dnear%28%22a%22%2C%20%22b%22%29%29
+</pre>
+    </td>
+  </tr>
+  <tr id="distancethreshold">
+    <td>distanceThreshold</td>
+    <td>2</td>
+    <td>int</td>
     <td></td>
-    <td></td>
-    <td>ToDo:
-      <!--
-DISTANCE = "distance";
-DISTANCE_THRESHOLD = "distanceThreshold";
-      -->
+    <td>
+      Used in <a href="#nearestneighbor">nearestNeighbor</a>.
+      The <code>distanceThreshold</code> annotation may be used to filter away hits
+      with a higher distance than the given threshold from the results.
+      Note that one will never get more hits with <code>distanceThreshold</code> than you would get without it -
+      to get more hits, increase <a href="#targethits">targetHits</a>, too.
+      The units for the threshold depends on the
+      <a href="schema-reference.html#distance-metric">distance metric</a> used.
     </td>
   </tr>
   <tr id="endanchor">
     <td>endAnchor</td>
+    <td>true</td>
+    <td>boolean</td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td>ToDo:
-      <!--
-END_ANCHOR = "endAnchor";
-      -->
+    <td>
+      <p>
+        The <code>hostname</code> subfield of <a href="#uri">uri</a>
+        supports anchoring to the start and/or end of the hostname,
+        controlled by the <code>startAnchor</code> and <code>endAnchor</code> annotations.
+        Anchoring to the end is on by default while anchoring to the start is not. Hence
+      </p>
+<pre class="urlunencode" oncopy="">
+where%20myUrlField.hostname%20contains%20uri(%5C%22vespa.ai%5C%22)
+</pre>
+      <p>will match <em>vespa.ai</em> and <em>docs.vespa.ai</em>, while</p>
+<pre class="urlunencode" oncopy="">
+where%20myUrlField.hostname%20contains%20(%7BstartAnchor%3A%20true%7Duri(%22vespa.ai%22))
+</pre>
+      <p>will only match vespa.ai.</p>
     </td>
   </tr>
   <tr id="filter">
@@ -1164,15 +1331,52 @@ SORTING_STRENGTH = "strength";
       -->
     </td>
   </tr>
+  <tr id="grammar">
+    <td>grammar</td>
+    <td><code>all</code></td>
+    <td><code>raw</code>, <code>segment</code> and all values accepted for the
+      <a href="query-api-reference.html#model.type">model.type</a> argument in the query API.</td>
+    <td>yes</td>
+    <td>
+      <p>
+      How to parse <a href="#userinput">userInput</a>.
+      <code>raw</code> will treat the user input as a string to be matched without any processing,
+      <code>segment</code> will do a first pass through the linguistic libraries,
+      while the rest of the values will treat the string as a query to be parsed.
+      If query parsing fails, an error message will be returned.
+      </p>
+    </td>
+  </tr>
   <tr id="hitlimit">
     <td>hitLimit</td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td>ToDo:
-      <!--
-HIT_LIMIT = "hitLimit";
-      -->
+    <td>int</td>
+    <td>no</td> <!-- ToDo: check -->
+    <td>
+      <p>
+        <a href="#numeric">Numeric</a> operations support <code>hitLimit</code>.
+        This is used for <em>capped range search</em>.
+        An alternative to using negative and positive values for hitLimit is always using a positive number of hits
+        (as a negative number of hits does not make much sense) and combine this with either of the
+        <a href="#ascending">ascending</a> and <a href="#descending">descending</a> annotations (but not both).
+        Example: <code>{hitLimit: 38, descending: true}</code> would be equivalent to setting it to -38,
+        i.e. only populate with 38 hits and start from upper boundary, i.e. descending order.
+      </p>
+      <p>
+        Note that hitLimit will limit the number of documents that are considered.
+        It is dangerous to use if you have other filters too.
+        This is a powerful optimisation that must be used with care.
+        The set of documents to be considered will be limited upfront
+        by only selecting the N best according to the range query and the hitLimit annotation,
+        for further query evaluation.
+      </p>
+      <p>
+        hitLimit is not exact, but "at least".
+        In addition, it will only kick in if the attribute has <a href="schema-reference.html#attribute">fast-search</a>.
+        It will look up the upper or lower bound in the range in the dictionary and scan in ascending or descending order
+        and select entries until it has satisfied hitLimit.
+        You will get all documents for all the dictionary entries selected.
+      </p>
     </td>
   </tr>
   <tr id="hnsw-exploreadditionalhits">
@@ -1180,10 +1384,13 @@ HIT_LIMIT = "hitLimit";
     <td></td>
     <td></td>
     <td></td>
-    <td>ToDo:
-      <!--
-HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
-      -->
+    <td>
+      Used in <a href="#nearestneighbor">nearestNeighbor</a>.
+      When using an <a href="schema-reference.html#index-hnsw">HNSW index</a>,
+      the optional <code>hnsw.exploreAdditionalHits</code> annotation can be used to
+      tune how many extra nodes in the graph (in addition to <code>targetHits</code>)
+      should be explored before selecting the best hits.
+      Using a greater number here gives better quality, but worse performance.
     </td>
   </tr>
   <tr id="id">
@@ -1212,7 +1419,19 @@ HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
     <td></td>
     <td>string</td>
     <td>yes</td>
-    <td>Label for referring to this term during ranking.</td>
+    <td>
+      Used by <a href="#geolocation">geoLocation</a>
+      and <a href="#nearestneighbor">nearestNeighbor</a>.. <!-- ToDo: and probably others ... -->
+      Label for referring to this term during ranking.
+    </td>
+  </tr>
+  <tr id="language">
+    <td>language</td>
+    <td></td>
+    <td>RFC 3066 language code</td>
+    <td>yes</td>
+    <td>Language setting for the linguistics handling of <a href="#userinput">userInput</a>,
+      also see <a href="query-api-reference.html#model.language">model.language</a> in the query API reference.</td>
   </tr>
   <tr id="nfkc">
     <td>nfkc</td>
@@ -1256,12 +1475,14 @@ HNSW_EXPLORE_ADDITIONAL_HITS = "hnsw.exploreAdditionalHits";
   <tr id="scorethreshold">
     <td>scoreThreshold</td>
     <td></td>
-    <td>double</td>
+    <td>double / integer</td>
     <td>yes</td>
-    <td>ToDo:
-    <!--
-SCORE_THRESHOLD = "scoreThreshold";
-    -->
+    <td>
+      Both <a href="#wand">wand</a> and <a href="#weakand">weakAnd</a> supports <code>scoreThreshold</code>,
+      which is a double for <code>wand</code> and an integer for <code>weakAnd</code>.
+      This threshold specifies the minimum rank score for hits to include.
+      The <code>wand</code> / <code>weakAnd</code> operators will both expose candidates
+      that were evaluated to the first-phase and not only the top-k.
     </td>
   </tr>
   <tr id="significance">
@@ -1273,14 +1494,10 @@ SCORE_THRESHOLD = "scoreThreshold";
   </tr>
   <tr id="startanchor">
     <td>startAnchor</td>
+    <td>false</td>
+    <td>boolean</td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td>ToDo:
-      <!--
-END_ANCHOR = "endAnchor";
-      -->
-    </td>
+    <td>See <a href="#endanchor">endAnchor</a>.</td>
   </tr>
   <tr id="stem">
     <td>stem</td>
@@ -1306,13 +1523,18 @@ END_ANCHOR = "endAnchor";
   </tr>
   <tr id="targethits">
     <td>targetHits</td>
+    <td>100</td>
+    <td>int</td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td>ToDo:
-    <!--
-TARGET_HITS = "targetHits";
-    -->
+    <td>
+      Used by <a href="#wand">wand</a>, <a href="#weakand">weakAnd</a>
+      and <a href="#nearestneighbor">nearestNeighbor</a>.
+      It sets the wanted number of hits exposed to the real first-phase ranking function per content node.
+      If additional second phase ranking with rerank-count is used,
+      do not set <code>targetHits</code> less than the configured rank-profile's
+      <a href="schema-reference.html#rerank-count">rerank-count</a>.
+      {% include note.html content="<code>targetHits</code> was previously named <code>targetNumHits</code> -
+      targetNumHits still works for backwards compatibility until Vespa 8."%}
     </td>
   </tr>
   <tr id="usepositiondata">
@@ -1324,14 +1546,6 @@ TARGET_HITS = "targetHits";
       This is <em>term</em> position, not to be confused with
       <a href="query-api-reference.html#geographical-searches">geo searches</a></td>
   </tr>
-
-  <!-- These are documented in userInput section above - integrate
-  USER_INPUT_ALLOW_EMPTY = "allowEmpty";
-USER_INPUT_DEFAULT_INDEX = "defaultIndex";
-USER_INPUT_GRAMMAR = "grammar";
-USER_INPUT_LANGUAGE = "language";
-  -->
-
   <tr id="weight">
     <td>weight</td>
     <td>100</td>
@@ -1339,7 +1553,7 @@ USER_INPUT_LANGUAGE = "language";
     <td>yes</td>
     <td>Term weight, used in some ranking calculations.
 <pre class="urlunencode" oncopy="">
-where%20title%20contains%20(%7Bweight%3A200%7D"heads")%20and%20album%20contains%20"tails"
+where%20title%20contains%20(%7Bweight%3A200%7D"heads")
 </pre>
     </td>
   </tr>

--- a/en/reference/rank-features.html
+++ b/en/reference/rank-features.html
@@ -628,9 +628,7 @@ tensor(dim{}):{ {dim:v1}:1.0, {dim:v2}:1.0, {dim:v3}:1.0} }
   <td>closeness(<em>dimension</em>,<em>name</em>)</td>
   <td>0</td>
   <td><p>
-    Used with the
-    <a href="query-language-reference.html#nearestneighbor">nearestNeighbor</a>
-    query operator.
+    Used with the <a href="query-language-reference.html#nearestneighbor">nearestNeighbor</a> query operator.
     A number which is close to 1 when a point vector in the document is close
     to a matching point vector in the query.
     The document field and the query vector must be the same tensor
@@ -642,8 +640,8 @@ tensor(dim{}):{ {dim:v1}:1.0, {dim:v2}:1.0, {dim:v3}:1.0} }
            <code>label</code>.  When using <code>field</code>, the name given must be
            a field with a tensor attribute of appropriate type.
            When using <code>label</code>, queries are assumed to contain a
-           NearestNeighbor query item with a label that matches the
-           given <em>name</em>.
+           <a href="query-language-reference.html#nearestneighbor">nearestNeighbor</a> query item
+           with a label that matches the given <em>name</em>.
       </li>
       <li> <em>name</em>: The value of the field name or label.
       </li>


### PR DESCRIPTION
- the gist of it is, document the annotation's behaviour once in a table of annotations, link to it from one or more places used
- still a few annotations to go
- few changes to content, other than re-arranging and adding the obvious. Will address some todos later once I know more
- need another pass and also look at the other docs linking into this and refine the annotation description / link out. the yql guide can be made much better once this is in place ...

Question: is it important to separate annotations valid for string literals and/or functions? There was a distinction in the old docs, but I don't see that is is useful for the user reading this, would like to remove a column