### PR TITLE
Remove documentation of priority command line flags

### DIFF
--- a/en/content/buckets.html
+++ b/en/content/buckets.html
@@ -90,8 +90,7 @@ while not affecting routing from client to distributors.
 <p>
 The content layer defines a set of maintenance operations to keep the cluster balanced.
 Distributors schedule maintenance operations and issue them to content nodes.
-Maintenance operations are typically not high
-<a href="../reference/services.html#clients">priority</a> requests.
+Maintenance operations are typically not high priority requests.
 Scheduling a maintenance operation does not block any external operations.
 </p>
 <table class="table">
@@ -100,25 +99,23 @@ Scheduling a maintenance operation does not block any external operations.
   <th>Split bucket</th><td>
     Split a bucket in two, by enforcing the documents within the new buckets
     to have more location bits in common.
-    Buckets are split either because they have grown too big (priority between LOW_2 and LOW3),
-    or because the cluster wants to use more distribution bits (priority LOWEST).</td>
+    Buckets are split either because they have grown too big,
+    or because the cluster wants to use more distribution bits.</td>
 </tr><tr>
   <th>Join bucket</th><td>
-    Join two buckets into one (priority between NORMAL_6 and LOW_).
+    Join two buckets into one.
     If a bucket has been previously split due to being large,
     but documents have now been deleted, the bucket can be joined again.</td>
 </tr><tr>
   <th>Merge bucket</th><td>
     If there are multiple replicas of a bucket, but they do not store the same
-    information, merge is used to synchronize the replicas.
+    set of versioned documents, <em>merge</em> is used to synchronize the replicas.
     A special case of a merge is a one-way merge, which may be done if
     some of the replicas are to be deleted right after the merge. Merging is used
-    not only to fix inconsistent bucket replicas (priority NORMAL_2 - NORMAL_3),
-    but also to move buckets between nodes (priority between LOW_1 and LOW_2).
+    not only to fix inconsistent bucket replicas,
+    but also to move buckets between nodes.
     To move a bucket, an empty replica is created on the target node,
     a merge is executed, and the source bucket is deleted.
-    Likewise for copy, minus the bucket delete -
-    buckets are merged with priority NORMAL_3 for redundancy levels.</td>
 </tr><tr>
   <th>Create bucket</th><td>
     This operation exist merely for the distributor to notify a content node
@@ -129,15 +126,15 @@ Scheduling a maintenance operation does not block any external operations.
     requests to fail than to alter the content cluster in strange ways.</td>
 </tr><tr>
   <th>Delete bucket</th><td>
-    Drop stored state for a bucket and reject further requests for it (priority NORMAL_1)</td>
+    Drop stored state for a bucket and reject further requests for it</td>
 </tr><tr>
   <th style="white-space: nowrap">(De)activate bucket</th><td>
-    Activate bucket for search results (priority NORMAL_1) -
+    Activate bucket for search results -
     refer to <a href="../proton.html#bucket-management">bucket management</a></td>
 </tr><tr>
-  <th>Expire documents</th><td>
-    Documents are <a href="../documents.html#document-expiry">expired</a>
-    with priority LOWEST</td>
+  <th>Garbage collections</th><td>
+    If configured, documents are periodically garbage collected through
+    background maintenance operations.</td>
 </tr>
 </tbody>
 </table>

--- a/en/content/visiting.html
+++ b/en/content/visiting.html
@@ -90,13 +90,11 @@ $ vespa-visit
 </pre>
 As a full data dump takes time / space / resources, refine as needed:
 <pre>
-$ vespa-visit -v --priority LOW_1 -p progress-file -s 'id.hash().abs() % 100 = 0' \
+$ vespa-visit -v -p progress-file -s 'id.hash().abs() % 100 = 0' \
   --fieldset 'music:[document]' > 100.json
 </pre>
 <ul>
   <li><em>-v</em> prints a % finished</li>
