### PR TITLE
Add bucket testing section

### DIFF
--- a/en/jdisc/container-components.html
+++ b/en/jdisc/container-components.html
@@ -117,7 +117,8 @@ public void deconstruct() {
   <li>The index of the node this is running on.</li>
 </ul>
 <p>
-  The two latter can be used e.g. for bucket testing new features on a subset of nodes.
+  The two latter can be used e.g. for <a href="../testing.html#feature-switches-and-bucket-tests">bucket testing</a>
+  new features on a subset of nodes.
   Please note that the node indices are not necessarily contiguous or starting from zero.
 </p>
 
@@ -321,7 +322,7 @@ http://localhost:8080/ApplicationStatus
   id may be <em>versioned</em>, that includes chains, components and query profiles.
   This allows multiple versions of these elements to be used at the same time,
   including multiple versions of the same classes,
-  which is handy for bucket testing new versions.
+  which is handy for <a href="../testing.html#feature-switches-and-bucket-tests">bucket testing</a> new versions.
 </p><p>
   An id or id reference may include a version by using the following syntax: <code>name:version</code>.
   This works with ids in search requests, services.xml, code and query profiles.

--- a/en/query-profiles.html
+++ b/en/query-profiles.html
@@ -12,7 +12,7 @@ whose parameters will be used as parameters of that request.
 This frees the client from having to manage and send a large number of parameters,
 and enables the request parameters to use for a use case to be changed
 without having to change the client.
-Query profiles enables <em>bucket tests</em>,
+Query profiles enables <a href="testing.html#feature-switches-and-bucket-tests">bucket tests</a>,
 where a part of the query stream is given some experimental treatment,
 as well as differentiating behavior based on (OEM) customer, user type, region, frontend type etc.
 This document explains how to create and use query profiles.

--- a/en/ranking.html
+++ b/en/ranking.html
@@ -100,8 +100,8 @@ either inside the schema or equivalently in their own files in the
 <a href="reference/application-packages-reference.html">application package</a>, named
 <code>schemas/[schema-name]/[profile-name].profile</code>.</p>
 
-<p>One schema can have any number of rank profiles for implementing e.g different use cases
-or bucket testing variations.
+<p>One schema can have any number of rank profiles for implementing e.g. different use cases
+or <a href="testing.html#feature-switches-and-bucket-tests">bucket testing</a> variations.
 If no profile is specified, the <a href="text-matching-ranking.html#ranking">default text ranking</a>
 profile is used.</p>
 

--- a/en/testing.html
+++ b/en/testing.html
@@ -1,12 +1,12 @@
 ---
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: Vespa application system tests
+title: Vespa testing
 ---
 
 <p>
   System tests are an invaluable tool both when developing and maintaing a complex Vespa application.
   These are functional tests which are run against a deployment of the application package to verify,
-  and use its HTTP APIs to execute feed and query operations which are compared to expected outcomes. 
+  and use its HTTP APIs to execute feed and query operations which are compared to expected outcomes.
   Vespa provides two formalizations of this:
 </p>
 <ul>
@@ -23,8 +23,12 @@ title: Vespa application system tests
   designated test deployment, separating the tests from the deployment and configuration of the test clusters.
 </p>
 <p>
-  The rest of this document describes how each of these test categories can be run as part of an imagined
-  CI/CD system for safely deploying changes to a Vespa application in a continuous manner. 
+  This document describes how each of these test categories can be run as part of an imagined
+  CI/CD system for safely deploying changes to a Vespa application in a continuous manner.
+</p>
+<p>
+  Finally, find a section on <a href="#feature-switches-and-bucket-tests">A/B-testing / bucket tests</a>
+  using feature switches.
 </p>
 
 
@@ -77,10 +81,10 @@ title: Vespa application system tests
   and querying for the document after the upgrade could give different results
   from what the system test would expect.
 </p>
-<p>Many such changes, which require additional action post-deployment, are also guarded by 
+<p>Many such changes, which require additional action post-deployment, are also guarded by
   <a href="reference/validation-overrides.html">validation overrides</a>,
   but the staging test is then a great way of figuring out what the exact consequences of the change are,
-  and how to deal with it. 
+  and how to deal with it.
 </p>
 <p>
   As opposed to system tests, staging tests are not self-contained, as the state change during upgrade is
@@ -93,7 +97,7 @@ title: Vespa application system tests
   and this dictates the workflow when deploying a breaking change:
 </p>
 <ol>
-  <li><p>First, the application code and system and and staging tests are updated, so tests pass; 
+  <li><p>First, the application code and system and and staging tests are updated, so tests pass;
     and clients are updated to reflect the updated test code.<p></li>
   <li><p>Next, the application is upgraded.</p></li>
   <li><p>Finally, the <em>staging setup</em> code is updated to match the new application code.</p></li>
@@ -113,5 +117,47 @@ title: Vespa application system tests
 </p>
 <p>
   These tests will be completely domain-dependent, and typically not run against the Vespa application
-  itself. The test framework therefore has less tooling here, and really only specifies this is a separate category. 
+  itself. The test framework therefore has less tooling here, and really only specifies this is a separate category.
+</p>
+
+
+
+<h2 id="feature-switches-and-bucket-tests">Feature switches and bucket tests</h2>
+<p>
+  With continuous deployment, it is not practical to hold off releasing a feature until it is done,
+  test it manually until convinced it works and then release it to production.
+  What to do instead?
+  The answer is <em>feature switches</em>: release new features to production as they are developed,
+  but include logic which keeps them deactivated until they are ready,
+  or until they have been verified in production with a subset of users.
+</p>
+<p>
+  <em>Bucket tests</em> is the practice of systematically testing new features or behavior for a controlled subset of users.
+  This is common practice when releasing new science models,
+  as they are difficult to verify in test, but can also be used for other features.
+</p>
+<p>
+  To test new behavior in Vespa, use a combination of
+  <a href="chained-components.html">search chains</a> and
+  <a href="reference/schema-reference.html#rank-profile">rank profiles</a>,
+  controlled by <a href="query-profiles.html">query profiles</a>,
+  where one query profile corresponds to one bucket.
+  These features support inheritance to make it easy to express variation without repetition.
+</p>
+<p>
+  Sometimes a new feature requires
+  <a href="reference/schema-reference.html#modifying-schemas">incompatible changes to a data field</a>.
+  To be able to CD such changes, it is necessary to create a new field containing the new version of the data.
+  This costs extra resources but less than the alternative: standing up a new system copy with the new data.
+  New fields can be added and populated while the system is live.
+</p>
+<p>
+  One way to reduce the need for incompatible changes can be decreased
+  by making the semantics of the fields more precise.
+  E.g., if a field is defined as the "quality" of a document, where a higher number means higher quality,
+  a new algorithm which produces a different range and distribution will typically be an incompatible change.
+  However, if the field is defined more precisely as the average time spent on the document once it is clicked,
+  then a new algorithm which produces better estimates of this value will not be an incompatible change.
+  Using precise semantics also have the advantage of making it easier to understand
+  if the use of the data and its statistical properties are reasonable.
 </p>

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -73,7 +73,8 @@ To ensure their applications are compatible with Vespa 8, application owners mus
 <p>These changes may break clients, and impact both performance and user experience.
 Applications that are in production and relies on these defaults should
 make configuration changes to keep the existing behavior when upgrading to Vespa 8.
-This can be done on Vespa 7, <i>before</i> upgrading.</p>
+This can be done on Vespa 7, <i>before</i> upgrading -
+using <a href="testing.html#feature-switches-and-bucket-tests">bucket tests</a> can be useful.</p>
 
 <p>
 The following defaults have changed:


### PR DESCRIPTION
- with the new testing.html document we have a great home for the generic bucket test doc found on cloud.vespa.ai - copied here as is
- add links, bucket testing is mentioned multiple places, so good to have this anchor

@jonmv FYI