### PR TITLE
Link query execution descriptions

### DIFF
--- a/en/performance/sizing-search.html
+++ b/en/performance/sizing-search.html
@@ -171,6 +171,11 @@ for examples using grouped and flat data distribution.
 
 <h2 id="life-of-a-query-in-vespa">Life of a query in Vespa</h2>
 <p>
+  Find an overview in <a href="../query-api.html#query-execution">query execution</a>:
+</p>
+<img src="/assets/img/query-to-response.svg" width="780px" height="auto"
+     alt="Query execution - from query to response"/>
+<p>
 Vespa executes a query in two protocol phases
 (or more if using <a href="../grouping.html">result grouping features</a>)
 to optimize the network footprint of the parallel query execution.
@@ -188,7 +193,7 @@ the second protocol phase fetch the summary data for the global best hits
 By doing the query in two protocol
 phases one avoids transferring summary data for hits which will not make it into the global best hits.
 </p><p>
-Components Involved in Query Execution:
+Components Involved in query execution:
 </p>
 <ul>
 <li><strong>Container</strong>
@@ -209,7 +214,7 @@ Components Involved in Query Execution:
   <li>Result processing and possible top-k re-ranking and finally rendering of results back to client.</li>
   </ul>
 </li>
-<li><strong>Search (Proton)</strong>
+<li><strong>Content node (Proton)</strong>
   <ul>
   <li>Finding all documents matching the <a href="../query-api.html">query specification</a>.
       For an ML serving use case, the selection might be a subset of the content pool

--- a/en/query-api.html
+++ b/en/query-api.html
@@ -209,6 +209,8 @@ use this to write code to manipulate results.
 <p>
   The above is a simplification - if the query also specifies <a href="grouping.html">result grouping</a>,
   the query phase might involve multiple phases or round-trips between the container and content nodes.
+  See <a href="performance/sizing-search.html#life-of-a-query-in-vespa">life of a query</a>
+  for a deeper dive into query execution details.
 </p>
 
 


### PR DESCRIPTION
- Use same illustration in both places
- It seems to me that these two sections overlap a lot, maybe we should have only one, moving some from the query API doc into the sizing doc - what do you think, @jobergum  ?