### PR TITLE
Default feeding.concurrency is 0.2 nowadays

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -913,7 +913,7 @@ Tune <a href="../proton.html">proton</a> settings for feed operations. Optional 
 </p>
 <ul>
   <li id="feeding-concurrency"><code>concurrency</code>:
-    A number between 0.0 and 1.0 that specifies the concurrency when handling feed operations, default 0.5.
+    A number between 0.0 and 1.0 that specifies the concurrency when handling feed operations, default 0.2.
     When set to 1.0, all cores on the cpu can be used for feeding.
     See <a href="https://github.com/vespa-engine/vespa/blob/master/searchcore/src/vespa/searchcore/config/proton.def">
     feeding.concurrency</a> for details on how this setting affects the thread pools used for feed operations.


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
