### PR TITLE
Changes related to vespa-http-client deprecation

### DIFF
--- a/en/feed-using-hadoop-pig-oozie.html
+++ b/en/feed-using-hadoop-pig-oozie.html
@@ -13,12 +13,12 @@ Prerequisite: Have some data on a Hadoop cluster, ready to feed to Vespa.
 This includes text or JSON files on HDFS, data in Hive or HBase table.
 </p><p>
 <code>vespa-hadoop</code> contains classes and utilities to enable feeding directly to Vespa endpoints.
-It is a minimal layer over the <a href="vespa-http-client.html">Vespa HTTP client</a>. Dependency:
+It is a minimal layer over the <a href="vespa-feed-client.html">vespa-feed-client</a>. Dependency:
 <pre>
 &lt;dependency&gt;
   &lt;groupId&gt;com.yahoo.vespa&lt;/groupId&gt;
   &lt;artifactId&gt;vespa-hadoop&lt;/artifactId&gt;
-  &lt;version&gt;7.25.26&lt;/version&gt; &lt;!-- Find latest version at <a href="https://search.maven.org/search?q=g:com.yahoo.vespa%20a:vespa-hadoop">search.maven.org/search?q=g:com.yahoo.vespa%20a:vespa-hadoop</a> --&gt;
+  &lt;version&gt;7.543.30&lt;/version&gt; &lt;!-- Find latest version at <a href="https://search.maven.org/search?q=g:com.yahoo.vespa%20a:vespa-hadoop">search.maven.org/search?q=g:com.yahoo.vespa%20a:vespa-hadoop</a> --&gt;
 &lt;/dependency&gt;
 </pre>
   {% include important.html content="<code>vespa-hadoop</code> depends on the Apache HTTP client library.
@@ -54,15 +54,11 @@ STORE A INTO '$ENDPOINT' USING VespaStorage();
 </pre>
 <p>
 To run the above Pig script, specify <a href="#vespa.feed.endpoint">endpoint</a>.
-The endpoint is the Vespa endpoint (hostname) to feed to.
-Importantly, the endpoint should be defined as it is for the
-<a href="vespa-http-client.html">Vespa HTTP client</a>,
-which means the endpoint is equal to the hostname, without schema ('http(s)://' and without port number.
+The endpoint is the hostname to feed to.
 Port 4080 currently the default setting, to override the port use <code>-Dvespa.feed.defaultport=8080</code>.
 </p>
 <p>
-  <code>VespaStorage</code> supports feeding to
-  <a href="vespa-http-client.html#feeding-multiple-clusters">multiple clusters</a>.
+  <code>VespaStorage</code> supports feeding to multiple clusters.
   To specify multiple endpoints, separate them by commas.
   The VespaStorage will write the operations to all clusters and wait for a reply/ack from all,
   hence it's a blocking implementation.
@@ -451,7 +447,7 @@ Any errors can be found in the job logs.
 <h3 id="efficiency">Efficiency</h3>
 <p>
 <code>VespaStorage</code> uses the
-<a href="vespa-http-client.html">Vespa HTTP Client</a>,
+<a href="vespa-feed-client.html">vespa-feed-client</a>,
 and as such feeds as efficiently as possible.
 As <code>VespaStorage</code> runs in a Pig job which is compiled down to a MapReduce or Tez job,
 a number of mappers or reducers will be used to cover the file if the input file is sufficiently large.
@@ -580,8 +576,7 @@ For Oozie, specify them as parameters in the configuration section of the action
       <td>Log sent/ok/failed/skipped documents every n records</td></tr>
     <tr id="vespa.feed.connections"><th>vespa.feed.connections</th>
       <td><em>1</em></td>
-      <td>Number of concurrent connections per mapper/reducer:
-        <a href="https://javadoc.io/doc/com.yahoo.vespa/vespa-http-client/latest/com/yahoo/vespa/http/client/config/ConnectionParams.Builder.html">setNumPersistentConnectionsPerEndpoint</a></td></tr>
+      <td>Number of concurrent connections per mapper/reducer</td></tr>
     <tr id="vespa.feed.route"><th>vespa.feed.route</th>
       <td><em>default</em></td>
       <td><a href="routing.html">Route</a> to use on endpoint</td></tr>

--- a/en/performance/http2.html
+++ b/en/performance/http2.html
@@ -12,6 +12,20 @@ redirect_from:
 <h2>Enabling HTTP/2 on container</h2>
 <p>
     HTTP/2 is enabled on a container for all connectors with TLS/HTTPS configured (requires Vespa 7.418.23 or newer).
+    From Vespa 7.462.20 HTTP/2 is available and enabled by default for connectors without TLS as well.
+    We do recommended HTTP/2 with TLS, both for added security, but also for a more robust connection upgrade mechanism.
+    Web browsers will typically only allow HTTP/2 over TLS.
+</p>
+
+<h3>HTTP/2 without TLS</h3>
+<p>The jdisc container supports both mechanism for HTTP/2 without TLS:</p>
+<ol>
+    <li>Upgrading to HTTP/2 from HTTP/1</li>
+    <li>HTTP/2 with prior knowledge</li>
+</ol>
+
+<h3>HTTP/2 with TLS</h3>
+<p>
     Both HTTP/1.1 and HTTP/2 will be served over the same connector using the <a href="https://datatracker.ietf.org/doc/html/rfc7301">TLS ALPN Extension</a>.
     The Application-Layer Protocol Negotiation (ALPN) extension allows the client to send a list of supported protocols during TLS handshake.
     The container selects a supported protocol from that list.

--- a/en/performance/http2.html
+++ b/en/performance/http2.html
@@ -17,13 +17,6 @@ redirect_from:
     Web browsers will typically only allow HTTP/2 over TLS.
 </p>
 
-<h3>HTTP/2 without TLS</h3>
-<p>The jdisc container supports both mechanism for HTTP/2 without TLS:</p>
-<ol>
-    <li>Upgrading to HTTP/2 from HTTP/1</li>
-    <li>HTTP/2 with prior knowledge</li>
-</ol>
-
 <h3>HTTP/2 with TLS</h3>
 <p>
     Both HTTP/1.1 and HTTP/2 will be served over the same connector using the <a href="https://datatracker.ietf.org/doc/html/rfc7301">TLS ALPN Extension</a>.
@@ -39,6 +32,13 @@ redirect_from:
     <li>Client must provide target domain with the TLS Server Name Indication (SNI) Extension.</li>
     <li>Client must not use any of the banned <a href="https://datatracker.ietf.org/doc/html/rfc7540#appendix-A">TLSv1.2 ciphers</a>.</li>
 </ul>
+
+<h3>HTTP/2 without TLS</h3>
+<p>The jdisc container supports both mechanism for HTTP/2 without TLS:</p>
+<ol>
+    <li>Upgrading to HTTP/2 from HTTP/1</li>
+    <li>HTTP/2 with prior knowledge</li>
+</ol>
 
 <h2>Feeding over HTTP/2</h2>
 <p>

--- a/en/vespa-feed-client.html
+++ b/en/vespa-feed-client.html
@@ -34,16 +34,6 @@ redirect_from:
     HTTP/2 over <a href="reference/services-http.html#ssl">TLS</a> is optional but recommended from a security perspective.
 </p>
 
-<h3>Example <em>services.xml</em> without TLS</h3>
-<pre>
-&lt;?xml version="1.0" encoding="utf-8" ?&gt;
-&lt;services version="1.0"&gt;
-  &lt;container version="1.0" id="default"&gt;
-    <span class="pre-hilite">&lt;document-api/&gt;</span>
-  &lt;/container&gt;
-&lt;/services&gt;
-</pre>
-
 <h3>Example <em>services.xml</em> with TLS</h3>
 <pre>
 &lt;?xml version="1.0" encoding="utf-8" ?&gt;
@@ -59,6 +49,16 @@ redirect_from:
       &lt;/server&gt;
     &lt;/http&gt;
     &lt;document-api/&gt;</span>
+  &lt;/container&gt;
+&lt;/services&gt;
+</pre>
+
+<h3>Example <em>services.xml</em> without TLS</h3>
+<pre>
+&lt;?xml version="1.0" encoding="utf-8" ?&gt;
+&lt;services version="1.0"&gt;
+  &lt;container version="1.0" id="default"&gt;
+    <span class="pre-hilite">&lt;document-api/&gt;</span>
   &lt;/container&gt;
 &lt;/services&gt;
 </pre>
@@ -93,18 +93,19 @@ redirect_from:
 
 <h3>Example command line</h3>
 
-HTTP/2 without TLS:
-<pre>
-$ vespa-feed-client --file /path/to/json/file --endpoint https://container-endpoint:4443/ --connections 4
-</pre>
-
-HTTP/2 over TLS:
+<h4>HTTP/2 over TLS</h4>
 <pre>
 $ vespa-feed-client --file /path/to/json/file --endpoint https://container-endpoint:4443/ --connections 4 \
     --certificate cert.pem --private-key key.pem --ca-certificates ca.pem
 </pre>
 The input must be either a proper JSON array, or a series, of JSON feed operations (<a href="https://jsonlines.org">JSONL</a>),
 in the format described for the Vespa feed client <a href="reference/document-json-format.html#document-operations">here</a>.
+
+
+<h4>HTTP/2 without TLS</h4>
+<pre>
+$ vespa-feed-client --file /path/to/json/file --endpoint https://container-endpoint:4443/ --connections 4
+</pre>
 
 <h3>Feed using Hadoop, Pig, Oozie</h3>
 <p>

--- a/en/vespa-feed-client.html
+++ b/en/vespa-feed-client.html
@@ -29,9 +29,22 @@ redirect_from:
 <p>Requirements:</p>
 <ul>
     <li><a href="reference/services-container.html#document-api">Document API must be enabled on container</a>.</li>
-    <li><a href="reference/services-http.html#ssl">Container port must be configured with SSL</a>.</li>
 </ul>
-<h3>Example services.xml</h3>
+<p>
+    HTTP/2 over <a href="reference/services-http.html#ssl">TLS</a> is optional but recommended from a security perspective.
+</p>
+
+<h3>Example <em>services.xml</em> without TLS</h3>
+<pre>
+&lt;?xml version="1.0" encoding="utf-8" ?&gt;
+&lt;services version="1.0"&gt;
+  &lt;container version="1.0" id="default"&gt;
+    <span class="pre-hilite">&lt;document-api/&gt;</span>
+  &lt;/container&gt;
+&lt;/services&gt;
+</pre>
+
+<h3>Example <em>services.xml</em> with TLS</h3>
 <pre>
 &lt;?xml version="1.0" encoding="utf-8" ?&gt;
 &lt;services version="1.0"&gt;
@@ -79,15 +92,21 @@ redirect_from:
 
 
 <h3>Example command line</h3>
+
+HTTP/2 without TLS:
+<pre>
+$ vespa-feed-client --file /path/to/json/file --endpoint https://container-endpoint:4443/ --connections 4
+</pre>
+
+HTTP/2 over TLS:
 <pre>
 $ vespa-feed-client --file /path/to/json/file --endpoint https://container-endpoint:4443/ --connections 4 \
     --certificate cert.pem --private-key key.pem --ca-certificates ca.pem
 </pre>
-where the input must be either a proper JSON array, or a series, of JSON feed operations (<a href="https://jsonlines.org">JSONL</a>),
+The input must be either a proper JSON array, or a series, of JSON feed operations (<a href="https://jsonlines.org">JSONL</a>),
 in the format described for the Vespa feed client <a href="reference/document-json-format.html#document-operations">here</a>.
 
 <h3>Feed using Hadoop, Pig, Oozie</h3>
 <p>
-    Set <code>vespa.feed.uselegacyclient</code> config parameter to <code>false</code> to enable <em>vespa-feed-client</em>
-    for the <a href="feed-using-hadoop-pig-oozie.html">vespa-hadoop library</a>.
+    See the dedicated documentation for <a href="feed-using-hadoop-pig-oozie.html">vespa-hadoop library</a>.
 </p>


### PR DESCRIPTION
Document that HTTP/2 / vespa-feed-client no longer requires TLS.
Update vespa-hadoop documentation to reflect new client backend.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
