### PR TITLE
Add API example usage

### DIFF
--- a/en/content/api-state-rest-api.html
+++ b/en/content/api-state-rest-api.html
@@ -6,14 +6,13 @@ redirect_from:
 ---
 
 <p>
-    The cluster controller has a RESTful API for viewing and modifying
-    the state of a content cluster.
-    To find the URL to access the State API, identify the cluster controller services in your application.
-    Only the master cluster controller will be able to respond.
-    The master cluster controller is the cluster controller alive that has the
-    lowest index. Thus, you will typically use cluster controller 0, but if you fail
-    to contact it, you need to try number 1 and so on.
-    Using the <em>vespa-model-inspect</em> command line tool:
+  The cluster controller has an  API for viewing and modifying a content cluster state.
+  To find the URL to access the State API, identify the <a href="../content/content-nodes.html#cluster-controller">
+  cluster controller services</a> in the application.
+  Only the master cluster controller will be able to respond.
+  The master cluster controller is the cluster controller alive that has the lowest index.
+  Thus, one will typically use cluster controller 0, but if contacting it fails, try number 1 and so on.
+  Using <a href="../reference/vespa-cmdline-tools.html#vespa-model-inspect">vespa-model-inspect</a>:
 </p>
 <pre>
 $ vespa-model-inspect service -u container-clustercontroller
@@ -26,14 +25,17 @@ admin/cluster-controllers/0
     tcp/hostname.domain.com:19119 (ADMIN RPC)
 </pre>
 <p>
-    In this example, there is only one clustercontroller, and the State Rest API is
-    available on the port marked STATE and HTTP, namely 19050 in this example. This
-    information can also be retrieved through the model config in the config server.
+  In this example, there is only one clustercontroller, and the State Rest API is
+  available on the port marked STATE and HTTP, 19050 in this example.
+  This information can also be retrieved through the model config in the config server.
+</p>
+<p>
+  Find examples of API usage in <a href="content-nodes.html#state-api-examples">content nodes</a>.
 </p>
 
 
 
-<h2>Types</h2>
+<h2 id="types">Types</h2>
 <table class="table">
 <thead>
 <tr>
@@ -68,9 +70,8 @@ admin/cluster-controllers/0
     <td><nobr><em>&lt;identifier&gt;</em>(\.<em>&lt;identifier&gt;</em>)*</nobr></td>
     <td><nobr>asia.switch0</nobr></td>
     <td>
-        The hierarchical group assignment of a given content node. This is a
-        dot separated list of identifiers given in the application services.xml
-        configuration.
+        The hierarchical group assignment of a given content node.
+        This is a dot separated list of identifiers given in the application services.xml configuration.
     </td>
 </tr>
 <tr>
@@ -87,8 +88,7 @@ admin/cluster-controllers/0
     <td><nobr>(distributor|storage)</nobr></td>
     <td><nobr>distributor</nobr></td>
     <td>
-        The type of the service to look at state for, within the context of a given
-        content cluster.
+        The type of the service to look at state for, within the context of a given content cluster.
     </td>
 </tr>
 <tr>
@@ -128,33 +128,32 @@ admin/cluster-controllers/0
 
 
 
-<h2>Errors</h2>
+<h2 id="errors">Errors</h2>
 <p>
