### PR TITLE
Matching and ranking with multi-valued fields. 

### DIFF
--- a/en/searching-multi-valued-fields.md
+++ b/en/searching-multi-valued-fields.md
@@ -28,7 +28,7 @@ designing both our document schema and the way we query the schema
 [linguistic processing](linguistics.html) like [tokenization](linguistics.html#tokenization), 
 normalization and language dependent [stemming](linguistics.html#stemming).
 - String fields which shares the same match and linguistic processing settings can be combined 
-  schema [fieldset](eference/schema-reference.html#fieldset). 
+  schema [fieldset](reference/schema-reference.html#fieldset). 
 - Should query matching in the field impact ranking, or is it just a filter which should not impact ranking order?
 
 At query time, we can take the user query and translate it into a valid Vespa query request which implements
@@ -245,7 +245,7 @@ Changing the type to `any`, recalls our sample document as we no longer require 
 Now, let us explore how Vespa matches the multi-valued tags field of 
 type [weightedset](reference/schema-reference.html#weightedset). Notice that we change
 back to default `type=all`. 
-In this example we also use the [default-index](en/reference/query-api-reference.html#model.defaultIndex) 
+In this example we also use the [default-index](reference/query-api-reference.html#model.defaultIndex) 
 parameter to limit matching to the `tags` field.
 
 <pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
@@ -283,7 +283,7 @@ exact, in order matches are ranked higher.
 We have now explored matching, now it's time to focus on how we want to rank the documents matched. 
 You might not have noticed, but in the above examples, each of the queries produced a `relevance` score, 
 this was in our previous examples calculated using the `default` ranking profile which in our case
-used [nativeRank](nativeRank.html). 
+used [nativeRank](nativerank.html). 
 
 We start with having Vespa calculate [rank features](reference/rank-features.html), then we can explore
 and create a baseline ranking function which be better for our data and domain usage. 

--- a/en/searching-multi-valued-fields.md
+++ b/en/searching-multi-valued-fields.md
@@ -580,6 +580,11 @@ $ vespa query 'yql=select * from photos where userQuery()' \
  'ranking.features.query(tagWeight)=3' 
 </pre>
 
+That concludes the experiments. To shutdown the container run:
+
+<pre data-test="after">
+$ docker rm -f vespa
+</pre>
 
 # Conclusion
 In this guide we have looked at how one can build a query retrieval strategy and how to change ranking 

--- a/en/searching-multi-valued-fields.md
+++ b/en/searching-multi-valued-fields.md
@@ -236,7 +236,7 @@ We can relax the query matching to instead of requiring that **all** terms match
 
 <pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
 $ vespa query 'yql=select * from photos where userQuery()' \
- 'query=sunset photos featuring a dog' 'type=any'
+ 'query=sunset photos featuring dogs 'type=any'
 </pre>
 
 Changing the type to `any`, recalls our sample document as we no longer require that all query terms must match.
@@ -244,9 +244,17 @@ With `type` it also possible to require that indivudual query terms match by usi
 
 <pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
 $ vespa query 'yql=select * from photos where userQuery()' \
- 'query=+sunset photos featuring a +dog' 'type=any'
+ 'query=+sunset photos featuring +dogs' 'type=any'
 </pre>
-In this example `sunset` and `dog` must be matched. 
+
+In this example `sunset` and `dogs` must be matched. Note that we have disabled stemming so querying
+for `dogs` won't recall documents with `dog`. This is one of the reasons we disabled stemming, to demonstrate
+that stemming has impact on recall. Requiring `dog` will cause the query to not recall our sample document.
+
+<pre data-test="exec" data-test-assert-contains='"totalCount": 0'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=+sunset photos featuring +dog' 'type=any'
+</pre>
 
 Now, let us explore how Vespa matches the multi-valued tags field of 
 type [weightedset](reference/schema-reference.html#weightedset). 

--- a/en/searching-multi-valued-fields.md
+++ b/en/searching-multi-valued-fields.md
@@ -34,7 +34,7 @@ our matching and retrieval strategy over the designed document schema.
 
 ### Ranking 
 
-The documents which matches the query and is retrieved by the query is scored using a ranking model. 
+The documents which match the query and are retrieved by the query are scored using a ranking model. 
 Once a document is retrieved by the query logic the document can be scored using the full 
 flexibility of the Vespa [ranking](ranking.html) framework. 
 
@@ -286,7 +286,7 @@ $ vespa query 'yql=select * from photos where userQuery()' \
 </pre>
 
 Also matches our document. This is an example of cross-element matching. With weightedset
-usig `indexing:index` with `match:text` multi term queries match across elements.
+using `indexing:index` with `match:text` multi term queries match across elements.
 
 This might be a good decision, as we increase recall, however
 in some cases we want to differentiate an exact match from a partial match during ranking, so that

--- a/en/searching-multi-valued-fields.md
+++ b/en/searching-multi-valued-fields.md
@@ -236,7 +236,7 @@ We can relax the query matching to instead of requiring that **all** terms match
 
 <pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
 $ vespa query 'yql=select * from photos where userQuery()' \
- 'query=sunset photos featuring dogs 'type=any'
+ 'query=sunset photos featuring dogs' 'type=any'
 </pre>
 
 Changing the type to `any`, recalls our sample document as we no longer require that all query terms must match.

--- a/en/searching-multi-valued-fields.md
+++ b/en/searching-multi-valued-fields.md
@@ -3,7 +3,11 @@
 title: "Searching and ranking of multi-valued fields"
 ---
 
-This guide explores how to search and rank over structured multi-valued fields. 
+This guide explores how to search and rank over structured multi-valued fields. The examples
+in this guide uses the [weightedset](reference/schema-reference.html#type:weightedset)
+[field type](reference/schema-reference.html#field-types). The generic
+[map<key-type,value-type>](reference/schema-reference.html#type:map) field type does not currently support
+ranking and can only be used for matching and filtering. 
 
 ## Introduction
 

--- a/en/searching-multi-valued-fields.md
+++ b/en/searching-multi-valued-fields.md
@@ -1,0 +1,326 @@
+---
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+title: "Searching and ranking of multi-valued fields"
+---
+
+This guide explores how to search and rank over structured multi-valued fields. 
+
+## Introduction
+
+When building a search application we need to think about
+
+- How to [match](query-language.html) a user query against our document schema  
+- How to [rank](ranking.html) documents matching the query 
+
+During the matching or retriveal stage, Vespa calculates several matching ranking features 
+which can influence the order of the documents retrieved. This process is called ranking. A
+single query request might retrieve documents into ranking by multiple different strategies combing
+the strategies using logica disjunction (OR): 
+
+
+### Matching
+
+There is a lot of matching options we should think about when 
+designing both our document schema and the way we query the schema
+
+- For string fields we need to decide if we want to use text style matching or database style exact matching?
+- For free text string fields, should we disable 
+linguistic processing like tokenization, normalization and language dependent stemming?
+- String fields which shares the same match and linguistic processing settings can be combined using fieldset. 
+- Should query matching in the field impact ranking, or is it just a filter which should not impact ranking order?
+
+At query time, we can take the user query and translate it into a valid Vespa query request which implements
+our matching and retriveal strategy. 
+
+### Ranking 
+
+The documents which matches the query and is retrieved by the query expression is ranked. Once a document
+is retrieved by the query logic one has access to the full flexibility of the Vespa ranking framework. In the
+following section we demonstrate both retriveal and ranking. 
+
+## Prerequisites
+- [Docker Desktop on Mac](https://docs.docker.com/docker-for-mac/install) 
+  or Docker on Linux
+- Operating system: macOS or Linux
+- Architecture: x86_64
+- [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download 
+ a vespa cli release from [Github releases](https://github.com/vespa-engine/vespa/releases).
+
+## A minimal Vespa application
+
+Assuming we have the following sample data document
+
+<pre data-test="file" data-path="doc.json"> 
+{
+    "put": "id:photos:photo::0",
+    "fields": {
+        "title": "Mira in the sunset",
+        "description": "A sunny afternoon with our dogs",
+        "interestingness": 0.23,
+        "tags": {
+            "#sunny": 1,
+            "no filter":1,
+            "light": 3,
+            "black and white": 3,
+            "clear sky": 2,
+            "sunset dogs": 4
+        }
+    }
+}
+</pre>
+
+How should we design our Vespa schema, and how should we match and search this data model for 
+end user free text queries? 
+
+- We want to use traditional text matching when searching the title and description
+- We also want to match the free form tags field as these tags might increase recall and the weight might
+impact the ranking. 
+
+We can start with the following schema:
+
+<pre data-test="file" data-path="my-app/schemas/photo.sd"> 
+schema photo {
+
+  stemming: none 
+  
+  document photo {
+
+    field title type string {
+      indexing: summary | index
+      match:text 
+      index: enable-bm25
+    }
+
+    field description type string {
+      indexing: summary | index
+      match:text
+      index: enable-bm25
+    }
+
+    field interestingness type float {
+      indexing: summary | attribute
+    }
+
+    field tags type weightedset&lt;string&gt; {
+      indexing: summary | index
+      match:text
+      index: enable-bm25
+    }
+
+  }
+  fieldset default {
+    fields: title, description, tags
+  }
+}
+</pre>
+We disable [stemming](reference/schema-reference.html#stemming) and
+also enable [bm25](reference/bm25.html) ranking for all string fields. 
+Since all string fields shares the same [match](reference/schema-reference.html#match)
+settings we can use a [fieldset](reference/schema-reference.html#fieldset) 
+so that searches does not need to mention all 3 fields we plan to match against. Along with the 
+schema, we also need a [services.xml](reference/services.html) file to deploy the application:
+
+<pre data-test="file" data-path="my-app/services.xml">
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;services version="1.0"&gt;
+
+    &lt;container id="default" version="1.0"&gt;
+        &lt;search&gt;&lt;/search&gt;
+        &lt;document-api&gt;&lt;/document-api&gt;
+        &lt;nodes&gt;
+            &lt;node hostalias="node1"&gt;&lt;/node&gt;
+        &lt;/nodes&gt;
+    &lt;/container&gt;
+
+    &lt;content id="photos" version="1.0"&gt;
+        &lt;redundancy&gt;1&lt;/redundancy&gt;
+        &lt;documents&gt;
+            &lt;document type="photo" mode="index"/&gt;
+        &lt;/documents&gt;
+        &lt;nodes&gt;
+            &lt;node hostalias="node1" distribution-key="0" /&gt;
+        &lt;/nodes&gt;
+    &lt;/content&gt;
+
+&lt;/services&gt;
+</pre>
+
+## Starting Vespa
+
+This example uses docker container:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre data-test="exec">
+$ docker pull vespaengine/vespa
+$ docker run --detach --name vespa --hostname vespa-container \
+  --publish 8080:8080 --publish 19071:19071 \
+  vespaengine/vespa
+</pre>
+</div>
+
+Install [Vespa-cli](vespa-cli.html):
+
+<pre>
+brew install vespa-cli
+</pre>
+
+Deploy the application using vespa-cli:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre data-test="exec">
+$ vespa deploy --wait 300 my-app
+</pre>
+</div>
+
+## Feeding to Vespa
+
+Feed the sample document 
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre data-test="exec">
+$ vespa document -v doc.json 
+</pre>
+</div>
+
+## Query our data
+Assuming a free text query *sunset photos featuring dogs*, we translate the user query into
+a Vespa query reques using YQL:
+
+<pre data-test="exec" data-test-assert-contains='"totalCount": 0'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=sunset photos featuring dogs' 
+</pre>
+
+The above query returns 0 hits, since by default query will require that *all* query terms matches the document. 
+By adding [tracelevel](reference/query-api-reference.html#tracelevel) to the request we can see this:
+
+<pre data-test="exec" data-test-assert-contains='"totalCount": 0'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=sunset photos featuring dogs' 'tracelevel=3'
+</pre>
+
+<pre>
+query=[AND sunshot photos featuring dogs]
+</pre>
+
+ Since our sample document does not contain the term *featuring* or *photos*, the query fails to retrieve the example document. 
+ We can relax the query matching to instead of requiring that **all** terms match, to use **any**. See
+ [model.type](reference/query-api-reference.html#model.type) query api reference for supported query types.
+
+<pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=sunshot photos featuring a dog' 'type=any'
+</pre>
+
+Changing the type to any, brings back the document as we don't require that all query terms needs to match.
+
+Now, let us explore how Vespa matches the multi-valued tags field of 
+type [weightedset](reference/schema-reference.html#weightedset).
+
+<pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=clear sky' 'type=all' 'default-index=tags'
+</pre>
+
+Matches, there is a tag with exactly that content so there is a match. Let us
+search for just *clear* instead:
+
+<pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=clear' 'type=all' 'default-index=tags'
+</pre>
+
+Also matches the document. But what about 'black sky'? 
+
+<pre data-test="exec" data-test-assert-contains='"totalCount": 1'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=black sky' 'type=all' 'default-index=tags'
+</pre>
+
+Also matches our document, since all elements of the tag field is indexed as a bag of words, we
+get matches across elements. This might be a good decision, as we increase recall, however
+in some cases we want to differentiate an exact match from a partial match during ranking.  
+
+
+## Ranking
+We have now explored matching, now it's time to focus on how we want to rank the documents matched. 
+
+We start with having Vespa calculate [ranking features](reference/rank-features.html), then we can explore
+and create a baseline ranking function. We use `match-features` to return calculated ranking features.
+These are all built-in ranking features which Vespa exposes:
+
+<pre data-test="file" data-path="my-app/schemas/photo.sd"> 
+schema photo {
+
+  stemming: none
+
+  document photo {
+
+    field title type string {
+      indexing: summary | index
+      match:text
+    }
+
+    field description type string {
+      indexing: summary | index
+      match:text
+    }
+
+    field interestingness type float {
+      indexing: summary | attribute
+    }
+
+    field tags type weightedset&lt;string&gt; {
+      indexing: summary | index
+      match:text
+    }
+
+  }
+
+  fieldset default {
+    fields: title, description, tags
+  }
+
+  rank-profile default {
+    first-phase {
+      expression: nativeRank
+    }
+    match-features {
+      bm25(title)
+      bm25(description)
+      bm25(tags)
+
+      nativeRank
+      nativeRank(title)
+      nativeRank(description)
+
+      attribute(interestingness)
+
+      elementSimilarity(tags)
+      elementCompleteness(tags).elementWeight
+      elementCompleteness(tags).fieldCompleteness
+      elementCompleteness(tags).queryCompleteness
+      elementCompleteness(tags).completeness
+    }
+  }
+}
+</pre>
+
+Re-deploy with the new ranking profile
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre data-test="exec">
+$ vespa deploy --wait 300 my-app
+</pre>
+</div>
+
+
+<pre data-test="exec" data-test-assert-contains='matchfeatures'>
+$ vespa query 'yql=select * from photos where userQuery()' \
+ 'query=black sky' 'type=any'
+</pre>
+<script src="/js/process_pre.js"></script>

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -56,8 +56,9 @@ jobs:
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
           echo $PWD
-          ls $PWD/.vespa
-          echo "$VESPA_TEAM_API_KEY" | openssl base64 -A -a -d | openssl ec > tmp.txt
+          mkdir -p $PWD/.vespa
+          ls -lart $PWD/
+          echo "$VESPA_TEAM_API_KEY" | openssl base64 -A -a -d | openssl ec |md5sum 
           $SD_SOURCE_DIR/test/test.py -v -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR
 
   verify-guides-large:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -55,11 +55,7 @@ jobs:
       - run-tests: |
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
-          echo $PWD
-          mkdir -p $PWD/.vespa
-          ls -lart $PWD/
-          echo "$VESPA_TEAM_API_KEY" | openssl base64 -A -a -d | openssl ec |md5sum 
-          $SD_SOURCE_DIR/test/test.py -v -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR
+          $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR
 
   verify-guides-large:
     requires: [~pr, ~commit]
@@ -80,7 +76,4 @@ jobs:
       - run-tests: |
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
-          echo $PWD
-          ls $PWD/.vespa
-          echo "$VESPA_TEAM_API_KEY" | openssl base64 -A -a -d | openssl ec > tmp.txt
           $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config-large.yml -w $SD_SOURCE_DIR

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -39,7 +39,7 @@ jobs:
             _site
 
   verify-guides:
-    requires: [~commit]
+    requires: [~pr, ~commit]
     secrets:
       - VESPA_TEAM_API_KEY
     image: buildpack-deps
@@ -55,7 +55,7 @@ jobs:
       - run-tests: |
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
-          $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config.yml
+          $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR
 
   verify-guides-large:
     requires: [~pr, ~commit]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -55,6 +55,9 @@ jobs:
       - run-tests: |
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
+          echo $PWD
+          ls $PWD/.vespa
+          echo "$VESPA_TEAM_API_KEY" | openssl base64 -A -a -d | openssl ec > tmp.txt
           $SD_SOURCE_DIR/test/test.py -v -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR
 
   verify-guides-large:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -76,4 +76,7 @@ jobs:
       - run-tests: |
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
+          echo $PWD
+          ls $PWD/.vespa
+          echo "$VESPA_TEAM_API_KEY" | openssl base64 -A -a -d | openssl ec > tmp.txt
           $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config-large.yml -w $SD_SOURCE_DIR

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -55,7 +55,7 @@ jobs:
       - run-tests: |
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
-          $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR
+          $SD_SOURCE_DIR/test/test.py -v -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR
 
   verify-guides-large:
     requires: [~pr, ~commit]

--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -12,7 +12,7 @@ urls:
     - >-
         en/tutorials/text-search.md,
         en/tutorials/text-search-ml.md
-    - en/getting-started-ranking.html
+    - en/getting-started-ranking.md
 
     #- https://docs.vespa.ai/en/tutorials/text-search-semantic.html Tests not implemented
     #- https://docs.vespa.ai/en/vespa-quick-start-vagrant.html Tests not implemented

--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -3,6 +3,7 @@
 # Use a comma-separated list of URLs to test multiple pages as one unit, like the news-tutorial
 
 urls:
+    - en/searching-multi-valued-fields.md
     - https://docs.vespa.ai/en/vespa-quick-start-java.html
     - >-
         https://docs.vespa.ai/en/vespa-quick-start.html,

--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -1,27 +1,6 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
 # Use a comma-separated list of URLs to test multiple pages as one unit, like the news-tutorial
 
 urls:
-    - en/searching-multi-valued-fields.md
-    - en/vespa-quick-start-java.html
-    - >-
-        en/vespa-quick-start.html,
-        en/operations/monitoring.html
-    # The text-search tutorials is ToDo and WIP - text-search-ml.html is not yet properly tested
-    - >-
-        en/tutorials/text-search.md,
-        en/tutorials/text-search-ml.md
-    - en/getting-started-ranking.md
-
-    #- https://docs.vespa.ai/en/tutorials/text-search-semantic.html Tests not implemented
-    #- https://docs.vespa.ai/en/vespa-quick-start-vagrant.html Tests not implemented
-    #- https://docs.vespa.ai/en/vespa-quick-start-multinode-aws.html Tests not implemented
-    #- https://docs.vespa.ai/en/vespa-quick-start-multinode-aws-ecs.html Tests not implemented
-    #
-    # Kubernetes testing is blocked on running minikube on Centos, in Docker - needs more work
-    #     - https://docs.vespa.ai/en/vespa-quick-start-kubernetes.html
-    #
     # Should be tested from the cloud repo, test here for now:
     - https://raw.githubusercontent.com/vespa-engine/cloud/master/en/getting-started-java.html
-    #- "https://cloud.vespa.ai/en/getting-started" This cannot be auto tested now due to console deployment - ToDo: check again

--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -4,15 +4,16 @@
 
 urls:
     - en/searching-multi-valued-fields.md
-    - https://docs.vespa.ai/en/vespa-quick-start-java.html
+    - en/vespa-quick-start-java.html
     - >-
-        https://docs.vespa.ai/en/vespa-quick-start.html,
-        https://docs.vespa.ai/en/operations/monitoring.html
+        en/vespa-quick-start.html,
+        en/operations/monitoring.html
     # The text-search tutorials is ToDo and WIP - text-search-ml.html is not yet properly tested
     - >-
-        https://docs.vespa.ai/en/tutorials/text-search.html,
-        https://docs.vespa.ai/en/tutorials/text-search-ml.html
-    - https://docs.vespa.ai/en/getting-started-ranking.html
+        en/tutorials/text-search.html,
+        en/tutorials/text-search-ml.html
+    - en/getting-started-ranking.html
+
     #- https://docs.vespa.ai/en/tutorials/text-search-semantic.html Tests not implemented
     #- https://docs.vespa.ai/en/vespa-quick-start-vagrant.html Tests not implemented
     #- https://docs.vespa.ai/en/vespa-quick-start-multinode-aws.html Tests not implemented

--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -1,6 +1,27 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 # Use a comma-separated list of URLs to test multiple pages as one unit, like the news-tutorial
 
 urls:
+    - en/searching-multi-valued-fields.md
+    - en/vespa-quick-start-java.html
+    - >-
+        en/vespa-quick-start.html,
+        en/operations/monitoring.html
+    # The text-search tutorials is ToDo and WIP - text-search-ml.html is not yet properly tested
+    - >-
+        en/tutorials/text-search.md,
+        en/tutorials/text-search-ml.md
+    - en/getting-started-ranking.md
+
+    #- https://docs.vespa.ai/en/tutorials/text-search-semantic.html Tests not implemented
+    #- https://docs.vespa.ai/en/vespa-quick-start-vagrant.html Tests not implemented
+    #- https://docs.vespa.ai/en/vespa-quick-start-multinode-aws.html Tests not implemented
+    #- https://docs.vespa.ai/en/vespa-quick-start-multinode-aws-ecs.html Tests not implemented
+    #
+    # Kubernetes testing is blocked on running minikube on Centos, in Docker - needs more work
+    #     - https://docs.vespa.ai/en/vespa-quick-start-kubernetes.html
+    #
     # Should be tested from the cloud repo, test here for now:
     - https://raw.githubusercontent.com/vespa-engine/cloud/master/en/getting-started-java.html
+    #- "https://cloud.vespa.ai/en/getting-started" This cannot be auto tested now due to console deployment - ToDo: check again

--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -10,8 +10,8 @@ urls:
         en/operations/monitoring.html
     # The text-search tutorials is ToDo and WIP - text-search-ml.html is not yet properly tested
     - >-
-        en/tutorials/text-search.html,
-        en/tutorials/text-search-ml.html
+        en/tutorials/text-search.md,
+        en/tutorials/text-search-ml.md
     - en/getting-started-ranking.html
 
     #- https://docs.vespa.ai/en/tutorials/text-search-semantic.html Tests not implemented


### PR DESCRIPTION
testing changes:

- enable PR testing - the test URL of vespa cloud getting started should be moved as it will fail as secrets are not available for PR testing. 
- To actually test PR builds one needs to use local paths instead of pulling from what is published 

new document demonstrates searching in weightedset set strings. 



I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
