### PR TITLE
Use new, slimmer syntax

### DIFF
--- a/en/approximate-nn-hnsw.html
+++ b/en/approximate-nn-hnsw.html
@@ -73,16 +73,17 @@ Choosing the value of these parameters affects both accuracy, query speed, and a
 <p>The tensors used in queries must have their type declared in a query profile in the application package
 as discussed in the <a href="nearest-neighbor-search.html">exact nearest neighbor search</a> document. 
 
+
 <h3 id="approximate-nearest-neighbor-query">Using fast approximate nearest neighbor search in query</h3>
 
 <p>With an <em>HNSW</em> index enabled on the tensor field one can choose between approximate
-or exact (brute-force) search by using the <em>approximate</em> annotation:</p>
-
+or exact (brute-force) search by using the
+<a href="reference/query-language-reference.html#approximate">approximate</a> annotation:</p>
 <pre>
 {
-  "yql": "select title,price from sources * where ([{\"targetHits\": 10, \"approximate\":false}]nearestNeighbor(image_sift_encoding,query_vector_sift)) and in_stock = true;",
+  "yql": "select title,price from sources * where ({targetHits: 10, approximate:false}nearestNeighbor(image_sift_encoding,query_vector_sift)) and in_stock = true",
   "hits": 100
-  "ranking.features.query(query_vector_sift): [0.21,0.12,....],
+  "ranking.features.query(query_vector_sift)": [0.21,0.12,....],
   "ranking.profile": "image_similarity" 
 }
 </pre>
@@ -92,7 +93,8 @@ The <em>approximate</em> parameter allows computing the accuracy loss
 by computing the exact neighbors and compare with the approximation to compute the accuracy metric (e.g., recall@k).
 </p>
 <p>
-In addition to <em>targetHits</em>, there is a <em>hnsw.exploreAdditionalHits</em> parameter
+In addition to <a href="reference/query-language-reference.html#targethits">targetHits</a>,
+there is a <a href="reference/query-language-reference.html#hnsw-exploreadditionalhits">hnsw.exploreAdditionalHits</a> parameter
 which controls how many extra nodes in the graph (in addition to <em>targetHits</em>)
 that are explored during the graph search.
 </p>
@@ -101,12 +103,13 @@ Using a greater number gives better quality (accuracy as compared with the brute
 </p>
 <pre>
 {
-  "yql": "select title,price from sources * where ([{\"targetHits\": 10, \"hnsw.exploreAdditionalHits\":100}]nearestNeighbor(image_sift_encoding,query_vector_sift)) and in_stock = true;
-  "hits": 10
-  "ranking.features.query(query_vector_sift): [0.21,0.12,....],
+  "yql": "select title,price from sources * where ({targetHits: 10, hnsw.exploreAdditionalHits:100}nearestNeighbor(image_sift_encoding,query_vector_sift)) and in_stock = true",
+  "hits": 10,
+  "ranking.features.query(query_vector_sift)": [0.21,0.12,....],
   "ranking.profile": "image_similarity" 
 }
 </pre>
+
 
 
 <h2 id="nearest-neighbor-search-considerations">Nearest Neighbor Search Considerations</h2>

--- a/en/getting-started-ranking.md
+++ b/en/getting-started-ranking.md
@@ -393,7 +393,7 @@ curl -s 'https://doc-search.vespa.oath.cloud/search/?yql=select%20*%20from%20doc
 </pre>
 
 {% include query.html content=
-"[select * from doc where [{\"scoreThreshold\": 0, \"targetHits\": 10}]weakAnd(default contains \"vespa\", default contains \"documents\", default contains \"about\", default contains \"ranking\", default contains \"and\", default contains \"retrieval\");](https://doc-search.vespa.oath.cloud/search/?yql=select%20*%20from%20doc%20where%20%5B%7B%22scoreThreshold%22%3A0%2C%22targetHits%22%3A10%7D%5D%0AweakAnd(default%20contains%20%22vespa%22,default%20contains%20%22documents%22,default%20contains%20%22about%22,default%20contains%20%22ranking%22,default%20contains%20%22and%22,default%20contains%20%22retrieval%22)%3B)"%}
+"[select * from doc where {scoreThreshold: 0, targetHits: 10}weakAnd(default contains \"vespa\", default contains \"documents\", default contains \"about\", default contains \"ranking\", default contains \"and\", default contains \"retrieval\");](https://doc-search.vespa.oath.cloud/search/?yql=select%20*%20from%20doc%20where%20%5B%7B%22scoreThreshold%22%3A0%2C%22targetHits%22%3A10%7D%5D%0AweakAnd(default%20contains%20%22vespa%22,default%20contains%20%22documents%22,default%20contains%20%22about%22,default%20contains%20%22ranking%22,default%20contains%20%22and%22,default%20contains%20%22retrieval%22)%3B)"%}
 
 Note that this blurs the distinction between filtering (retrieval) and ranking a little -
 here the `weakAnd` does <span style="text-decoration: underline">both</span> filtering and ranking