-    Errors will be indicated using the HTTP status codes. An error response from the
-    State API will include a JSON encoded error response with extra information. As a
-    request may fail outside of the State API, we can not guarantee that such a JSON
-    representation exist though. To make it simpler for clients, all errors they need
-    to handle specifically should be specified in HTTP error codes. Thus, the content
-    of the JSON error report, if it exists, can be left unspecified, and just used to
-    improve an error report if needed.
-    {% include note.html content="
-    Note: Do not depend on the JSON content for anything other than improving error reports -
-    contents may change at any time"%}
+  Errors are indicated using HTTP status codes.
+  An error response from the State API includes a JSON encoded error response with extra information.
+  As a request may fail outside of the State API,
+  it is not guaranteed that such a JSON representation exist though.
+  To make it simpler for clients, all errors they need to handle specifically should be specified in HTTP error codes.
+  Thus, the content of the JSON error report, if it exists, can be left unspecified,
+  and just used to improve an error report if needed.
 </p>
+  {% include note.html content="
+  Note: Do not depend on the JSON content for anything other than improving error reports -
+  contents may change at any time"%}
 
-<h4>Cluster controller not master - master known</h4>
+
+<h3 id="cluster-controller-not-master-master-known">Cluster controller not master - master known</h3>
 <p>
-    This error means you are talking to the wrong cluster controller. This will give
-    you a standard HTTP redirect, so your HTTP client may automatically redo the
-    request on the correct cluster controller. If it does not you might want to handle
-    this specifically.
+  This error means communicating with the wrong cluster controller.
+  This returns a standard HTTP redirect,
+  so the HTTP client can automatically redo the request on the correct cluster controller.
 </p>
 <p>
-    Note that since we know the cluster controller available with the
-    lowest index will be the master, you will typically try to query the
-    cluster controllers in index order, in which case you are unlikely to ever
-    get this error, but rather fail to connect to the cluster controller if it
-    is not the current master.
+  As the cluster controller available with the lowest index will be the master,
+  the cluster controllers are normally queried in index order.
+  Hence, it is unlikely to ever get this error,
+  but rather fail to connect to the cluster controller if it is not the current master.
 </p>
 <pre>
 HTTP/1.1 303 See Other
@@ -166,13 +165,14 @@ Content-Type: application/json
 }
 </pre>
 
-<h4>Cluster controller not master - unknown or no master</h4>
+
+<h3 id="cluster-controller-not-master-unknown-or-no-master">Cluster controller not master - unknown or no master</h3>
 <p>
-    This error is used if the cluster controller asked is not master, and
-    it doesn't know who the master is. This can happen, for instance in a network
-    split where cluster controller 0 no longer can reach cluster controller 1 and 2,
-    in which case cluster controller 0 knows it is not master as it can't see the
-    majority, and cluster controller 1 and 2 will vote 1 to master.
+  This error is used if the cluster controller asked is not master,
+  and it doesn't know who the master is.
+  This can happen, e.g. in a network split where cluster controller 0 no longer can reach cluster controller 1 and 2,
+  in which case cluster controller 0 knows it is not master, as it can't see the majority,
+  and cluster controller 1 and 2 will vote 1 to master.
 </p>
 <pre>
 HTTP/1.1 503 Service Unavailable
@@ -185,36 +185,36 @@ Content-Type: application/json
 
 
 
-<h2>Recursive mode</h2>
+<h2 id="recursive-mode">Recursive mode</h2>
 <p>
-    To use recursive mode, specify the <em>recursive</em> URL parameter, and
-    give it a numeric value for number of levels.
-    A value of <em>true</em> is also valid, this returns all levels.
-    Examples: Use <em>recursive=1</em> for a node request
-    to also see all data, use <em>recursive=2</em>
-    to see all the node data within each
-    service type.
+  To use recursive mode, specify the <em>recursive</em> URL parameter,
+  and give it a numeric value for number of levels.
+  A value of <em>true</em> is also valid, this returns all levels. Examples:
 </p>
+<ul>
+  <li>Use <em>recursive=1</em> for a node request to also see all data</li>
+  <li>use <em>recursive=2</em> to see all the node data within each service type</li>
+</ul>
 <p>
-    In recursive mode, you will see the same output as you find in the spec below.
-    However, where there is a <em>{ "link" : "&lt;url-path&gt;" }</em> element, this
-    element will be replaced by the content of that request, given a recursive value
-    of one less than the request above.
-</p>
-
-
-
-<h2>Functions</h2>
-<p>
-    Here follows a list of all the available functions. Note that more headers than
-    the ones specified will exist. All requests with content will obviously have a
-    content length for instance.
+  In recursive mode, you will see the same output as found in the spec below.
+  However, where there is a <code>{ "link" : "&lt;url-path&gt;" }</code> element,
+  this element will be replaced by the content of that request,
+  given a recursive value of one less than the request above.
 </p>
 
 
-<h3>List the existing content clusters</h3>
-<code>HTTP GET /cluster/v2/</code>
-<p>Example success result:</p>
+
+<h2 id="functions">Functions</h2>
+<p>
+  Following is a list of the available functions, with sample successful responses.
+  All requests with content have a content length response header, and more headers are generally returned.
+</p>
+
+
+<h3 id="list-content-clusters">List content clusters</h3>
+<p>
+  <code>HTTP GET /cluster/v2/</code>
+</p>
 <pre>{% highlight json %}
 {
     "cluster" : {
@@ -229,9 +229,11 @@ Content-Type: application/json
 {% endhighlight %}</pre>
 
 
-<h3>Get cluster state and list the various service types within the cluster</h3>
-<code>HTTP GET /cluster/v2/&lt;cluster&gt;</code>
-<p>Example success result:</p>
+<h3 id="get-cluster-state-and-list-service-types-within-cluster">
+  Get cluster state and list service types within cluster</h3>
+<p>
+  <code>HTTP GET /cluster/v2/&lt;cluster&gt;</code>
+</p>
 <pre>{% highlight json %}
 {
     "state" : {
@@ -251,9 +253,11 @@ Content-Type: application/json
  }
 {% endhighlight %}</pre>
 
-<h3>List the nodes of a given service type for a cluster</h3>
-<code>HTTP GET /cluster/v2/cluster/service-type</code>
-<p>Example success result:</p>
+
+<h3 id="list-nodes-per-service-type-for-cluster">List nodes per service type for cluster</h3>
+<p>
+  <code>HTTP GET /cluster/v2/cluster/service-type</code>
+</p>
 <pre>{% highlight json %}
 {
     "node" : {
@@ -267,9 +271,11 @@ Content-Type: application/json
 }
 {% endhighlight %}</pre>
 
-<h3>Get node state</h3>
-<code>HTTP GET /cluster/v2/cluster/service-type/node</code>
-<p>Example success result:</p>
+
+<h3 id="get-node-state">Get node state</h3>
+<p>
+  <code>HTTP GET /cluster/v2/cluster/service-type/node</code>
+</p>
 <pre>{% highlight json %}
 {
     "attributes" : {
@@ -303,8 +309,10 @@ Content-Type: application/json
 {% endhighlight %}</pre>
 
 
-<h3>Set node user state</h3>
-<code>HTTP PUT /cluster/v2/cluster/service-type/node</code>
+<h3 id="set-node-user-state">Set node user state</h3>
+<p>
+  <code>HTTP PUT /cluster/v2/cluster/service-type/node</code>
+</p>
 <pre>{% highlight json %}
 {
     "state" : {
@@ -315,7 +323,6 @@ Content-Type: application/json
     }
 }
 {% endhighlight %}</pre>
-<p>Success result:</p>
 <pre>{% highlight json %}
 {
     "wasModified": true,

--- a/en/content/content-nodes.html
+++ b/en/content/content-nodes.html
@@ -99,9 +99,12 @@ Content and distributor nodes have state:
   </tbody>
 </table>
 <p>
-Distributor nodes start / transfer buckets quickly
-and are hence not in <em>maintenance</em> or <em>retired</em>.
-<!-- ToDo: it should not be possible to set a distributor in this mode, check -->
+  Distributor nodes start / transfer buckets quickly
+  and are hence not in <em>maintenance</em> or <em>retired</em>.
+  <!-- ToDo: it should not be possible to set a distributor in this mode, check -->
+</p>
+<p>
+  Refer to <a href="#state-api-examples">examples</a> of manipulating states.
 </p>
 
 
@@ -125,12 +128,13 @@ There are three kinds of state:
         The cluster controller fetches states from all nodes, called <em>unit states</em>.
         States reported from the nodes are either <em>initializing</em>, <em>up</em> or <em>stopping</em>.
         If the node can not be reached, a <em>down</em> state is assumed.
-      </p><p>
-      This means, the cluster controller detects failed nodes.
-      The subsequent <em>generated states</em> will hence have nodes in <em>down</em>,
-      and the <a href="idealstate.html">ideal state algorithm</a> will redistribute
-      <a href="buckets.html">buckets</a> of documents.
-    </p>
+      </p>
+      <p>
+        This means, the cluster controller detects failed nodes.
+        The subsequent <em>generated states</em> will hence have nodes in <em>down</em>,
+        and the <a href="idealstate.html">ideal state algorithm</a> will redistribute
+        <a href="buckets.html">buckets</a> of documents.
+      </p>
     </td>
   </tr><tr>
     <th>User state</th>
@@ -163,19 +167,20 @@ There are three kinds of state:
   </tbody>
 </table>
 <p>
-For new cluster states, the cluster state version is upped,
-and the new cluster state is broadcast to all nodes.
-There is a minimum time between each cluster state change.
-<!-- ToDo ref to config here -->
-</p><p>
-It is possible to set a minimum capacity for the cluster state to be <em>up</em>.
-<!-- ToDo ref to config here -->
-If a cluster has so many nodes unavailable that it is considered down,
-the state of each node is irrelevant,
-and thus new cluster states will not be created and broadcast
-before enough nodes are back for the cluster to come back up.
-A cluster state indicating the entire cluster is down,
-may thus have outdated data on the node level.
+  For new cluster states, the cluster state version is upped,
+  and the new cluster state is broadcast to all nodes.
+  There is a minimum time between each cluster state change.
+  <!-- ToDo ref to config here -->
+</p>
+<p>
+  It is possible to set a minimum capacity for the cluster state to be <em>up</em>.
+  <!-- ToDo ref to config here -->
+  If a cluster has so many nodes unavailable that it is considered down,
+  the state of each node is irrelevant,
+  and thus new cluster states will not be created and broadcast
+  before enough nodes are back for the cluster to come back up.
+  A cluster state indicating the entire cluster is down,
+  may thus have outdated data on the node level.
 </p>
 <!-- ToDo: An example cluster state string is useful here -->
 
@@ -183,12 +188,12 @@ may thus have outdated data on the node level.
 
 <h2 id="cluster-controller">Cluster controller</h2>
 <p>
-The main task of the cluster controller is to maintain the <a href="#cluster-state">cluster state</a>.
-This is done by <em>polling</em> nodes for state,
-<em>generating</em> a cluster state,
-which is then <em>broadcast</em> to all the content nodes in the cluster.
-Note that clients do not interface with the cluster controller -
-they get the cluster state from the distributors - <a href="#distributor">details</a>.
+  The main task of the cluster controller is to maintain the <a href="#cluster-state">cluster state</a>.
+  This is done by <em>polling</em> nodes for state,
+  <em>generating</em> a cluster state,
+  which is then <em>broadcast</em> to all the content nodes in the cluster.
+  Note that clients do not interface with the cluster controller -
+  they get the cluster state from the distributors - <a href="#distributor">details</a>.
 </p>
 <table class="table">
   <thead>
@@ -210,13 +215,14 @@ they get the cluster state from the distributors - <a href="#distributor">detail
         even with one pending.
         This triggers a reply to the lingering request and makes the new one linger instead.
         Hence, nodes have a pending state request.
-      </p><p>
-      During a controlled node shutdown, it starts the shutdown process
-      by responding to the pending state request that it is now stopping.
-      <strong>Note: </strong> As controlled restarts or shutdowns are implemented as TERM signals
-      from the <a href="../config-sentinel.html">config-sentinel</a>,
-      the cluster controller is not able to differ between controlled and other shutdowns.
-    </p>
+      </p>
+      <p>
+        During a controlled node shutdown, it starts the shutdown process
+        by responding to the pending state request that it is now stopping.
+        <strong>Note: </strong> As controlled restarts or shutdowns are implemented as TERM signals
+        from the <a href="../config-sentinel.html">config-sentinel</a>,
+        the cluster controller is not able to differ between controlled and other shutdowns.
+      </p>
     </td>
   </tr><tr>
     <th>Cluster state generation</th>
@@ -234,13 +240,15 @@ they get the cluster state from the distributors - <a href="#distributor">detail
         New cluster states are distributed with a minimum interval between. <!-- ToDo link to config here -->
         A grace period per unit state too -
         e.g, distributors and content nodes that are on the same node often stop at the same time.
-      </p><p>
-      The version number is upped, and the new cluster state is broadcast.
-    </p><p>
-      If cluster state version is <a href="../operations/admin-procedures.html#cluster-state">reset</a>,
-      clients to distributors can temporarily fail operations in the transition,
-      but will eventually converge on the new (lower) cluster state version.
-    </p>
+      </p>
+      <p>
+        The version number is upped, and the new cluster state is broadcast.
+      </p>
+      <p>
+        If cluster state version is <a href="../operations/admin-procedures.html#cluster-state">reset</a>,
+        clients to distributors can temporarily fail operations in the transition,
+        but will eventually converge on the new (lower) cluster state version.
+      </p>
     </td>
   </tr>
   </tbody>
@@ -369,6 +377,111 @@ e.g. to remap requests to other buckets after bucket splitting and joining.
 </p>
 
 
+<h3 id="distributor-restart">Restart</h3>
+<p>
+  When a distributor stops, it will try to respond to any pending cluster state request first.
+  New incoming requests after shutdown is commenced will fail immediately,
+  as the socket is no longer accepting requests.
+  Cluster controllers will thus detect processes stopping almost immediately.
+</p>
+<p>
+  The cluster state will be updated with the new state internally in the cluster controller.
+  Then the cluster controller will wait for maximum
+  <a href="https://github.com/vespa-engine/vespa/blob/master/configdefinitions/src/vespa/fleetcontroller.def">
+    min_time_between_new_systemstates</a>
+  before publishing the new cluster state - this to reduce short-term state fluctuations.
+</p>
+<p>
+  The cluster controller has the option of setting states to make other
+  distributors take over ownership of buckets, or mask the change, making the
+  buckets owned by the distributor restarting unavailable for the time being.
+  Distributors restart fast, so the restarting distributor may transition
+  directly from up to initializing.
+  If it doesn't, current default behavior is to set it down immediately.
+</p>
+<p>
+  If transitioning directly from up to initializing, requests going through
+  the remaining distributors will be unaffected.
+  The requests going through the restarting distributor will immediately fail when it shuts down,
+  being resent automatically by the client.
+  The distributor typically restart within seconds,
+  and syncs up with the service layer nodes to get metadata on buckets it owns,
+  in which case it is ready to serve requests again.
+</p>
+<p>
+  If the distributor transitions from up to down, and then later to initializing,
+  other distributors will request metadata from the service layer node to take
+  over ownership of buckets previously owned by the restarting distributor.
+  Until the distributors have gathered this new metadata from all the service
+  layer nodes, requests for these buckets can not be served, and will fail back to client.
+  When the restarting node comes back up and is marked initializing or up in the cluster state again,
+  the additional nodes will dump knowledge of the extra buckets they previously acquired.
+</p>
+<p>
+  For requests with timeouts of several seconds,
+  the transition should be invisible due to automatic client resending.
+  Requests with a lower timeout might fail,
+  and it is up to the application whether to resend or handle failed requests.
+</p>
+<p>
+  Requests to buckets not owned by the restarting distributor will not be affected.
+  The other distributors will start to do some work though, affecting latency,
+  and distributors will re-fetch metadata for all buckets they own,
+  not just the additional buckets, which may cause some disturbance.
+</p>
+
+
+
+<h2 id="content-node">Content node</h2>
+<p>
+  The content node runs <em>proton</em>, which is the query backend.
+</p>
+
+
+
+<h3 id="content-node-restart">Restart</h3>
+<p>
+  When a content node restarts in a controlled fashion,
+  it marks itself in the stopping state and rejects new requests.
+  It will process its pending request queue before shutting down.
+  Consequently, client requests are typically unaffected by content node restarts.
+  The currently pending requests will typically be completed.
+  New copies of buckets will be created on other nodes, to store new requests in appropriate redundancy.
+  This happens whether node transitions through down or maintenance state.
+  The difference being that if transitioning through maintenance state,
+  the distributor will not start any effort of synchronizing new copies with existing copies.
+  They will just store the new requests until the maintenance node comes back up.
+</p>
+<p>
+  When coming back up, content nodes will start with gathering information
+  on what buckets it has data stored for.
+  While this is happening, the service layer will expose that it is initializing,
+  but not done with the bucket list stage.
+  During this time, the cluster controller will not mark it initializing in cluster state yet.
+  Once the service layer node knows what buckets it has,
+  it reports that it is calculating metadata for the buckets,
+  at which time the node may become visible as initializing in cluster state.
+  At this time it may start process requests,
+  but as bucket checksums have not been calculated for all buckets yet,
+  there will exist buckets where the distributor doesn't know if they are in sync with other copies or not.
+</p>
+<p>
+  The background load to calculate bucket checksums has low priority,
+  but load received will automatically create metadata for used buckets.
+  With an overloaded cluster, the initializing step may not finish before all buckets
+  have been initialized by requests.
+  With a cluster close to max capacity, initializing may take quite some time.
+</p>
+<p>
+  The cluster is mostly unaffected during restart.
+  During the initializing stage, bucket metadata is unknown.
+  Distributors will assume other copies are more appropriate for serving read requests.
+  If all copies of a bucket are in an initializing state at the same time,
+  read requests may be sent to a bucket copy that does not have the most updated state to process it.
+</p>
+
+
+
 <h2 id="metrics">Metrics</h2>
 <table class="table">
   <thead>
@@ -428,92 +541,92 @@ e.g. to remap requests to other buckets after bucket splitting and joining.
 
 
 
-<h2 id="distributor-node-restart">Distributor node restart</h2>
+<h2 id="state-api-examples">State API examples</h2>
 <p>
-  When a distributor stops, it will try to respond to any pending cluster state request first.
-  New incoming requests after shutdown is commenced will fail immediately,
-  as the socket is no longer accepting requests.
-  Cluster controllers will thus detect processes stopping almost immediately.
-</p><p>
-  The cluster state will be updated with the new state internally in the cluster controller.
-  Then the cluster controller will wait for maximum
-  <a href="https://github.com/vespa-engine/vespa/blob/master/configdefinitions/src/vespa/fleetcontroller.def">
-    min_time_between_new_systemstates</a>
-  before publishing the new cluster state - this to reduce short-term state fluctuations.
-</p><p>
-  The cluster controller has the option of setting states to make other
-  distributors take over ownership of buckets, or mask the change, making the
-  buckets owned by the distributor restarting unavailable for the time being.
-  Distributors restart fast, so the restarting distributor may transition
-  directly from up to initializing.
-  If it doesn't, current default behavior is to set it down immediately.
-</p><p>
-  If transitioning directly from up to initializing, requests going through
-  the remaining distributors will be unaffected.
-  The requests going through the restarting distributor will immediately fail when it shuts down,
-  being resent automatically by the client.
-  The distributor typically restart within seconds,
-  and syncs up with the service layer nodes to get metadata on buckets it owns,
-  in which case it is ready to serve requests again.
-</p><p>
-  If the distributor transitions from up to down, and then later to initializing,
-  other distributors will request metadata from the service layer node to take
-  over ownership of buckets previously owned by the restarting distributor.
-  Until the distributors have gathered this new metadata from all the service
-  layer nodes, requests for these buckets can not be served, and will fail back to client.
-  When the restarting node comes back up and is marked initializing or up in the cluster state again,
-  the additional nodes will dump knowledge of the extra buckets they previously acquired.
-</p><p>
-  For requests with timeouts of several seconds,
-  the transition should be invisible due to automatic client resending.
-  Requests with a lower timeout might fail,
-  and it is up to the application whether to resend or handle failed requests.
-</p><p>
-  Requests to buckets not owned by the restarting distributor will not be affected.
-  The other distributors will start to do some work though, affecting latency,
-  and distributors will re-fetch metadata for all buckets they own,
-  not just the additional buckets, which may cause some disturbance.
+  Examples of state manipulation using the <a href="api-state-rest-api.html">State API</a>.
 </p>
-
-
-
-<h2 id="content-node-restart">Content node restart</h2>
 <p>
-  When a content node restarts in a controlled fashion,
-  it marks itself in the stopping state and rejects new requests.
-  It will process its pending request queue before shutting down.
-  Consequently, client requests are typically unaffected by content node restarts.
-  The currently pending requests will typically be completed.
-  New copies of buckets will be created on other nodes, to store new requests in appropriate redundancy.
-  This happens whether node transitions through down or maintenance state.
-  The difference being that if transitioning through maintenance state,
-  the distributor will not start any effort of synchronizing new copies with existing copies.
-  They will just store the new requests until the maintenance node comes back up.
-</p><p>
-  When coming back up, content nodes will start with gathering information
-  on what buckets it has data stored for.
-  While this is happening, the service layer will expose that it is initializing,
-  but not done with the bucket list stage.
-  During this time, the cluster controller will not mark it initializing in cluster state yet.
-  Once the service layer node knows what buckets it has,
-  it reports that it is calculating metadata for the buckets,
-  at which time the node may become visible as initializing in cluster state.
-  At this time it may start process requests,
-  but as bucket checksums have not been calculated for all buckets yet,
-  there will exist buckets where the distributor doesn't know if they are in sync with other copies or not.
-</p><p>
-  The background load to calculate bucket checksums has low priority,
-  but load received will automatically create metadata for used buckets.
-  With an overloaded cluster, the initializing step may not finish before all buckets
-  have been initialized by requests.
-  With a cluster close to max capacity, initializing may take quite some time.
-</p><p>
-  The cluster is mostly unaffected during restart.
-  During the initializing stage, bucket metadata is unknown.
-  Distributors will assume other copies are more appropriate for serving read requests.
-  If all copies of a bucket are in an initializing state at the same time,
-  read requests may be sent to a bucket copy that does not have the most updated state to process it.
+  Get node state:
 </p>
+<pre>
+$ curl http://localhost:19050/cluster/v2/music/storage/0
+</pre>
+<pre>{% highlight json %}
+{
+  "attributes": {
+    "hierarchical-group": "group0"
+  },
+  "state": {
+    "generated": {
+      "state": "up",
+      "reason": ""
+    },
+    "unit": {
+      "state": "up",
+      "reason": ""
+    },
+    "user": {
+      "state": "up",
+      "reason": ""
+    }
+  },
+  "metrics": {
+    "bucket-count": 0,
+    "unique-document-count": 0,
+    "unique-document-total-size": 0
+  }
+}
+{% endhighlight %}</pre>
+<p>
+  Get all nodes, including topology information (see <em>hierarchical-group</em>):
+</p>
+<pre>
+$ curl http://localhost:19050/cluster/v2/music/?recursive=true
+</pre>
+<pre>{% highlight json %}
+{
+  "state": {
+    "generated": {
+      "state": "up",
+      "reason": ""
+    }
+  },
+  "service": {
+    "storage": {
+      "node": {
+        "0": {
+          "attributes": {
+            "hierarchical-group": "group0"
+          },
+          "state": {
+            "generated": {
+              "state": "up",
+              "reason": ""
+            },
+            "unit": {
+              "state": "up",
+              "reason": ""
+            },
+            "user": {
+              "state": "up",
+              "reason": ""
+            }
+          },
+          "metrics": {
+            "bucket-count": 0,
+            "unique-document-count": 0,
+            "unique-document-total-size": 0
+          }
+        },
+{% endhighlight %}</pre>
+<p>
+  Set node state:
+</p>
+<pre>
+$ curl -X PUT \
+  --data '{"state":{"user":{"state": "down", "reason": "Down a broken node"}}}' \
+  http://localhost:19050/cluster/v2/music/storage/0
+</pre>
 
 
 


### PR DESCRIPTION
- Some text rewrites. sorry for all the reindent ...
- The real change is adding curl examples - it has shown too difficult with the reference API examples. maybe we should just remove those