### PR TITLE
Document parmeter substitution

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -471,11 +471,12 @@ yql=select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%2020
 select%20%2A%20from%20sources%20%2A%20where%20range%28year%2C%201963%2C%202014%29%20and%20%28default%20contains%20%22panda%22%20or%20default%20contains%20phrase%28%22bear%22%2C%20%22roosevelt%22%29%29
 </pre>
       <p>
-        Instead of a variable reference,
+        Instead of <a href="#parameter-substitution">parameter substitution</a>,
         the <em>userInput()</em> function also accepts raw strings as arguments,
         but this would obviously not be suited for parametrizing the query from a query profile.
         It is mostly intended as test feature.
       </p>
+      <!-- ToDo: rewrite this a little once all the examples are moved to the query api guide -->
       <table class="table">
         <thead>
         <tr>
@@ -584,15 +585,10 @@ where%20dotProduct%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29
         for a discussion of usage and examples.
       </p>
       <p>
-        The list of terms may also be specified as a separate parameter:
-        <code>where dotProduct(description, @myterms)</code>,
-        where a separate parameter "myterms" must then be passed containing the terms as a string.
-        Passing the terms as a separate parameter is <b>much faster</b> when the term list is long.
-      </p>
-      <p>
-        The term string (whether a separate parameter or inline) can be passed either on array form: [[key, value], ...],
-        or map form: {key: value, ...}. Keys must be single or double quoted if passed inline in YQL. Quotes can be skipped
-        when passing a separate parameter unless the keys contains "," or ":".
+        Keys must be single or double-quoted if passed inline in YQL -
+        alternatively, use <a href="#parameter-substitution">parameter substitution</a>
+        to submit the weighted set with a simple format for faster query parsing -
+        example: <code>where dotProduct(description, @myterms)</code>.
       </p>
       <table class="table">
         <thead></thead><tbody>
@@ -650,15 +646,10 @@ where%20weightedSet%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29
         Also see <a href="../performance/feature-tuning.html#multi-lookup-set-filtering">multi-lookup set filtering</a>.
       </p>
       <p>
-        The list of terms may also be specified as a separate parameter:
-        <code>where weightedSet(description, @myterms)</code>,
-        where a separate parameter "myterms" must then be passed containing the terms as a string.
-        Passing the terms as a separate parameter is <b>much faster</b> when the term list is long.
-      </p>
-      <p>
-        The term string (whether a separate parameter or inline) can be passed either on array form: [[key, value], ...],
-        or map form: {key: value, ...}. Keys must be single or double quoted if passed inline in YQL. Quotes can be skipped
-        when passing a separate parameter unless the keys contains "," or ":".
+        Keys must be single or double-quoted if passed inline in YQL -
+        alternatively, use <a href="#parameter-substitution">parameter substitution</a>
+        to submit the weighted set with a simple format for faster query parsing -
+        example: <code>where weightedSet(description, @myterms)</code>.
       </p>
       <table class="table">
         <thead></thead><tbody>
@@ -708,14 +699,10 @@ where%20weightedSet%28description%2C%20%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%29
 where%20wand%28description%2C%20%5B%5B11%2C1%5D%2C%20%5B37%2C2%5D%5D%29
 </pre>
     <p>
-      The list of terms may also be specified as a separate parameter: <code>where wand(description, @myterms)</code>,
-      where a separate parameter "myterms" must then be passed containing the terms as a string.
-      Passing the terms as a separate parameter is <b>much faster</b> when the term list is long.
-    </p>
-    <p>
-      The term string (whether a separate parameter or inline) can be passed either on array form: [[key, value], ...],
-      or map form: {key: value, ...}. Keys must be single or double quoted if passed inline in YQL. Quotes can be skipped
-      when passing a separate parameter unless the keys contains "," or ":".
+      Keys must be single or double-quoted if passed inline in YQL -
+      alternatively, use <a href="#parameter-substitution">parameter substitution</a>
+      to submit the weighted set with a simple format for faster query parsing -
+      example: <code>where wand(description, @myterms)</code>.
     </p>
     <table class="table">
       <thead>
@@ -1219,6 +1206,46 @@ where%20title%20contains%20%22madonna%22%20timeout%2070
 <p>
   Only literal numbers are valid, i.e. setting another unit is not supported.
 </p>
+
+
+
+<h2 id="parameter-substitution">Parameter substitution</h2>
+<p>
+  The query operators <a href="#dotproduct">dotProduct(field, value)</a>,
+  <a href="#weightedset">weightedSet(field, value)</a> and <a href="#wand">wand(field, value)</a>
+  support parameter substitution for the <code>value</code> parameter - example of equivalent queries:
+</p>
+<pre>
+... where weightedSet(field, {"a":1, "b":2})
+... where weightedSet(field, @myset)&amp;myset={a:1,b:2}
+</pre>
+<p>
+  Use this to:
+</p>
+<ul>
+  <li>Simplify query generation, separating the value of the set/array from the YQL string.
+    Quotes can be skipped unless the keys contain <code>,</code> or <code>:</code>.</li>
+  <li>Speed up query parsing. Using parameter substitution accelerates string parsing.</li>
+</ul>
+<p>
+  The value string can be passed in one of:
+</p>
+<ul>
+  <li>Array form: <code>[[key, value], ...]</code></li>
+  <li>Map form: <code>{key: value, ...}</code></li>
+</ul>
+<p>
+  The query operator <a href="#userinput">userInput(value)</a>
+  supports parameter substitution for the <code>value</code> parameter:
+</p>
+<pre>
+... where userInput(@input)&amp;input=free+text
+</pre>
+<p>
+  Use this to submit the user data unchanged for parsing in Vespa,
+  without risk of corrupting the YQL query.
+</p>
+<!-- ToDo: Move the examples to the query-api guide instead -->
 
 
 


### PR DESCRIPTION
@jobergum 

I am not sure if _parameter substitution_ is the best name, open for suggestions. This PR defines the format once, and link from the three operators using it. Also, userInput uses the same mechanism, with free-text input
