### PR TITLE
Add section about unknown summary classes.

### DIFF
--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -635,6 +635,13 @@ TODO Check:
 * VESPA-7875 Move XML files to top-level inside application package
 </p>
 -->
+<h3 id="unknown-summary-classes">Unknown summary classes</h3>
+<p>
+  Queries that specify a non-existent <a href="document-summaries.html#summary-classes-in-queries">summary class</a>
+  will now fail, instead of being rendered empty. Queries hitting multiple document types must use a summary class
+  that exists in all of them
+</p>
+
 <h3 id="qrserver-service-name">The "qrserver" service name</h3>
 <p>
   Vespa containers are in general using "container" as their service name. However, a container cluster that has


### PR DESCRIPTION
Should we be more specific, or is there any more context we can add? For example, should the query fail in a specific way, error code or similar?
