### PR TITLE
Format default result format to match output

### DIFF
--- a/en/reference/default-result-format.html
+++ b/en/reference/default-result-format.html
@@ -28,6 +28,51 @@ in other words, only strings are used as map keys.
             <li><code>children</code> optional, array of objects<br>
                 Array of JSON objects with exactly the same structure as
                 <code>root</code>.
+                <ul>
+                    <li><code>fields</code> optional, map of string to object<br>
+                        <ul>
+                            <li>The named document fields, this is where fields of search documents go</li>
+                            <li><a href="schema-reference.html#summary-features">summaryfeatures</a></li>
+                            <li><a href="schema-reference.html#match-features">matchfeatures</a></li>
+                        </ul>
+                    </li>
+
+                    <li><code>id</code> optional, string<br>
+                        String or URI identifying the hit, document or other data type.
+                    </li>
+
+                    <li><code>label</code> optional, string<br>
+                        The label of a grouping list.
+                    </li>
+
+                    <li><code>limits</code> optional, object<br>
+                        Used in grouping, the limits of a bucket in histogram style data.
+                        <ul>
+                            <li><code>from</code> optional, string<br>
+                                Lower bound of a bucket group.
+                            </li>
+                            <li><code>to</code> optional, string<br>
+                                Upper bound of a bucket group.
+                            </li>
+                        </ul>
+                    </li>
+
+                    <li><code>relevance</code> mandatory, double<br>
+                        Double value representing the rank score.
+                    </li>
+
+                    <li><code>source</code> optional, string<br>
+                        Which data provider created this node.
+                    </li>
+
+                    <li><code>types</code> optional, array of string<br>
+                        Meta data about what kind of document or other kind of node in the result set this object is.
+                    </li>
+
+                    <li><code>value</code> optional, string<br>
+                        Used in grouping for value groups, the argument for the grouping data which is in the fields.
+                    </li>
+                </ul>
             </li>
             <li><code>fields</code> optional, map of string to object<br>
                 <ul>
@@ -85,50 +130,6 @@ in other words, only strings are used as map keys.
                         If the flag is not present, this may or may not be the case, or the flag is not applicable.
                     </li>
                 </ul>
-            </li>
-
-            <li><code>fields</code> optional, map of string to object<br>
-                <ul>
-                    <li>The named document fields, this is where fields of search documents go</li>
-                    <li><a href="schema-reference.html#summary-features">summaryfeatures</a></li>
-                    <li><a href="schema-reference.html#match-features">matchfeatures</a></li>
-                </ul>
-            </li>
-
-            <li><code>id</code> optional, string<br>
-                String or URI identifying the hit, document or other data type.
-            </li>
-
-            <li><code>label</code> optional, string<br>
-                The label of a grouping list.
-            </li>
-
-            <li><code>limits</code> optional, object<br>
-                Used in grouping, the limits of a bucket in histogram style data.
-                <ul>
-                    <li><code>from</code> optional, string<br>
-                        Lower bound of a bucket group.
-                    </li>
-                    <li><code>to</code> optional, string<br>
-                        Upper bound of a bucket group.
-                    </li>
-                </ul>
-            </li>
-
-            <li><code>relevance</code> mandatory, double<br>
-                Double value representing the rank score.
-            </li>
-
-            <li><code>source</code> optional, string<br>
-                Which data provider created this node.
-            </li>
-
-            <li><code>types</code> optional, array of string<br>
-                Meta data about what kind of document or other kind of node in the result set this object is.
-            </li>
-
-            <li><code>value</code> optional, string<br>
-                Used in grouping for value groups, the argument for the grouping data which is in the fields.
             </li>
         </ul>
     </li>

--- a/en/reference/default-result-format.html
+++ b/en/reference/default-result-format.html
@@ -89,7 +89,7 @@ in other words, only strings are used as map keys.
 
             <li><code>fields</code> optional, map of string to object<br>
                 <ul>
-                    <li>The named document fields, this where fields of search documents go</li>
+                    <li>The named document fields, this is where fields of search documents go</li>
                     <li><a href="schema-reference.html#summary-features">summaryfeatures</a></li>
                     <li><a href="schema-reference.html#match-features">matchfeatures</a></li>
                 </ul>


### PR DESCRIPTION
This moves the list of fields typically found under the children array
of objects, more closely matching the expected JSON result format.

Additionally, adds a missing verb ("is") to one sentence.

Screenshot of formatting change

<img width="816" alt="Screen Shot 2022-02-11 at 4 05 17 PM" src="https://user-images.githubusercontent.com/5839/153662394-b9d2d722-e33e-476c-8c08-b87eb7779699.png">
: