### PR TITLE
More coherent config documentation

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -234,7 +234,7 @@ docs:
 
   - title: Configuration
     documents:
-      - page: Configuration Intro
+      - page: Vespa Configuration
         url: /en/config-introduction.html
       - page: Routing
         url: /en/routing.html

--- a/en/config-introduction.html
+++ b/en/config-introduction.html
@@ -1,17 +1,19 @@
 ---
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "The Cloud Configuration System"
+title: "Vespa Configuration"
 redirect_from:
 - /documentation/cloudconfig/config-introduction.html
 - /en/cloudconfig/config-introduction.html
 ---
 
 <p>
-The Cloud Config System (CCS) is an integral part of Vespa.
-To use it, it suffices to read about <a href="application-packages.html">application packages</a> -
-this article details the inner workings of Cloud Configuration.
-The problem of configuring cloud nodes can be divided into three parts,
-each addressed by different solutions:
+  This article details the inner workings of Vespa Configuration.
+  Related documents are <a href="application-packages.html">application packages</a> and
+  <a href="operations/configuration-server.html">configuration server operations</a>.
+</p>
+<p>
+  The problem of configuring nodes can be divided into three parts,
+  each addressed by different solutions:
 </p>
 <ul>
   <li><strong>Node system level configuration:</strong> Configure OS
@@ -19,7 +21,7 @@ each addressed by different solutions:
   <li><strong>Package management</strong>: Ensure that the correct
   set of software packages is installed on the nodes.
   This functionality is provided by three tools working together.</li>
-  <li><strong>Cloud configuration:</strong> Starts the configured
+  <li><strong>Vespa configuration:</strong> Starts the configured
   set of processes on each node with their configured startup
   parameters and provides dynamic configuration to the modules run by these services.
   <em>Configuration</em> here is any data which:
@@ -30,132 +32,138 @@ each addressed by different solutions:
   </li>
 </ul>
 <p>
-Note that by these definitions, we may allow all the cloud nodes to
-have the same software packages (disregarding version differences, discussed later),
-because variations in what services are run on each node and in their behavior
-can be achieved entirely by using CCS.
-This allows us to manage the complexity of node variations completely
-within the cloud configuration system, rather than across multiple systems.
-</p><p>
-Configuring a system can be divided into:
+  Note that by these definitions, this allows all the nodes to
+  have the same software packages (disregarding version differences, discussed later),
+  as variations in what services are run on each node and in their behavior
+  is achieved entirely by using Vespa Configuration.
+  This allows managing the complexity of node variations completely
+  within the configuration system, rather than across multiple systems.
+</p>
+<p>
+  Configuring a system can be divided into:
 </p>
 <ul>
-  <li> <strong>Configuration assembly:</strong> Assembly of a complete
+  <li><strong>Configuration assembly:</strong> Assembly of a complete
   set of configurations for delivery from the inputs provided by the
   parties involved in configuring the system</li>
-  <li> <strong>Configuration delivery:</strong> Definition of
+  <li><strong>Configuration delivery:</strong> Definition of
   individual configurations, APIs for requesting and accessing
   configuration, and the mechanism for delivering configurations from
   their source to the receiving components</li>
  </ul>
 <p>
