### PR TITLE
Document sorting YQL annotations MERGEOK

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1094,7 +1094,19 @@ is enabled when sorting - refer to the <a href='sorting.html'>sorting reference<
   <tr>
     <td><a href="#function">function</a></td>
     <td>
-
+      Sort function, default UCA.
+    </td>
+  </tr>
+  <tr>
+    <td><a href="#locale">locale</a></td>
+    <td>
+      Locale identifier for the <a href="#function">UCA sort function</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><a href="#strength">strength</a></td>
+    <td>
+      Strength setting for the <a href="#function">UCA sort function</a>.
     </td>
   </tr>
   </tbody>
@@ -1323,12 +1335,65 @@ where%20myUrlField.hostname%20contains%20(%7BstartAnchor%3A%20true%7Duri(%22vesp
     <td></td>
     <td></td>
     <td></td>
-    <td>ToDo:
-      <!--
-SORTING_FUNCTION = "function";
-SORTING_LOCALE = "locale";
-SORTING_STRENGTH = "strength";
-      -->
+    <td>
+      <p>
+        Default sort function for strings is <code>uca</code>.
+        Field sort specification can be configured in the <a href="schema-reference.html#sorting">schema</a>,
+        values in the query overrides the schema settings.
+      </p>
+      <p>
+        Numeric fields are numerically sorted.
+      </p>
+      <table class="table">
+        <thead>
+        <tr>
+          <th>Function</th>
+          <th>Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr id="uca">
+          <td><code>uca</code></td>
+          <td>
+            <p>
+              This sorting is based on the <a href="http://site.icu-project.org/">icu</a> library
+              that follows the <a href="https://unicode.org/reports/tr10/">
+              Universal Collation Algorithm</a>.
+              The specification of
+              <a href="https://unicode-org.github.io/icu-docs/#/icu4j/com/ibm/icu/util/ULocale.html">locale</a>
+              and <a href="https://unicode-org.github.io/icu-docs/#/icu4j/com/ibm/icu/text/Collator.html">strength</a>
+              are identical to how <a href="http://site.icu-project.org/">icu</a> specifies them.
+            </p>
+            <p>
+              Both <a href="#locale">locale</a> and <a href="#strength">strength</a> are optional,
+              however <code>strength</code> requires <code>locale</code>.
+            </p>
+            <p>
+              The <a href="#locale">locale</a> query annotation will override
+              locale-setting in the <a href="schema-reference.html#sorting">schema</a>.
+              If <code>locale</code> is missing from both, the <code>lowercase</code> function will be used by default.
+            </p>
+          </td>
+        </tr>
+        <tr id="lowercase">
+          <td><code>lowercase</code></td>
+          <td>
+            This improves the sorting by first lowercasing and normalising the strings before sorting.
+            This is slightly more correct and might be enough for the use case.
+            It is not that much more costly than <code>raw</code> sort, and less expensive than <code>uca</code>.
+          </td>
+        </tr>
+        <tr id="raw">
+          <td><code>raw</code></td>
+          <td>
+            Raw byteorder is a simple and fast ordering based on memcmp of utf8 for strings
+            and correct sort order compliant binary rep for other fields is done.
+            However, that is not correct for anything except computers,
+            looking only at the binary representation.
+          </td>
+        </tr>
+      </tbody>
+      </table>
     </td>
   </tr>
   <tr id="grammar">
@@ -1433,6 +1498,17 @@ SORTING_STRENGTH = "strength";
     <td>Language setting for the linguistics handling of <a href="#userinput">userInput</a>,
       also see <a href="query-api-reference.html#model.language">model.language</a> in the query API reference.</td>
   </tr>
+  <tr id="locale">
+    <td>locale</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>
+      Used by the <a href="#function">UCA sort function</a>.
+      An identifier following <a href="https://www.unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers">
+      unicode locale identifiers</a>, e.g. <code>en_US</code>.
+    </td>
+  </tr>
   <tr id="nfkc">
     <td>nfkc</td>
     <td>true</td>
@@ -1505,6 +1581,25 @@ SORTING_STRENGTH = "strength";
     <td>boolean</td>
     <td>no</td>
     <td>Stem this term if it is the setting for this field.</td>
+  </tr>
+  <tr id="strength">
+    <td>strength</td>
+    <td><code>PRIMARY</code></td>
+    <td>
+      <ul>
+        <li><code>PRIMARY</code></li>
+        <li><code>SECONDARY</code></li>
+        <li><code>TERTIARY</code></li>
+        <li><code>QUATERNARY</code></li>
+        <li><code>IDENTICAL</code></li>
+      </ul>
+    </td>
+    <td></td>
+    <td>
+      Used by the <a href="#function">UCA sort function</a>.
+      Default is <code>PRIMARY</code>, which only sorts on primary differentiating characteristics;
+      this means that letters in uppercase/lowercase or with differences in accents only are considered equal.
+    </td>
   </tr>
   <tr id="substring">
     <td>substring</td>

--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -1509,7 +1509,6 @@ or
 <pre>
 sorting {
     [property]
-    [property]
     &hellip;
 }
 </pre>
@@ -1520,45 +1519,36 @@ sorting {
     <tr>
       <td><code>order</code></td>
       <td>
-        Either <em>ascending</em> or <em>descending</em>. Default is ascending.
-        Used unless overridden in <a href="../reference/sorting.html">sortspec</a> in query.
+        <code>ascending</code> (default) or <code>descending</code>.
+        Used unless overridden using <a href="query-language-reference.html#function">order by</a> in query.
       </td>
     </tr>
     <tr>
       <td><code>function</code></td>
       <td>
-        The <a href="../reference/sorting.html#sort-function">Sort
-        function</a> to be used.  Implemented functions
-        are <em>raw</em>, <em>lowercase</em>, and <em>uca</em>. The
-        default is <a href="../reference/sorting.html#uca"><em>uca</em></a>,
-        but please note that if no language or locale is specified in
-        the query sortspec, the field, or generally for the
-        query, <a href="../reference/sorting.html#lowercase">lowercase</a>
-        will be used instead. Used unless overridden
-        in <a href="../reference/sorting.html">sortspec</a> in query.
+        <a href="query-language-reference.html#function">Sort function</a>:
+        <code>uca</code> (default), <code>lowercase</code> or <code>raw</code>.
+        Note that if no language or locale is specified in the query, the field,
+        or generally for the query, <code>lowercase</code> will be used instead of <code>uca</code>.
+        See <a href="query-language-reference.html#order-by">order by</a> for details.
       </td>
     </tr>
     <tr>
       <td><code>strength</code></td>
       <td>
-        <a href="../reference/sorting.html#uca">Sort
-        strength</a> to be used. Implemented levels are <em>primary</em>,
-        <em>secondary</em>, <em>tertiary</em>, <em>quaternary</em>
-        and <em>identical</em>. The default is <em>primary</em>.
-        Used unless overridden in <a href="../reference/sorting.html">sortspec</a>
-        in query. Only applicable if <code>function</code> is set to <em>uca</em>.
+        <a href="query-language-reference.html#strength">UCA sort strength</a>, default <code>primary</code> -
+        see <a href="query-language-reference.html#strength">strength</a> for values.
+        Values set in the query overrides the schema definition.
       </td>
     </tr>
     <tr>
       <td><code>locale</code></td>
       <td>
-        <a href="../reference/sorting.html#uca">Locale</a>
-        to be used. The default is none, indicating that it is
-        inferred from query. It should only be set here if the
-        attribute is filled with data that is in 1 language only. Used
-        unless overridden in <a href="../reference/sorting.html">sortspec</a>
-        in query. Only applicable if <code>function</code> is set
-        to <em>uca</em>.
+        <a href="query-language-reference.html#locale">UCA locale</a>, default none,
+        indicating that it is inferred from query.
+        It should only be set here if the attribute is filled with data in one language only.
+        See <a href="query-language-reference.html#locale">locale</a> for details.
+        Values set in the query overrides the schema definition.
       </td>
     </tr>
   </tbody>

--- a/en/reference/sorting.html
+++ b/en/reference/sorting.html
@@ -84,84 +84,8 @@ score and sort by the specified sorting specification.
 
 <h2 id="sort-function">Sort function</h2>
 <p>
-It is possible to specify how sorting should be done.
-The default depends on configuration of attributes and
-language, if specified in query.
-Fallback when no sorting could be done is using the order that
-the documents were indexed in (on the backend search node).
-</p><p>
-You can specify that you want to sort on raw binary values,
-or a simple and cheap lowercase, but usually the more expensive,
-but linguistically correct,
-<a href="https://unicode.org/reports/tr10/">UCA sorting</a>
-is used.
-Default sort function for strings is <code>uca</code>, unless overridden in
-<a href="schema-reference.html#sorting">schema</a>,
-or given explicitly in sortspec.
-Numeric fields are numerically sorted.
+  Refer to <a href="query-language-reference.html#function">function</a>.
 </p>
-<table class="table">
-  <thead></thead><tbody>
-    <tr id="raw">
-      <th style="width:150px">Raw byteorder</th>
-      <td>
-        Here a simple and fast ordering based on memcmp of utf8 for strings
-        and correct sort order compliant binary rep for other fields is done.
-        However, that is not correct for anything except computers,
-        looking only at the binary representation.
-      </td>
-    </tr><tr id="lowercase">
-      <th>Lowercase</th>
-      <td>
-        This improves the sorting by first lowercasing and normalising the strings before sorting.
-        This is slightly more correct and might be enough for what you want.
-        It is not that much more costly than raw sort.
-      </td>
-    </tr><tr id="uca">
-      <th>UCA</th>
-      <td><p>
-        This sorting is based on the <a href="http://site.icu-project.org/">icu</a> library
-        that follows the <a href="https://unicode.org/reports/tr10/">
-          Universal Collation Algorithm</a>.
-        The specification of
-        <a href="https://unicode-org.github.io/icu-docs/#/icu4j/com/ibm/icu/util/ULocale.html">locale</a>
-        and <a href="https://unicode-org.github.io/icu-docs/#/icu4j/com/ibm/icu/text/Collator.html">strength</a>
-        are identical to how <a href="http://site.icu-project.org/">icu</a> specifies them.
-        The default is strength <code>PRIMARY</code>
-        which only sorts on primary differentiating characteristics;
-        this means that letters in uppercase/lowercase
-        or with differences in accents only are considered equal.
-        </p><p>
-        Note that both locale and strength are optional,
-        but that if you need to set strength, you must also specify locale:
-        </p>
-        <table class="table">
-          <thead></thead><tbody>
-            <tr>
-              <th style="width:200px">Default sort locale</th>
-              <td>
-                Locale is default derived from query unless overridden in
-                <a href="schema-reference.html#sorting">schema</a>,
-                or given explicitly in sortspec.
-                Note that if neither the query sortspec, nor the schema,
-                nor the query itself specifies a language or locale
-                then UCA sorting won't be used by default anymore;
-                in this case the fallback is to use the lowercase function instead.
-              </td>
-            </tr><tr>
-              <th>Default sort strength</th>
-              <td>
-                Strength is <code>PRIMARY</code> unless overridden in
-                <a href="schema-reference.html#sorting">schema</a>,
-                or given explicitly in sortspec.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 
 


### PR DESCRIPTION
- and harmonize with the schema reference for the same.

I think that reference/sorting.html will die, as the content here is either more ref doc that belongs in query/schema doc (already overlaps), or examples that should go into the query-api guide. This will be a welcome cleanup in later PR