### PR TITLE
Add draft live query for grouping examples

### DIFF
--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -35,4 +35,7 @@
     <script src="/js/load-mathjax.js" async></script>
     <!-- pre Highlight style, ref https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting -->
     <link rel="stylesheet" href="{{ site.baseurl }}/css/native.css">
+
+    <!-- Query example generator -->
+    <script src="/js/query_examples.js"></script>
 </head>

--- a/en/grouping.html
+++ b/en/grouping.html
@@ -242,6 +242,11 @@ Example: <em>Return the total sum of purchases per customer</em> - steps:
 <p>
   Final query, producing the sum of the price of all purchases for each customer:
 </p>
+<p><a class="docsearch-x">select * from purchase where true limit 0 |
+  all(
+    group(customer)
+    each(output(sum(price)))
+  )</a></p>
 <pre>
 /search/?yql=select * from sources * where true limit 0 |
   all( group(customer) each(output(sum(price))) )

--- a/en/query-language.html
+++ b/en/query-language.html
@@ -127,25 +127,3 @@ field my_map type map&lt;string, int&gt; {
     struct-field value { indexing: attribute }
 }
 </pre>
-
-
-<script>
-  function generateQueryExamples () {
-    let docsearchQueries = document.getElementsByClassName("docsearch-x");
-    for (let anchor of docsearchQueries) {
-      generateQuery(anchor, "https://doc-search.vespa.oath.cloud/search/");
-    }
-    let cord19Queries = document.getElementsByClassName("cord19-x");
-    for (let anchor of cord19Queries) {
-      generateQuery(anchor, "https://api.cord19.vespa.ai/search/");
-    }
-  }
-
-  function generateQuery(anchor, endpoint) {
-    let hr = document.createElement("hr");
-    anchor.parentElement.insertBefore(hr, anchor);
-    anchor.setAttribute("href", encodeURI(endpoint + "?yql=" + anchor.innerText));
-  }
-
-  document.addEventListener("DOMContentLoaded", generateQueryExamples);
-</script>

--- a/js/query_examples.js
+++ b/js/query_examples.js
@@ -1,0 +1,19 @@
+
+function generateQueryExamples () {
+    let docsearchQueries = document.getElementsByClassName("docsearch-x");
+    for (let anchor of docsearchQueries) {
+        generateQuery(anchor, "https://doc-search.vespa.oath.cloud/search/");
+    }
+    let cord19Queries = document.getElementsByClassName("cord19-x");
+    for (let anchor of cord19Queries) {
+        generateQuery(anchor, "https://api.cord19.vespa.ai/search/");
+    }
+}
+
+function generateQuery(anchor, endpoint) {
+    //let hr = document.createElement("hr");
+    //anchor.parentElement.insertBefore(hr, anchor);
+    anchor.setAttribute("href", encodeURI(endpoint + "?yql=" + anchor.innerText));
+}
+
+document.addEventListener("DOMContentLoaded", generateQueryExamples);


### PR DESCRIPTION
We agreed to make the doc more clickable / live, so some sample grouping data is added to doc search in https://github.com/vespa-cloud/vespa-documentation-search/pull/15 (must be merged with this), based on https://github.com/vespa-engine/sample-apps/tree/master/examples/part-purchases-demo (this one can be removed later)

The idea is to easily write sample queries in clear text and auto-generate the link to the source.

@ldalves I would like these clickable examples stand out, maybe like in https://docs.vespa.ai/en/getting-started-ranking.html - but I would like your input on how to make this look great and intuitive

I just added one such query to the grouping guide for now so you can see how it works / change before we do more

FYI @jobergum 