-This division allows the problem of reliable configuration delivery in
-large distributed systems to be addressed in configuration delivery,
-while the complexities of assembling complete configurations in the
-cloud environment can be treated as a vm-local design problem.
-</p><p>
-An important feature of CCS is the nature of the interface between the delivery and assembly subsystems.
-The assembly subsystem creates as output a (Java) object model of the distributed system.
-The delivery subsystem queries this model to obtain concrete configurations
-of all the components of the system.
-This allows the assembly subsystem to accept higher level, and simpler to use,
-abstractions as input and automatically derive detailed configurations with the correct interdependencies.
-This division insulates the external interface and the components being configured
-from changes in each other.
-In addition, the system model provides the home for logic
-implementing node/component instance variations of configuration.
+  This division allows the problem of reliable configuration delivery in
+  large distributed systems to be addressed in configuration delivery,
+  while the complexities of assembling complete configurations
+  can be treated as a vm-local design problem.
+</p>
+<p>
+  An important feature of Vespa Configuration is the nature of the interface
+  between the delivery and assembly subsystems.
+  The assembly subsystem creates as output a (Java) object model of the distributed system.
+  The delivery subsystem queries this model to obtain concrete configurations
+  of all the components of the system.
+  This allows the assembly subsystem to accept higher level, and simpler to use,
+  abstractions as input and automatically derive detailed configurations with the correct interdependencies.
+  This division insulates the external interface and the components being configured from changes in each other.
+  In addition, the system model provides the home for logic
+  implementing node/component instance variations of configuration.
 </p>
 
 
 
 <h2 id="configuration-assembly">Configuration assembly</h2>
 <p>
-Config assembly is the process of turning the configuration input sources
-into an object model of the desired system,
-which can respond to queries for configs given a name and config id.
-Config assembly for cloud systems can become complex,
-because it involves merging information owned by multiple parties:
+  Config assembly is the process of turning the configuration input sources
+  into an object model of the desired system,
+  which can respond to queries for configs given a name and config id.
+  Config assembly for Vespa systems can become complex,
+  because it involves merging information owned by multiple parties:
 </p>
 <ul>
-  <li><strong>Cloud operations</strong>
-    own the machines on the cloud and controls assignment of nodes to services/applications</li>
-  <li><strong>Cloud service providers</strong>
-    own services which hosts multiple applications running on the cloud</li>
-  <li><strong>Cloud applications</strong>
-    define the final applications running on cloud nodes and shared services</li>
+  <li><strong>Vespa operations</strong>
+    own the nodes and controls assignment of nodes to services/applications</li>
+  <li><strong>Vespa service providers</strong>
+    own services which hosts multiple applications running on Vespa</li>
+  <li><strong>Vespa applications</strong>
+    define the final applications running on nodes and shared services</li>
 </ul>
 <p>
-The current config model assembly procedure uses a single source -
-the <a href="application-packages.html">application package</a>.
-The application package is a directory structure containing defined files
-and sub-directories which together completely defines the system -
-including which nodes belong in the system,
-which services they should run and the configuration of these services and their components.
-When the application deployer wants to change the application,
-<a href="application-packages.html#deploy">vespa-deploy prepare</a> is issued to a config server,
-with the application package as argument.
-</p><p>
-At this point the system model is assembled and validated
-and any feedback is issued to the deployer.
-If the deployer decides to make the new configuration active,
-a <a href="application-packages.html#deploy">vespa-deploy activate</a> is then issued,
-causing the config server cluster to switch to the new system model
-and respond with new configs on any active subscriptions
-where the new system model caused the config to change.
-This ensures that subscribers gets new configs timely on changes,
-and that the changes propagated are the minimal set
-such that small changes to an application package
-causes correspondingly small changes to the system.
+  The current config model assembly procedure uses a single source -
+  the <a href="application-packages.html">application package</a>.
+  The application package is a directory structure containing defined files
+  and sub-directories which together completely defines the system -
+  including which nodes belong in the system,
+  which services they should run and the configuration of these services and their components.
+  When the application deployer wants to change the application,
+  <a href="application-packages.html#deploy">vespa-deploy prepare</a> is issued to a config server,
+  with the application package as argument.
+</p>
+<p>
+  At this point the system model is assembled and validated
+  and any feedback is issued to the deployer.
+  If the deployer decides to make the new configuration active,
+  a <a href="application-packages.html#deploy">vespa-deploy activate</a> is then issued,
+  causing the config server cluster to switch to the new system model
+  and respond with new configs on any active subscriptions
+  where the new system model caused the config to change.
+  This ensures that subscribers gets new configs timely on changes,
+  and that the changes propagated are the minimal set
+  such that small changes to an application package
+  causes correspondingly small changes to the system.
 </p>
 <img src="/assets/img/config-assembly.svg" alt="The config server assembles app config" width="810px" height="auto" />
 <p>