-  <li><em>--priority LOW_1</em> <a href="#priority">de-prioritizes</a> the data dump -
-    useful in live applications.</li>
   <li><em>-p progress-file</em> saves progress, allowing the visitor to resume at next startup.
     Always remove the progress file to run the visiting operation from the start.</li>
   <li><em>-s 'id.hash().abs() % 100 = 0'</em> dumps 1% of the corpus - see <a href="#selection">selection</a>.</li>
@@ -399,64 +397,6 @@ The default is one iterator request is pending to the backend at any time.
 By sending many small iterator requests, having several pending at a time,
 the processing may occur in parallel with the document fetching.
 </p>
-
-
-<h3 id="priority">Priority</h3>
-<p>
-Visitor requests have priorities just like any other requests.
-These priorities are kept throughout the chain of requests.
-A low priority reprocessing visitor will end up sending
-low priority visitor requests to the content nodes,
-which will send low priority put operations to be reprocessed,
-which will end up as low priority put operations to the backend. Example:
-</p>
-<pre>
-$ vespa-visit --priority LOW_1
-</pre>
-<p>Refer to <a href="../reference/services.html#clients">load types</a> for priority values.</p>
-
-
-<h3 id="max-concurrent-visitors-on-content-nodes">Max concurrent visitors on content nodes</h3>
-<p>
-Content nodes process <a href="../reference/services-content.html#max-concurrent">max-concurrent</a>
-visitors at a time.
-This enforces enough memory for the currently active ones,
-and that the active ones will complete in reasonable time.
-To prevent a lot of low priority visitors to stop high priority visitors from being started,
-the maximum amount of concurrent visitors is a function that depends on the priority:
-</p><p><!-- depends on mathjax -->
-$$\text{maxconcurrent}_{V} = \text{fixed + variable} \times \frac{255 - \text{priority}_{V}}{255}$$
-</p><p>
-The <em>fixed</em> value represent the number always allowed to process in parallel regardless of priority,
-and the <em>variable</em> represent how many additional visitors can be run at maximum priority.
-Thus, if only low priority visitors are running,
-there will be free slots in the queue for high priority visitors incoming.
-</p><p>
-Once visitors have started, backend requests for documents are also prioritized,
-but the processing of the documents are not.
-However, as the high priority backend requests will take priority,
-the high priority visitors should also get responses to process faster.
-</p>
-
-
-<h3 id="queueing">Queueing</h3>
-<p>
-Visitor requests may be queued at several layers.
-Visitor clients have a virtual queue by deciding only to send requests for a few buckets at a time.
-Distributors have a virtual queue deciding to only forward requests for some buckets at a time.
-These queues are per visitor, and can be adjusted through visitor parameters.
-</p><p>
-The content node queues up visitor requests if the maximum allowed is already running.
-If doing so, this queue will be kept in priority order.
-In the event of client hammering, this queue may also fill up, replying busy back to the clients.
-</p><p>
-The partition threads will queue up requests to read needed parts of data.
-These requests will be tagged with the priority of the visitor itself.
-Additionally, the responses from the backend will be queued for processing in the visitor thread.
-This queue is not a priority queue, but as it contains replies from data processed of a priority queue,
-this is not expected to be an issue.
-</p>
-
 
 
 <h2 id="visitor-processor-types">Visitor processor types</h2>

--- a/en/operations/admin-procedures.html
+++ b/en/operations/admin-procedures.html
@@ -30,7 +30,6 @@ redirect_from:
   <li>Use performance graphs, System Activity Report (<em>sar</em>)
     or <a href="#status-pages">status pages</a> to track load</li>
   <li>Use <a href="../reference/query-api-reference.html#tracelevel">query tracing</a></li>
-  <li>Use <a href="../reference/services.html#clients">feed tracing</a></li><!-- ToDo: this works? must document ... -->
   <li>Disk and/or memory might be exhausted and block feeding - recover from
     <a href="feed-block.html">feed block</a></li>
 </ul>

--- a/en/reference/vespa-cmdline-tools.html
+++ b/en/reference/vespa-cmdline-tools.html
@@ -820,7 +820,7 @@ routed to any <a href="services-content.html">content clusters</a> because they 
   </li>
 </ul>
 <p>
