### PR TITLE
Jetty bundles are no longer provided on Vespa 8

### DIFF
--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -743,6 +743,10 @@ The following Maven artifacts are no longer provided runtime to user application
     <td>JAX-RS API, used by Jersey 2.</td>
   </tr>
   <tr>
+    <td><a href="https://search.maven.org/search?q=g:org.eclipse.jetty"><em>org.eclipse.jetty:*</em></a></td>
+    <td>The Eclipse Jetty Project.</td>
+  </tr>
+  <tr>
     <td><a href="https://search.maven.org/artifact/org.apache.felix/org.apache.felix.framework"><em>org.apache.felix:org.apache.felix.framework</em></a></td>
     <td>Felix OSGi framework.</td>
   </tr>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