-The config model itself is pluggable, so that cloud service providers may write
-plugins for assembling a particular service.
-The plugins are written in Java, and is installed together with the CCS.
-Service plugins define their own syntax for specifying services
-that may be configured by cloud applications.
-This allows the applications to be specified in an abstract manner,
-decoupled from the configuration that is delivered to the components.
+  The config model itself is pluggable, so that service providers may write
+  plugins for assembling a particular service.
+  The plugins are written in Java, and is installed together with the Vespa Configuration.
+  Service plugins define their own syntax for specifying services
+  that may be configured by Vespa applications.
+  This allows the applications to be specified in an abstract manner,
+  decoupled from the configuration that is delivered to the components.
 </p>
 
 
 
 <h2 id="configuration-delivery">Configuration delivery</h2>
 <p>
-Configuration delivery encompasses the following aspects:
+  Configuration delivery encompasses the following aspects:
+</p>
 <ul>
   <li>Definition of configurations</li>
   <li>The component view (API) of configuration</li>
   <li>Configuration delivery mechanism</li>
 </ul>
-These aspects work together to realize the following goals:
+<p>These aspects work together to realize the following goals:</p>
 <ul>
-  <li> Eliminate inconsistency between code and configuration.</li>
-  <li> Eliminate inconsistency between the desired configuration and
-   the state on each node.</li>
-  <li> Limit temporary inconsistencies after reconfiguration.</li>
+  <li>Eliminate inconsistency between code and configuration.</li>
+  <li>Eliminate inconsistency between the desired configuration and the state on each node.</li>
+  <li>Limit temporary inconsistencies after reconfiguration.</li>
 </ul>
 <p>
-The next three subsections discusses the three aspects above,
-followed by subsections on two special concerns - bootstrapping and system upgrades.
+  The next three subsections discusses the three aspects above,
+  followed by subsections on two special concerns - bootstrapping and system upgrades.
 </p>
 
 
 <h3 id="configuration-definitions">Configuration definitions</h3>
 <p>
-A <em>configuration</em> is a set of simple or array key-values
-with a name and a type which can possibly be nested. Example:
+  A <em>configuration</em> is a set of simple or array key-values with a name and a type,
+  which can possibly be nested - example:
+</p>
 <pre>
 myProperty "myvalue"
 myArray[1]
 myArray[0].key1 "someValue"
 myArray[0].key2 1337
 </pre>
-The <em>type definition</em> (or class) of a configuration object
-defines and documents the set of fields a configuration may contain
-with their types and default values.
-It has a name as well as a namespace.
-For example, the above config instance may have this definition:
+<p>
+  The <em>type definition</em> (or class) of a configuration object
+  defines and documents the set of fields a configuration may contain
+  with their types and default values.
+  It has a name as well as a namespace.
+  For example, the above config instance may have this definition:
+</p>
 <pre>
 namespace=foo.bar
 
@@ -175,22 +183,24 @@ A complete system consists of many instances of many config types.
 
 <h3 id="component-view">Component view</h3>
 <p>
-Individual components of a system consumes one or more such configs and
-use their values to influence their behavior.
-APIs are needed for <em>requesting</em> configs
-and for <em>accessing</em> the values of those configs as they are provided.
-</p><p>
-<em>Access</em> to configs happens through a (Java or C++) class
-generated from the config definition file.
-This ensures that any inconsistency between the fields declared in a config type and the
-expectations of the code accessing it are caught at compile time.
-The config definition is best viewed as another class with an alternative
-form of source syntax belonging to the components consuming it.
-A Maven target is provided for generating such classes from config definition types.
-</p><p>
-Components may use two different methods for <em>requesting</em> configurations
-(refer to
-<a href="contributing/configapi-dev-cpp.html">Config API</a> for C++ code):
+  Individual components of a system consumes one or more such configs and
+  use their values to influence their behavior.
+  APIs are needed for <em>requesting</em> configs
+  and for <em>accessing</em> the values of those configs as they are provided.
+</p>
+<p>
+  <em>Access</em> to configs happens through a (Java or C++) class
+  generated from the config definition file.
+  This ensures that any inconsistency between the fields declared in a config type
+  and the expectations of the code accessing it are caught at compile time.
+  The config definition is best viewed as another class with an alternative
+  form of source syntax belonging to the components consuming it.
+  A Maven target is provided for generating such classes from config definition types.
+</p>
+<p>
+  Components may use two different methods for <em>requesting</em> configurations
+  (refer to <a href="contributing/configapi-dev-cpp.html">Config API</a> for C++ code):
+</p>
 <ul>
   <li>
     <strong>Subscription:</strong> The component sets up
