### PR TITLE
Fix transition-time unit in tuning doc

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -1756,7 +1756,7 @@ Tuning parameters for the cluster controller managing this cluster - child eleme
         distributor_transition_time</a></td>
       <td>
         <p id="transition-time">
-        The transition time states how long (in milliseconds) a node will be in maintenance mode
+        The transition time states how long (in seconds) a node will be in maintenance mode
         during what looks like a controlled restart.
         Keeping a node in maintenance mode during a restart allows a restart
         without the cluster trying to create new copies of all the data immediately.


### PR DESCRIPTION
@kkraune please review

Default interpretation of value is in seconds, not milliseconds.