--- a/en/learning-to-rank.html
+++ b/en/learning-to-rank.html
@@ -181,7 +181,7 @@ In this example use the ranking profile <em>training</em> as defined above:
 </p>
 <pre>
 {
-    "yql" : "select rankfeatures from sources * where ([{\"grammar\": \"any\"}]userInput(@userQuery));",
+    "yql" : "select rankfeatures from sources * where ({grammar: \"any\"}]userInput(@userQuery))",
     "userQuery": "hotels close to san jose airport",
     "recall:": "+id:8444",
     "hits": 1,
@@ -196,7 +196,8 @@ In this example use the ranking profile <em>training</em> as defined above:
 <p>
 We limit the recall to the document id by the recall parameter,
 and we select only rankfeatures field.
-We also use grammar 'any' instead of the default 'and' mode when parsing the user input query,
+We also use <a href="reference/query-language-reference.html#grammar">grammar</a> 'any' instead of the default 'and' mode
+when parsing the user input query,
 as the document will not be recalled if not all terms are found in the document.
 Vespa will return a response like this per hit:
 </p>

--- a/en/nearest-neighbor-search.html
+++ b/en/nearest-neighbor-search.html
@@ -278,7 +278,7 @@ rank-profile image-similarity inherits default {
 </p>
 <pre>
 {
-    "yql": "select title, price from sources products where ([{\"targetHits\": 10}]nearestNeighbor(image_sift_encoding,query_vector_sift)) and in_stock = true;",
+    "yql": "select title, price from sources products where ({targetHits: 10}nearestNeighbor(image_sift_encoding,query_vector_sift)) and in_stock = true",
     "ranking.features.query(query_vector_sift)": [
         0.22507139604882176,
         0.11696498718517367,
@@ -292,8 +292,8 @@ rank-profile image-similarity inherits default {
 <p>
   The YQL query uses logical conjunction <em>and</em> so that the nearest neighbor search is restricted
   to documents where <em>in_stock</em> is true.
-  The <em>targetHits</em> is the desired number of neighbors which is exposed to the first-phase ranking function
-  declared in the image-similarity ranking profile.
+  The <a href="reference/query-language-reference.html#targethits">targetHits</a> is the desired number of neighbors
+  which is exposed to the first-phase ranking function declared in the image-similarity ranking profile.
 </p>
 <p>
   The total number of hits which is ranked by the ranking profile
@@ -368,8 +368,8 @@ rank-profile hybrid-similarity {
 </p>
 <pre>
 {
-    "yql": "select title, price from sources products where (([{\"targetNumHits\": 10}]nearestNeighbor(title_bert_embedding,query_vector_bert))
-    or ([{\"targetNumHits\": 10}]nearestNeighbor(image_sift_encoding,query_vector_sift))) and in_stock = true;",
+    "yql": "select title, price from sources products where (({targetHits: 10}nearestNeighbor(title_bert_embedding,query_vector_bert))
+    or ({targetHits: 10}nearestNeighbor(image_sift_encoding,query_vector_sift))) and in_stock = true",
     "hits": 10,
     "ranking.features.query(query_vector_sift)": [
         0.5158057404746615,

--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1348,6 +1348,7 @@ where%20text%20contains%20(%7Bdistance%3A%205%7Dnear(%22a%22%2C%20%22b%22))
     <td>Map of <code>id: int, weight: double</code> of explicit connectivity of this item - example:
       <pre>connectivity: {"id": 4, "weight": 7.0}</pre>
     </td>
+    <!-- ToDo: link to weight-significance-and-connectedness in text-matching-ranking ? I think this is the same ...-->
   </tr>
   <tr id="descending">
     <td>descending</td>
@@ -1641,7 +1642,9 @@ where%20myUrlField.hostname%20contains%20(%7BstartAnchor%3A%20true%7Duri(%22vesp
     <td>significance</td>
     <td></td>
     <td>double</td>
-    <td>Significance value for ranking.</td>
+    <td>Significance value for ranking -
+      see <a href="../text-matching-ranking.html#weight-significance-and-connectedness">text matching and ranking</a>.
+    </td>
   </tr>
   <tr id="startanchor">
     <td>startAnchor</td>
@@ -1706,7 +1709,8 @@ where%20myUrlField.hostname%20contains%20(%7BstartAnchor%3A%20true%7Duri(%22vesp
     <td>weight</td>
     <td>100</td>
     <td>int</td>
-    <td>Term weight, used in some ranking calculations.
+    <td>Term weight, used in some ranking calculations -
+      see <a href="../text-matching-ranking.html#weight-significance-and-connectedness">text matching and ranking</a>.
 <pre class="urlunencode" oncopy="">
 where%20title%20contains%20(%7Bweight%3A200%7D"heads")
 </pre>

--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1345,10 +1345,13 @@ where%20text%20contains%20(%7Bdistance%3A%205%7Dnear(%22a%22%2C%20%22b%22))
     <td>connectivity</td>
     <td></td>
     <td>map</td>
-    <td>Map of <code>id: int, weight: double</code> of explicit connectivity of this item - example:
-      <pre>connectivity: {"id": 4, "weight": 7.0}</pre>
+    <td>Map of <code>id: int, weight: double</code> of explicit connectivity between this item
+      and the item with the given <a href="#id">id</a> -
+      see <a href="../text-matching-ranking.html#weight-significance-and-connectedness">text matching and ranking</a>.
+      Example:
+      <pre>connectivity: {id: 4, weight: 0.8}</pre>
+      <!-- ToDo: verify that the keys in the map do not have to be quoted -->
     </td>
-    <!-- ToDo: link to weight-significance-and-connectedness in text-matching-ranking ? I think this is the same ...-->
   </tr>
   <tr id="descending">
     <td>descending</td>
@@ -1550,7 +1553,7 @@ where%20myUrlField.hostname%20contains%20(%7BstartAnchor%3A%20true%7Duri(%22vesp
     <td>id</td>
     <td></td>
     <td>int</td>
-    <td>Unique ID used for e.g. connectivity.</td>
+    <td>Unique ID used for e.g. <a href="#connectivity">connectivity</a>.</td>
   </tr>
   <tr id="implicittransforms">
     <td>implicitTransforms</td>

--- a/en/reference/rank-features.html
+++ b/en/reference/rank-features.html
@@ -64,8 +64,10 @@ Notes:
     </p><p>
     This should ideally be set by a searcher in the container for global correctness
     as each node will estimate the significance values from the local corpus.
-    <a href="https://javadoc.io/doc/com.yahoo.vespa/container-search/latest/com/yahoo/prelude/query/TaggableItem.html#setSignificance-double-">
-    Query API for setting significance</a>
+    Use the
+    <a href="https://javadoc.io/doc/com.yahoo.vespa/container-search/latest/com/yahoo/prelude/query/TaggableItem.html#setSignificance(double)">
+      Java API for significance</a> or
+    <a href="query-language-reference.html#significance">YQL annotation for significance</a>.
     </p><p>
     As a fallback, a significance based on Robertson-Sparck-Jones term
     weighting is used; it is logarithmic from 1.0 for rare terms down
@@ -88,7 +90,10 @@ Notes:
   <td>0.1</td>
   <td>
     The normalized strength with which this term is connected to the previous term in the query.
-    Must be assigned to query terms in a  <a href="../searcher-development.html">searcher</a>.
+    Must be assigned to query terms in a <a href="../searcher-development.html">searcher</a> using the
+    <a href="https://javadoc.io/doc/com.yahoo.vespa/container-search/latest/com/yahoo/prelude/query/TaggableItem.html#setConnectivity(com.yahoo.prelude.query.Item,double)">
+    Java API for connectivity</a>
+    or <a href="query-language-reference.html#connectivity">YQL annotation for connectivity</a>.
   </td></tr>
 
 <tr id="queryTermCount"><td>queryTermCount</td>

--- a/en/reference/select-reference.md
+++ b/en/reference/select-reference.md
@@ -434,7 +434,7 @@ Format of this in JSON:
 ```
 
 ###### weakAnd
-YQL: `where [{"scoreThreshold": 41, "targetHits": 7}]weakAnd(a contains "A", b contains "B")`.
+YQL: `where {scoreThreshold: 41, "targetHits": 7}weakAnd(a contains "A", b contains "B")`.
 
 Format of this in JSON:
 

--- a/en/semantic-qa-retrieval.html
+++ b/en/semantic-qa-retrieval.html
@@ -274,7 +274,7 @@ schema sentence {
 </p>
 <pre>{% highlight json %}
 {
-    "yql": "select * from sources sentence where ({targetNumHits:100}nearestNeighbor(sentence_embedding,query_embedding))",
+    "yql": "select * from sources sentence where ({targetHits:100}nearestNeighbor(sentence_embedding,query_embedding))",
     "hits": 100,
     "ranking.features.query(query_embedding)": [-0.0466, ...,0.064],
     "ranking.profile": "sentence-semantic-similarity"
@@ -311,7 +311,7 @@ rank-profile sentence-semantic-similarity inherits default {
 </p>
 <pre>{% highlight json %}
 {
-    "yql": "select * from sources sentence where ({targetNumHits:100}nearestNeighbor(sentence_embedding,query_embedding)) | all(group(context_id) max(100) order(-max(relevance())) each( max(2) each(output(summary())) as(sentences)) as(paragraphs))",
+    "yql": "select * from sources sentence where ({targetHits:100}nearestNeighbor(sentence_embedding,query_embedding)) | all(group(context_id) max(100) order(-max(relevance())) each( max(2) each(output(summary())) as(sentences)) as(paragraphs))",
     "hits": 0,
     "ranking.features.query(query_embedding)": [-0.0466, ...,0.064],
     "ranking.profile": "sentence-semantic-similarity"
@@ -333,7 +333,7 @@ rank-profile sentence-semantic-similarity inherits default {
 </p>
 <pre>{% highlight json %}
 {
-    "yql": "select * from sources sentence  where ({targetNumHits:100}nearestNeighbor(sentence_embedding,query_embedding)) or userQuery()",
+    "yql": "select * from sources sentence  where ({targetHits:100}nearestNeighbor(sentence_embedding,query_embedding)) or userQuery()",
     "query": "To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?",
     "type": "any",
     "hits": 100,

--- a/en/streaming-search.html
+++ b/en/streaming-search.html
@@ -125,9 +125,9 @@ select * from sources * where artist contains "billie";
 Without changing schema, one can do substring matching in tokens using
 <a href="reference/query-language-reference.html#annotations">annotations</a> - this matches "Coldplay":
 <pre>
-select * from sources * where artist contains ([{"prefix":true}]"col");
-select * from sources * where artist contains ([{"substring":true}]"old");
-select * from sources * where artist contains ([{"suffix":true}]"play");
+select * from sources * where artist contains ({prefix:true}]"col");
+select * from sources * where artist contains ({substring:true}"old");
+select * from sources * where artist contains ({suffix:true}"play");
 </pre>
 Instead of annotating query terms, enable prefix matching as default,
 and find that this query now also matches "Coldplay":

--- a/en/text-matching-ranking.html
+++ b/en/text-matching-ranking.html
@@ -294,7 +294,8 @@ by sending weight, significance and connectedness with the query:
       <code><a href="reference/rank-features.html#fieldMatch(name).importance">
       fieldMatch(<em>name</em>).importance</a></code> for convenience.</p></td>
     </tr><tr><th>Connectedness</th><td><p>
-      Signify the degree of connection between adjacent terms in the query.
+      Signify the degree of connection between adjacent terms in the query -
+      set query term <a href="reference/query-language-reference.html#connectivity">connectivity</a> to another term.
       For example, the query <code>new york newspaper</code> should have a higher connectedness
       between the terms "new" and "york" than between "york" and "newspaper" to rank documents higher
       if they contain "new york" as a phrase.

--- a/en/text-matching-ranking.html
+++ b/en/text-matching-ranking.html
@@ -265,8 +265,8 @@ by sending weight, significance and connectedness with the query:
 <table class="table">
   <thead></thead><tbody>
     <tr><th>Weight</th><td><p>
-      Set query term weight.
-      Example: <code>... where (title contains ([{"weight":200}]"heads") AND title contains "tails")</code>
+      Set query term <a href="reference/query-language-reference.html#weight">weight</a>.
+      Example: <code>... where (title contains ({weight:200}"heads") AND title contains "tails")</code>
       specifies that <code>heads</code> is twice as important for the final rank score than <code>tails</code>
       (the default weight is 100).
       </p><p>
@@ -280,7 +280,8 @@ by sending weight, significance and connectedness with the query:
       Configure static field weights in the
       <a href="reference/schema-reference.html#weight">schema</a>.</p></td>
     </tr><tr><th>Significance</th><td><p>
-      How rare a particular term is in the corpus or the language.
+      Set query term <a href="reference/query-language-reference.html#significance">significance</a> -
+      how rare a particular term is in the corpus or the language.
       This is sometimes valuable information because if a document matches a rare word,
       it might mean the document is more important than one which matches a common word.
       Significance is calculated automatically by Vespa during indexing,
@@ -305,6 +306,7 @@ by sending weight, significance and connectedness with the query:
       Connectedness is a normalized value which is 0.1 by default.
       It must be set by a custom Searcher,
       looking up connectivity information from somewhere - there is no query syntax for it.</p></td>
+      <!-- ToDo: Use connectivity and id query annotations to do this? -->
     </tr>
   </tbody>
 </table>

--- a/en/tutorials/text-search-semantic.md
+++ b/en/tutorials/text-search-semantic.md
@@ -94,11 +94,12 @@ A sample query looks like this:
 
 The match operator `OR` means that we are matching documents that contain any of the query terms
 either in the title or in the body.
-The only difference is the inclusion of the `[{"grammar": "any"}]` in the [YQL](../query-language.html) expression:
+The only difference is the inclusion of the `{grammar: "any"}` in the
+[YQL](../reference/query-language-reference.html#grammar) expression:
 
 ```
 {
-	"yql":"select * from sources * where ([{"grammar": "any"}]userInput(@userQuery));"
+	"yql":"select * from sources * where ({grammar: "any"}userInput(@userQuery))"
 	...
 }
 ```
@@ -271,7 +272,7 @@ together with the appropriate rank-profile:
 
 ```
 {
-	"yql":"select * from sources * where ([{"targetHits": 1000, "label": "nns"}]nearestNeighbor(title_bert, tensor_bert));"
+	"yql":"select * from sources * where ({targetHits: 1000, label: "nns"}nearestNeighbor(title_bert, tensor_bert))"
 	"userQuery":"what types of plate boundaries cause deep sea trenches"
 	"ranking":{
 		"profile":"bert_title_body_all"
@@ -339,7 +340,7 @@ with an annotation that sets the target number of documents to be 1.000:
 
 ```
 {
-	"yql":"select * from sources * where ([{"targetHits": 1000}]weakAnd(default contains "what", default contains "types", default contains "of", default contains "plate", default contains "boundaries", default contains "cause", default contains "deep", default contains "sea", default contains "trenches"));"
+	"yql":"select * from sources * where ({targetHits: 1000}weakAnd(default contains "what", default contains "types", default contains "of", default contains "plate", default contains "boundaries", default contains "cause", default contains "deep", default contains "sea", default contains "trenches"))"
 	"userQuery":"what types of plate boundaries cause deep sea trenches"
 	"ranking":{
 		"profile":"bm25"

--- a/en/using-wand-with-vespa.html
+++ b/en/using-wand-with-vespa.html
@@ -155,15 +155,16 @@ select * from passages where (
 </p>
 <pre>
 select * from passages where (
-    [{"targetHits": 200}]
+    {targetHits: 200}
         weakAnd(
             default contains "is", default contains "cdg", default contains "airport",
             default contains "in", default contains "main", default contains "paris"
     )
-);
+)
 </pre>
 <p>
-  We specify that the target number of hits (top k) should be 200 (Default 100)
+  We specify that the <a href="reference/query-language-reference.html#targethits">target number of hits (top k)</a>
+  should be 200 (Default 100),
   and this number is used per content node if the content is distributed over more than one node.
 </p>
 
@@ -275,12 +276,12 @@ We can process text and tokenize the text with a BERT tokenizer and set the weig
 <pre>
 {
     "yql":"select * from passages where rank(
-        ([{"targetHits": 25}]
+        ({targetHits: 25}
             wand(deep_ct_tokens, @tokens)),
             userQuery());",
-    "tokens": "{2003: 1, 3729: 1, 2290: 1, 3199: 1, 1999: 1, 2364: 1, 3000: 1}"
+    "tokens": "{2003: 1, 3729: 1, 2290: 1, 3199: 1, 1999: 1, 2364: 1, 3000: 1}",
     "query": "is cdg airport in main paris?",
-    "type": "any"
+    "type": "any",
     "ranking.profile": "deep_bm25"
 }
 </pre>


### PR DESCRIPTION
- targetNumHits is now targetHits
- ToDo on connectivity/id annotations, I think latest update to http://localhost:4000/en/text-matching-ranking.html#connectedness might be wrong, Searcher not required, can do this in YQL?