@@ -208,12 +218,12 @@ if (handle.isChanged()) {
 </pre>
   </li>
   <li>
-  <strong>Dependency injection:</strong> The component declares its
-  config dependencies in the constructor and subscriptions are set up on its behalf.
-  When changed configs are available a new instance of the component is created.
-  The advantage of this method is that configs are immutable throughout the lifetime of the component
-  such that no thread coordination is required.
-  This method is currently only available in Java using the <a href="jdisc/index.html">Container</a>.
+    <strong>Dependency injection:</strong> The component declares its
+    config dependencies in the constructor and subscriptions are set up on its behalf.
+    When changed configs are available a new instance of the component is created.
+    The advantage of this method is that configs are immutable throughout the lifetime of the component
+    such that no thread coordination is required.
+    This method is currently only available in Java using the <a href="jdisc/index.html">Container</a>.
 <pre>
 public MyComponent(MyConfig config) {
   String myKey = config.myKey();
@@ -231,22 +241,26 @@ submitted directly to components.
 
 <h3 id="delivery-mechanism">Delivery mechanism</h3>
 <p>
-The config delivery mechanism is responsible for ensuring that a new
-config instance is delivered to subscribing components in a timely fashion,
-each time there is a change to the system model causing that config instance to change.
-A config subscription is identified by two parameters,
-the config definition name and namespace
-and the <a href="contributing/configapi-dev.html#config-id">config id</a>
-used to identify the particular component instance making the subscription.
-The in-process config library will forward these subscription requests to a node local
-<a href="operations/config-proxy.html">config proxy</a>,
-which provides caching and fan-in from processes to node.
-The proxy in turn issues these subscriptions to a node in the configuration server cluster,
-each of which hosts a copy of the system model and resolves config requests by querying the system model.
-To provide config server failover,
-the config subscriptions are implemented as long-timeout gets,
-which are immediately resent when they time out,
-but conceptually this is best understood as push subscriptions.
+  The config delivery mechanism is responsible for ensuring that a new
+  config instance is delivered to subscribing components,
+  each time there is a change to the system model causing that config instance to change.
+  A config subscription is identified by two parameters,
+  the <em>config definition name and namespace</em>
+  and the <a href="contributing/configapi-dev.html#config-id">config id</a>
+  used to identify the particular component instance making the subscription.
+</p>
+<p>
+  The in-process config library will forward these subscription requests to a node local
+  <a href="operations/config-proxy.html">config proxy</a>,
+  which provides caching and fan-in from processes to node.
+  The proxy in turn issues these subscriptions to a node in the configuration server cluster,
+  each of which hosts a copy of the system model and resolves config requests by querying the system model.
+</p>
+<p>
+  To provide config server failover,
+  the config subscriptions are implemented as long-timeout gets,
+  which are immediately resent when they time out,
+  but conceptually this is best understood as push subscriptions:
 </p>
 <img src="/assets/img/config-delivery.svg" alt="Nodes get config from a config server cluster"
      width="795px" height="auto" />
@@ -284,10 +298,11 @@ require a <a href="operations/config-proxy.html">procedure</a>.
 
 <h2 id="notes">Notes</h2>
 <p>
-Find more information for using the Cloud config API in the
-<a href="contributing/configapi-dev.html">reference doc</a>.
-</p><p>
-CCS makes the following assumptions about the nodes using it:
+  Find more information for using the Vespa config API in the
+  <a href="contributing/configapi-dev.html">reference doc</a>.
+</p>
+<p>
+  Vespa Configuration makes the following assumptions about the nodes using it:
 </p>
 <ul>
   <li>All nodes have the software packages needed to run the
@@ -297,9 +312,11 @@ CCS makes the following assumptions about the nodes using it:
   <li>All nodes have <a href="reference/files-processes-and-ports.html#environment-variables">
     VESPA_CONFIGSERVERS</a> set</li>
   <li>All nodes know their fully qualified domain name</li>
+  <li><a href="operations/configuration-server.html">Configuration server operations</a>
+    is a good resource for troubleshooting</li>
 </ul>
 <p>
-Reading this document is not necessary in order to use Vespa or to develop
-Java components for the Vespa container - for this purpose, refer to
-<a href="configuring-components.html">Configuring components</a> instead.
+  Reading this document is not necessary in order to use Vespa or to develop
+  Java components for the Vespa container - for this purpose, refer to
+  <a href="configuring-components.html">Configuring components</a>.
 </p>

--- a/en/document-api-guide.html
+++ b/en/document-api-guide.html
@@ -6,13 +6,18 @@ redirect_from:
 ---
 
 <p>
-This is an introduction to how to build and compile Vespa clients using the Document API.
-It can be used for feeding, updating and retrieving documents,
-or removing documents from the repository. See also the
-<a href="https://javadoc.io/doc/com.yahoo.vespa/documentapi">Java reference</a>.
-</p><p>
-The most common use case is using the async API in a
-<a href="document-processing.html">document processor</a> - from the sample apps:
+  This is an introduction to how to build and compile Vespa clients using the Document API.
+  It can be used for feeding, updating and retrieving documents,
+  or removing documents from the repository. See also the
+  <a href="https://javadoc.io/doc/com.yahoo.vespa/documentapi">Java reference</a>.
+</p>
+<p>
+  Use the <a href="reference/files-processes-and-ports.html#environment-variables">VESPA_CONFIG_SOURCES</a>
+  environment variable to set config servers to interface with.
+</p>
+<p>
+  The most common use case is using the async API in a
+  <a href="document-processing.html">document processor</a> - from the sample apps:
 </p>
 <ul>
   <li>Async GET in

--- a/en/operations/configuration-server.html
+++ b/en/operations/configuration-server.html
@@ -9,7 +9,8 @@ redirect_from:
 <p>
   Vespa Configuration Servers host the endpoint where application packages are deployed -
   and serves generated configuration to all services -
-  see the <a href="../overview.html">overview</a>.
+  see the <a href="../overview.html">overview</a>
+  and <a href="../config-introduction.html">Vespa configuration</a> for details.
   I.e. one cannot configure Vespa without config servers, and services cannot run without it.
 </p>
 <p>
@@ -20,7 +21,7 @@ redirect_from:
   for practical examples of multi-configserver configuration.
 </p>
 <p>
-  The Config System can be set up with one or more configuration servers (config servers).
+  Vespa configuration is set up using one or more configuration servers (config servers).
   A config server uses <a href="https://zookeeper.apache.org/">ZooKeeper</a>
   as a distributed data storage for the configuration system.
   In addition, each node runs a config proxy to cache configuration data -
@@ -31,10 +32,13 @@ redirect_from:
 
 <h2 id="redundancy">Redundancy</h2>
 <p>
-  The config servers are defined in <a href="../reference/services.html">services.xml</a>,
-  <a href="../reference/hosts.html">hosts.xml</a>
-  and <a href="../reference/files-processes-and-ports.html#environment-variables">VESPA_CONFIGSERVERS</a>:
+  The config servers are defined in
+  <a href="../reference/files-processes-and-ports.html#environment-variables">VESPA_CONFIGSERVERS</a>,
+  <a href="../reference/services.html">services.xml</a> and <a href="../reference/hosts.html">hosts.xml</a>:
 </p>
+<pre>
+$ VESPA_CONFIGSERVERS=myserver0.mydomain.com,myserver1.mydomain.com,myserver2.mydomain.com
+</pre>
 <pre>{% highlight xml %}
 <services>
     <admin version="2.0">
@@ -46,7 +50,6 @@ redirect_from:
     </admin>
 </services>
 {% endhighlight %}</pre>
-
 <pre>{% highlight xml %}
 <hosts>
     <host name="myserver0.mydomain.com">
@@ -60,11 +63,7 @@ redirect_from:
     </host>
 </hosts>
 {% endhighlight %}</pre>
-<pre>
-$ VESPA_CONFIGSERVERS=myserver0.mydomain.com,myserver1.mydomain.com,myserver2.mydomain.com
-</pre>
 <p>
-  Refer to the <a href="../reference/services-admin.html#configservers">admin model</a> reference.
   <a href="../reference/files-processes-and-ports.html#environment-variables">VESPA_CONFIGSERVERS</a>
   must be set on all nodes.
   This is a comma or whitespace-separated list with the hostname of all configservers,
@@ -89,6 +88,10 @@ $ VESPA_CONFIGSERVERS=myserver0.mydomain.com,myserver1.mydomain.com,myserver2.my
   it will continue to serve config to the services on that node.
   However, restarting a node when config servers are unavailable
   will lead to a failure of that node, since restarting a node means restarting the config proxy.
+</p>
+<p>
+  Refer to the <a href="../reference/services-admin.html#configservers">admin model reference</a>
+  for more details on <em>services.xml</em>.
 </p>
 
 
@@ -356,15 +359,16 @@ $ vespa-zkcli get /config/v2/tenants/default/sessions/[sessionid]/userapp/servic
 <p>
   To access config from a node not running the config system
   (e.g. doing feeding via the Document API),
-  use the environment variable VESPA_CONFIG_SOURCES:
+  use the environment variable
+  <a href="../reference/files-processes-and-ports.html#environment-variables">VESPA_CONFIG_SOURCES</a>:
 </p>
 <pre>
-$ export VESPA_CONFIG_SOURCES="myadmin0.mydomain.com:12345,myadmin1.mydomain.com:12345"
+$ export VESPA_CONFIG_SOURCES="myadmin0.mydomain.com:19071,myadmin1.mydomain.com:19071"
 </pre>
 <p>
   Alternatively, for Java programs, use the system property <em>configsources</em>
   and set it programmatically or on the command line with the <em>-D</em> option to Java.
-  The syntax for the value is the same as for VESPA_CONFIG_SOURCES.
+  The syntax for the value is the same as for <em>VESPA_CONFIG_SOURCES</em>.
 </p>
 
 
@@ -390,7 +394,7 @@ $ export VESPA_CONFIG_SOURCES="myadmin0.mydomain.com:12345,myadmin1.mydomain.com
 </p>
 <pre>{% highlight xml %}
 <http>
-    <server port="12345" id="configserver" />
+    <server port="19079" id="configserver" />
 </http>
 {% endhighlight %}</pre>
 <p>

--- a/en/reference/files-processes-and-ports.html
+++ b/en/reference/files-processes-and-ports.html
@@ -313,6 +313,15 @@ Each line  has the format <code>action variablename value</code> where the items
     </td>
   </tr>
   <tr>
+    <th>VESPA_CONFIG_SOURCES</th>
+    <td>
+      Used by libraries like the <a href="../document-api-guide.html">Document API</a>
+      to set config server endpoints.
+      Refer to <a href="../operations/configuration-server.html#configuration">configuration server operations</a>
+      for example use.
+    </td>
+  </tr>
+  <tr>
     <th>VESPA_WEB_SERVICE_PORT</th>
     <td>
       The port number where REST apis will run, default <code>8080</code>.


### PR DESCRIPTION
- removed the cloudconfig concept for less confusion
- added doc for VESPA_CONFIG_SOURCES
- readability / flow