### PR TITLE
Mention removal of "second pass" methods from VisitorStatistics in release notes

### DIFF
--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -532,6 +532,10 @@ most notable changes.
       <td><em>com.yahoo.jdisc.Container</em></td>
       <td>Removed use of Guice types from class signature.</td>
     </tr>
+    <tr>
+      <td><em>com.yahoo.vdslib.VisitorStatistics</em></td>
+      <td>Removed all <em>set/getSecondPass</em>-related methods</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
@gjoranv please review. No idea if anyone's actually using this API, but let's stay on the safe side.
