### PR TITLE
Remove <clients> element that only contained deprecated load type config

### DIFF
--- a/en/reference/services.html
+++ b/en/reference/services.html
@@ -14,7 +14,6 @@ redirect_from:
   <a href="services-content.html">content   [version]</a>
   <a href="services-admin.html">admin     [version]</a>
   <a href="services-routing.html">routing   [version]</a>
-  <a href="#clients">clients   [version]</a>
 </pre>
 Nodes/hosts referred to in <em>services.xml</em> must be defined in
 <a href="hosts.html">hosts.xml</a> using <em>hostalias</em>.
@@ -43,7 +42,6 @@ or <em>service</em> is required):
   <li><a href="services-content.html"><code>content</code></a></li>
   <li><a href="services-container.html"><code>container</code></a></li>
   <li><a href="services-routing.html"><code>routing</code></a></li>
-  <li><a href="#clients"><code>clients</code></a></li>
 </ul>
 <p>Example:</p>
 <pre>
@@ -68,51 +66,6 @@ or <em>service</em> is required):
   &lt;/content&gt;
 &lt;/services&gt;
 </pre>
-
-
-
-<h2 id="clients">clients</h2>
-<p>
-The <code>clients</code>-element is for configuring clients accessing Vespa
-using the <a href="../api.html">Document API</a>.
-<em>version</em> must be set to "2.0".
-The only supported child element is <code>load-types</code>, that has one or more <code>types</code>.
-Use the type to create user-defined load-types with a default priority.
-</p>
-<table class="table">
-  <thead>
-  <tr><th>Attribute</th><th>Required</th><th>Value</th><th>Default</th><th>Description</th></tr>
-  </thead><tbody>
-<tr><th>name</th>
-  <td>required</td>
-  <td>string</td>
-  <td></td>
-  <td>User-defined load type name</td></tr>
-<tr><th>default-priority</th>
-  <td>required</td>
-  <td>string</td>
-  <td></td>
-  <td>Default priority</td></tr>
-</tbody>
-</table>
-<p>
-Priorities are byte values from 0 to 255, where 0 is the highest priority.
-16 priority values are mapped to names, see <em>Priority</em> enum in
-<a href="https://github.com/vespa-engine/vespa/blob/master/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentProtocol.java">
-DocumentProtocol</a>.
-Do not use HIGH_3 or higher, as this will interfere with internal Vespa operations. Example:
-</p>
-<pre>
-&lt;clients version="2.0"&gt;
-  &lt;load-types&gt;
-    &lt;type name="user_query"  default-priority="VERY_HIGH" /&gt;
-    &lt;type name="maintenance" default-priority="NORMAL_6" /&gt;
-    &lt;type name="third_party" default-priority="LOW_1" /&gt;
-  &lt;/load-types&gt;
-&lt;/clients&gt;
-</pre>
-
-
 
 <h2 id="generic-config">Generic configuration using &lt;config&gt;</h2>
 <p>

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -395,13 +395,17 @@ The following defaults have changed:
     <td>Ignored, the local node will automatically be preferred when appropriate.</td>
   </tr>
   <tr>
-    <td rowspan="2">&lt;services&gt; (root)</td>
+    <td rowspan="3">&lt;services&gt; (root)</td>
     <td>&lt;jdisc&gt;</td>
     <td>Use <a href="reference/services-container.html">container</a> instead.
   </tr>
   <tr>
     <td>&lt;service&gt;</td>
     <td>Running generic services is no longer supported.</td>
+  </tr>
+  <tr>
+    <td>&lt;clients&gt;</td>
+    <td>Client load types are deprecated and ignored.</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
@kkraune please review
@gjoranv @ean @bratseth FYI

Load types are deprecated, so don't advertise their existence. Clients should
prefer using default priorities for feed, as there is a fine internal balance
between external and internal operations and their mutual priorities.
