### PR TITLE
Remove vespa7 text from reference

### DIFF
--- a/en/geo-search.html
+++ b/en/geo-search.html
@@ -32,13 +32,10 @@ redirect_from:
   east (longitudes); negative numbers are used for south and west.
   This is the usual convention.
 </p>
-<p>
-  NOTE: Old formats for position (those used in Vespa 5, 6, and 7)
-  are still accepted as feed input; enabling legacy output is
-  temporarily possible also.  See
-  <a href="reference/default-result-format.html#geo-position-rendering">legacy flag v7-geo-positions</a>.
-</p>
-
+{% include note.html content="Old formats for position (those used in Vespa 5, 6, and 7)
+are still accepted as feed input; enabling legacy output is
+temporarily possible also.  See
+<a href='reference/default-result-format.html#geo-position-rendering'>legacy flag v7-geo-positions</a>." %}
 
 
 <h2 id="sample-schema-and-document">Sample schema and document</h2>

--- a/en/reference/document-json-format.html
+++ b/en/reference/document-json-format.html
@@ -88,79 +88,14 @@ Also refer to <a href="../troubleshooting-encoding.html">encoding troubleshootin
   </tr><tr>
     <th>position</th>
     <td>
-      <p id="position">A position is encoded as a <em>latitude;longitude</em> string, valid formats:</p>
-      <ol>
-        <li>S22.4532;W123.9887 -
-          default <a href="query-api-reference.html#geographical-searches">query/result format</a></li>
-        <li>N72°23'52;E26°04'22</li>
-        <li>N72o20.92;E26o08.54</li>
-      </ol>
-      <p>
-      Latitude is prefixed by N or S, and longitude by E or W.
-      The angular measurement is expressed as degrees with a decimal fraction,
-      or as degrees subdivided in minutes and seconds.
-      It is also valid to express minutes with a decimal fraction, supporting regular GPS output format.
-      Small letter o may be used as a replacement for the degrees sign.
-      </p>
-      <h3 id="document-api">Document API</h3>
-      <p>
-      To input a location field using <a href="document-v1-api-reference.html">/document/v1/</a>,
-      use the <em>latitude;longitude</em> string:
-      </p>
+      <p id="position">A position is encoded as a lat/lng object:</p>
 <pre>
-"location": "N37.401;W121.996"
-</pre>
-      <p>When output in <em>document api</em>, the field is rendered as:</p>
-<pre>
-"location": {
-    "y": 37401000,
-    "x": -121996000
-}
-</pre><p>
-      The <a href="../geo-search.html#x-y">X/Y coordinates</a> are in millionths of degrees
-      </p>
-      <h3 id="document-summary">Document summary</h3>
-      <p>A position field configured as:</p>
-<pre>
-field location type position { indexing: attribute }
-</pre>
-      <p>is rendered as:</p>
-<pre>
-"location.position": {
-    "x": -121996000,
-    "y": 37401000,
-    "latlong": "N37.401000;W121.996000"
+"mypos": {
+    "lat": 37.4181488,
+    "lng": -122.0256157
 }
 </pre>
-      <p>Adding <em>summary</em>:</p>
-<pre>
-field location type position { indexing: summary | attribute }
-</pre>
-      <p>will render it as:</p>
- <pre>
-"location": {
-    "x": -121996000,
-    "y": 37401000
-},
-"location.position": {
-    "x": -121996000,
-    "y": 37401000,
-    "latlong": "N37.401000;W121.996000"
-}
-</pre>
-      <p>
-      If the request specifies a <em>position</em>,
-      the distance to this position is calculated and rendered in <em>fieldname.distance</em>.
-      Find details in <a href="../geo-search.html">Geo search</a>:
-      </p>
-<pre>
-"location.position": {
-    "x": -121996000,
-    "y": 37401000,
-    "latlong": "N37.401000;W121.996000"
-},
-"location.distance": 27488
-</pre>
+      <p>See <a href="../geo-search.html">Geo Search</a> for details.</p>
     </td>
   </tr><tr>
     <th>predicate</th>
@@ -402,7 +337,7 @@ There are two methods for document operations:
   </li><li>
     <a href="document-v1-api-reference.html">/document/v1/</a>:
     This API accepts one operation per request, with the document ID encoded in the URL.
-    This is the API used by the Vespa feed client, and is the recommendation for new feed clients using HTTP/2. 
+    This is the API used by the Vespa feed client, and is the recommendation for new feed clients using HTTP/2.
   </li>
 </ul>
 

--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -1075,9 +1075,7 @@ see the rendering <a href="document-json-format.html#position">reference</a> and
 <table class="table table-striped">
 <tr><td>Alias</td><td>pos.ll</td></tr>
 <tr><td>Values</td>
-  <td>Position given in latitude and longitude - example: <em>S22.4532;W123.9887</em>
-    Refer to <a href="document-json-format.html#position">position field</a>
-    for format specification.</td>
+  <td>Position given in latitude and longitude - example: <em>S22.4532;W123.9887</em></td>
 </tr>
 <tr><td>Default</td><td>None</td></tr>
 </table>


### PR DESCRIPTION
- linking to the geo doc will suffice
- I am not sure if the Vespa 7 `latlong` description should be anywhere, @arnej27959 ?