### PR TITLE
Kkraune/geo cleanup

### DIFF
--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -112,15 +112,6 @@ get methods as Java objects from the Query to Searcher components.
   </ul>
 </dd>
 
-<dt><a href="#geographical-searches">Geographical Searches</a></dt>
-<dd>
-  <ul>
-    <li><a href="#pos.ll">pos.ll</a></li>
-    <li><a href="#pos.radius">pos.radius</a>,</li>
-    <li><a href="#pos.attribute">pos.attribute</a></li>
-  </ul>
-</dd>
-
 <dt><a href="#tracing">Tracing</a></dt>
 <dd>
   <ul>
@@ -1006,57 +997,6 @@ Otherwise, use grouping.
   is not specified. The final precision value is calculated by multiplying the effective <code>max</code> value with the scale factor.
 </p>
 
-<h2 id="geographical-searches">Geographical Searches</h2>
-<p>
-When a position is used in a query, a distance to this position is calculated and returned -
-see the rendering <a href="document-json-format.html#position">reference</a> and
-<a href="../geo-search.html">geo search</a> for details.
-</p>
-  {% include deprecated.html content="Adding a <a href='query-language-reference.html#geolocation'>geoLocation</a>
-  item to the query tree is the preferred and uniform way to inject the position, radius, and attribute field,
-  so the pos.ll, pos.radius, and pos.attribute request parameters below are deprecated."%}
-
-
-<h3 id="pos.ll">pos.ll</h3>
-<table class="table table-striped">
-<tr><td>Alias</td><td>pos.ll</td></tr>
-<tr><td>Values</td>
-  <td>Position given in latitude and longitude - example: <em>S22.4532;W123.9887</em></td>
-</tr>
-<tr><td>Default</td><td>None</td></tr>
-</table>
-
-
-<h3 id="pos.radius">pos.radius</h3>
-<table class="table table-striped">
-<tr><td>Alias</td><td>pos.radius</td></tr>
-<tr><td>Values</td><td>
-  Radius of the circle used for filtering.
-  Valid units of measurement are <code>km</code>, <code>m</code> and <code>mi</code>. Examples:
-  <ul>
-    <li>pos.radius=1609.344m</li>
-    <li>pos.radius=1mi</li>
-    <li>pos.radius=1.609344km</li>
-  </ul>
-  One can also specify just a number (internal units, micro-degrees), but this is not recommended.
-  Any negative number is interpreted as an "infinite" radius, letting any geographical position at all
-  match the filter.
-</td></tr>
-<tr><td>Default</td><td>50km</td></tr>
-</table>
-
-
-
-<h3 id="pos.attribute">pos.attribute</h3>
-<table class="table table-striped">
-  <tr><td>Alias</td><td>pos.attribute</td></tr>
-  <tr><td>Values</td><td>Any attribute that has zcurve encoded positions as a long attribute.</td></tr>
-  <tr><td>Default</td><td>Random choice among the ones declared as position in the schema.</td></tr>
-</table>
-<p>
-Which attribute to use for the position. Can be both single-valued or
-<a href="../schemas.html#field">array</a>.
-</p>
 
 
 <h2 id="tracing">Tracing</h2>

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -866,7 +866,7 @@ The following HTTP APIs are removed:
 
 <h2 id="removed-http-api-parameters">Removed HTTP API parameters</h2>
 <p>
-The following HTTP API parameters are removed:
+The following HTTP API parameters are removed from the <a href="reference/query-api-reference.html">query API</a>:
 </p>
 <table class="table">
   <thead>

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -881,6 +881,9 @@ item to the query</td> </tr>
   <tr> <td>/search/</td><td><em>pos.radius</em></td> <td>add a
 <a href="reference/query-language-reference.html#geolocation">geoLocation</a>
 item to the query</td> </tr>
+  <tr> <td>/search/</td><td><em>pos.attribute</em></td> <td>add a
+    <a href="reference/query-language-reference.html#geolocation">geoLocation</a>
+    item to the query</td> </tr>
   <tr> <td>/search/</td><td><em>pos.bb</em></td> <td>
     Support for restricting search by a bounding box, using the <code>pos.bb</code>
     query parameter, has been removed - add a

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -877,10 +877,15 @@ The following HTTP API parameters are removed:
   <tbody>
   <tr> <td>/search/</td><td><em>pos.ll</em></td> <td>add a
 <a href="reference/query-language-reference.html#geolocation">geoLocation</a>
-item to your query</td> </tr>
+item to the query</td> </tr>
   <tr> <td>/search/</td><td><em>pos.radius</em></td> <td>add a
 <a href="reference/query-language-reference.html#geolocation">geoLocation</a>
-item to your query</td> </tr>
+item to the query</td> </tr>
+  <tr> <td>/search/</td><td><em>pos.bb</em></td> <td>
+    Support for restricting search by a bounding box, using the <code>pos.bb</code>
+    query parameter, has been removed - add a
+    <a href="reference/query-language-reference.html#geolocation">geoLocation</a>
+    item to the query</td> </tr>
   </tbody>
 </table>
 
@@ -1216,8 +1221,3 @@ The following metrics are removed:
 where text contains ([{"distance": 5}]near("a", "b"));
 where text contains ({distance: 5}near("a", "b"))
 </pre>
-
-<h3 id="geo-bounding-box-is-removed">Geo bounding box is removed</h3>
-
-<p>Support for restricting search by a bounding box, using the <code>pos.bb</code>
-query parameter, has been removed.</p>


### PR DESCRIPTION
- note: pos.attribute is not mentioned in vespa8-release-notes.html, this is an oversight? This PR removes it from doc as it is the only geo parameter left in the query API