### PR TITLE
Add DocumentAccess.createDefault to removed Java APIs

### DIFF
--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -195,12 +195,15 @@ to generate the correct set of imported packages for your OSGi bundles.
 <p>
 Classes and methods that were marked as deprecated in Vespa 7 are removed.
 If deprecation warnings are emitted for Vespa API's when building the application,
-these must be fixed before migrating to Vespa 8. The below list contains only the
+these must be fixed before migrating to Vespa 8. The sections below contain only the
 most notable changes.
 </p>
 
+
+<h3 id="removed-java-packages">Java Packages</h3>
+
 <table class="table">
-  <thead><tr><th>Type(s)</th><th>Description</th></tr></thead>
+  <thead><tr><th>Package</th><th>Description</th></tr></thead>
   <tbody>
     <tr>
       <td><em>com.yahoo.config.subscription</em></td>
@@ -222,6 +225,21 @@ most notable changes.
       <td><em>com.yahoo.vespa.curator</em></td>
       <td>No longer public API</td>
     </tr>
+  </tbody>
+</table>
+
+
+<h3 id="removed-clases-and-methods">Java Methods</h3>
+
+<table class="table">
+  <thead><tr><th>Method</th><th>Description</th></tr></thead>
+  <tbody>
+  <tr>
+    <td><em>com.yahoo.documentapi.DocumentAccess.createDefault()</em></td>
+    <td>Container components can have a <em>DocumentAccess</em> injected via their constructor.
+      For use outside the container, e.g. in a custom command line tool, use the new method
+      <em>createForNonContainer()</em>.</td>
+  </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
- Use separate subsections for packages and methods.

