### PR TITLE
Vespa 8 release note changes

### DIFF
--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -5,29 +5,24 @@ redirect_from:
 - /documentation/vespa8-release-notes.html
 ---
 
-{% include note.html content="This is work in progress, Vespa 8 has not been released yet."%}
+{% include note.html content="Vespa 8 will be released in June 2022."%}
 <p>
-  This document describes the changes between Vespa major versions 7 and 8.
+  This document lists the changes between Vespa major versions 7 and 8.
   As documented in <a href="https://vespa.ai/releases#versions">Vespa versions</a>,
-  new functionality is introduced in minor versions, while major versions are used to mark
-  breaking compatibility. As Vespa 8 does not introduce new functionality,
+  new functionality in Vespa is introduced in minor versions,
+  while major versions are used to mark releases breaking compatibility.
+  As Vespa 8 does not introduce any new functionality,
   it is as safe and mature as the versions of Vespa 7 preceding it.
-  Upon release of Vespa 8, no further releases will be made of Vespa 7.
+  Upon release of Vespa 8, no further releases will be made of Vespa 7, except
+  possible critical security fixed.
 </p>
 
 
 
 <h2 id="compatibility-overview">Overview</h2>
-<p>
-  Usage of deprecated Java APIs produce warnings during compilation, while <em>deployment warnings</em>
-  are produced for application package deprecations and most changes to the container runtime environment.
-  In hosted Vespa or Vespa Cloud, deployment warnings are shown in the application's console view.
-  However, for other types of changes, there is no way to emit deprecation warnings,
-  so these are only described in this document and other Vespa documentation.
-</p>
 
 <p>
-  The compatibility breaking changes in Vespa 8 can be split into these main categories:
+  The compatibility breaking changes in Vespa 8 falls into these categories:
 </p>
 <ul>
   <li><a href="#changed-defaults">Changes to default behaviour</a></li>
@@ -44,11 +39,11 @@ redirect_from:
   <li><a href="#document-selection-exact-type-matching">Changes to the document selection language</a></li>
   <li><a href="#security">Security related changes</a></li>
   <li><a href="#operating-system">Operating system support</a></li>
-  <li><a href="#other-changes">Other changes</a>, not covered by any of the above categories.</li></ul>
-
+  <li><a href="#other-changes">Other changes</a>, not covered by any of the above categories.</li>
+</ul>
 
 <p>
-In order to be compatible with Vespa 8, application owners must:
+To ensure their applications are compatible with Vespa 8, application owners must:
 <ul>
   <li>Review the list of <a href="#changed-defaults">changes to defaults</a> and add the necessary options
     if you want to preserve behavior from Vespa 7.</li>
@@ -61,14 +56,18 @@ In order to be compatible with Vespa 8, application owners must:
 </ul>
 
 <p>
-  The sections below describe the changes from Vespa 7 to Vespa 8 in more detail.
+  Usage of deprecated Java APIs produce warnings during compilation, while <em>deployment warnings</em>
+  are produced for application package deprecations and most changes to the container runtime environment.
+  In hosted Vespa or Vespa Cloud, deployment warnings are shown in the application's console view.
+  However, for other types of changes, there is no way to emit deprecation warnings,
+  so these are only described in this document and other Vespa documentation.
 </p>
 
+<p>
+  The following sections lists all the changes from Vespa 7 to Vespa 8 in detail.
+</p>
 
 <!-- ToDo: something on the xml/page presentation.format from query-api-reference.html -->
-
-<!-- ToDo: searchdefinitions and search is deprecated - note here -->
-
 
 <h2 id="changed-defaults">Changed defaults</h2>
 <p>
@@ -78,6 +77,19 @@ The following defaults have changed:
   <tr>
     <th>Change</th>
     <th>Configuration required to avoid change on Vespa 8</th>
+  </tr>
+
+  <tr>
+    <td>
+      The default rank function is changed from <code>nativeRank</code>.
+    </td>
+    <td>
+      Set a first-phase ranking function containing the expression
+      <code><a href="nativerank.html">nativeRank</a></code>
+      in the default rank profile of all <a href="schemas.html">schemas</a>.
+      If a schema does not have a default <a href="ranking.htmll#rank-profiles">rank profile</a>,
+      add one called <code>default</code>.
+    </td>
   </tr>
 
   <tr>
@@ -981,14 +993,6 @@ The following metrics are renamed:
   will now fail, instead of being rendered empty. Queries hitting multiple document types must use a summary class
   that exists in all of them
 </p>
-
-<h3 id="rank-features-must-be-float-or-tensors">Rank features must be floats or tensors</h3>
-<p>
-  If the value of a rank feature set in the query is not a float or tensor, Vespa 7 will
-  automatically convert it to a float by taking the hash of the values toString. On Vespa 8
-  this will instead be an illegal assignment.
-</p>
-
 
 <h3 id="qrserver-service-name">The "qrserver" service name</h3>
 <p>

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -14,7 +14,7 @@ redirect_from:
   As Vespa 8 does not introduce any new functionality,
   it is as safe and mature as the versions of Vespa 7 preceding it.
   Upon release of Vespa 8, no further releases will be made of Vespa 7, except
-  possible critical security fixed.
+  possible critical security fixes.
 </p>
 
 


### PR DESCRIPTION
- Document release timeframe
- Remove undeprecated support for text rank features
- Add change of default ranking
- Minor flow and text improvements