-Synopsis: <code>vespa-feeder [--abortondataerror true|false] [--abortonsenderror true|false] [--file arg] [--maxpending arg] [--maxpendingsize arg] [--maxfeedrate arg] [mode standard|benchmark] [--noretry] [--retrydelay arg] [--route arg] [--timeout arg] [--trace arg] [--validate] [--dumpDocuments filename] [priority arg] [--numthreads arg] [create-if-non-existent] [-v,--verbose] filename</code>
+Synopsis: <code>vespa-feeder [--abortondataerror true|false] [--abortonsenderror true|false] [--file arg] [--maxpending arg] [--maxpendingsize arg] [--maxfeedrate arg] [mode standard|benchmark] [--noretry] [--retrydelay arg] [--route arg] [--timeout arg] [--trace arg] [--validate] [--dumpDocuments filename] [--numthreads arg] [create-if-non-existent] [-v,--verbose] filename</code>
 </p><p>
 Example:
 </p>
@@ -910,11 +910,6 @@ $ vespa-feeder file.json
         File where documents in the put are serialized
       </td>
     </tr><tr>
-        <th>--priority arg</th>
-      <td>
-        Set <a href="services.html#clients">priority</a> of sent messages
-      </td>
-    </tr><tr>
         <th>--numthreads arg</th>
       <td>
         How many threads to use for sending. Default 1
@@ -985,9 +980,6 @@ Synopsis: <code>vespa-get &lt;options&gt; [documentid...]</code>
     </tr><tr>
       <th>-n,--noretry</th>
       <td>Do not retry operation on transient errors, as is default</td>
-    </tr><tr>
-      <th>-p,--priority <em>priority</em></th>
-      <td>Priority (default 6)</td>
     </tr><tr>
       <th>-r,--route <em>route</em></th>
       <td>Send request to the given messagebus route</td>
@@ -2614,12 +2606,6 @@ Synopsis: <code>vespa-visit [options]</code>
     </tr><tr>
         <th>-p, --progress &lt;file&gt;</th>
       <td>Use given file to track progress</td>
-    </tr><tr>
-      <th>--priority &lt;name&gt;</th>
-      <td>
-        Visitor <a href="services.html#clients">priority</a>. Defaults to NORMAL_3.
-        Use with care to avoid starving lower prioritized traffic in the cluster
-      </td>
     </tr><tr>
       <th>--processtime &lt;num&gt;</th>
       <td>

--- a/en/streaming-search.html
+++ b/en/streaming-search.html
@@ -574,19 +574,6 @@ There are 1 hop(s):
 </p>
 
 
-<h3 id="streaming.priority">streaming.priority</h3>
-<table class="table table-striped">
-  <tr><td>Alias</td><td></td></tr>
-  <tr><td>Values</td><td><a href="reference/services.html#clients">Priority class</a></td></tr>
-  <tr><td>Default</td><td>VERY_HIGH</td></tr>
-</table>
-<p>
-  Priority of the streaming search <a href="content/visiting.html">visitor</a>.
-  Having a high priority visitor helps maintain low latencies,
-  even when the system is under load.
-</p>
-
-
 <h3 id="streaming.maxbucketspervisitor">streaming.maxbucketspervisitor</h3>
 <table class="table table-striped">
   <tr><td>Alias</td><td></td></tr>

--- a/en/vespa-http-client.html
+++ b/en/vespa-http-client.html
@@ -248,8 +248,6 @@ These calls will block when queues are full
   so when feeding from different machines you might want to shard data accordingly.
   If it does not increase performance, the vespa cluster is the bottleneck.
   You need to increase the number of containers with gateway nodes and/or increase the number of content nodes.
-  Use <em>--priority</em> with a <a href="reference/services.html#clients">load type</a>
-  to assign priority classes to operations.
 </p>
 
 


### PR DESCRIPTION
@kkraune please review. Should fix the broken links in #1909, but please defer merging until PR build shows no further broken links from _these_ changes...

Also remove some overly complicated implementation details that are
realistically of interest to less people on the planet than can be
counted on one hand.
