### PR TITLE
Remove experimental flag from GC tuning example

### DIFF
--- a/en/performance/container-tuning.html
+++ b/en/performance/container-tuning.html
@@ -126,7 +126,7 @@ Example: Running with 4 GB heap using G1 garbage collector and using NewRatio = 
 <pre>
 &lt;container id="default" version="1.0"&gt;
   &lt;nodes&gt;
-    &lt;jvm options="-Xms4g -Xmx4g -XX:+PrintCommandLineFlags -XX:+PrintGC" gc-options="-XX:+UseG1GC -XX:MaxTenuringThreshold=15 -XX:G1NewSizePercent=50" /&gt;
+    &lt;jvm options="-Xms4g -Xmx4g -XX:+PrintCommandLineFlags -XX:+PrintGC" gc-options="-XX:+UseG1GC -XX:MaxTenuringThreshold=15" /&gt;
     &lt;node hostalias="node0" /&gt;
   &lt;/nodes&gt;
 &lt;/container&gt;


### PR DESCRIPTION
`-XX:G1NewSizePercent` is experimental and requires `-XX:+UnlockExperimentalVMOptions` in order to deploy. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
