### PR TITLE
Kkraune/restart

### DIFF
--- a/en/config-sentinel.html
+++ b/en/config-sentinel.html
@@ -86,6 +86,7 @@ redirect_from:
         each assigned the same or another config id, and instantiating further components.
       </li>
     </ol>
+    Also see <a href="#cluster-startup">cluster startup</a> for a minimum nodes-up start setting.
   </li>
 </ol>
 <p>
@@ -134,15 +135,15 @@ slobrok state=RUNNING mode=AUTO pid=28000 exitstatus=0 id="admin/slobrok.0"
   The safe mode is disabled by default,
   enable it by setting configuration on top level in <em>services.xml</em> (since Vespa-7.415):
 </p>
-<pre>
-&lt;services&gt;
-    &lt;config name="cloud.config.sentinel"&gt;
-        &lt;connectivity&gt;
-            &lt;minOkPercent&gt;40&lt;/minOkPercent&gt;
-            &lt;maxBadCount&gt;1&lt;/maxBadCount&gt;
-        &lt;/connectivity&gt;
-    &lt;/config&gt;
-</pre>
+<pre>{% highlight xml %}
+<services>
+    <config name="cloud.config.sentinel">
+        <connectivity>
+            <minOkPercent>40</minOkPercent>
+            <maxBadCount>1</maxBadCount>
+        </connectivity>
+    </config>
+{% endhighlight %}</pre>
 <p>
   Example: <code>minOkPercent 40</code> means that services will be started only if
   more than or equal to 40% of nodes are up.

--- a/en/operations/admin-procedures.html
+++ b/en/operations/admin-procedures.html
@@ -18,6 +18,56 @@ redirect_from:
 
 
 
+<h2 id="vespa-start-stop-restart">Vespa start / stop / restart</h2>
+<p>
+  There is no restart command, do a stop then start for a restart.
+  Start and stop <span style="text-decoration: underline">all</span> services on a node:
+</p>
+<pre>
+$ $VESPA_HOME/bin/<a href="../reference/vespa-cmdline-tools.html#vespa-start-services">vespa-start-services</a>
+$ $VESPA_HOME/bin/<a href="../reference/vespa-cmdline-tools.html#vespa-stop-services">vespa-stop-services</a>
+</pre>
+<p>Likewise, for the config server:</p>
+<pre>
+$ $VESPA_HOME/bin/<a href="../reference/vespa-cmdline-tools.html#vespa-start-configserver">vespa-start-configserver</a>
+$ $VESPA_HOME/bin/<a href="../reference/vespa-cmdline-tools.html#vespa-stop-configserver">vespa-stop-configserver</a>
+</pre>
+<p>
+  Learn more about which processes / services are started at <a href="../config-sentinel.html">Vespa startup</a>,
+  read the <a href="configuration-server.html#start-sequence">start sequence</a>
+  and find training videos at the <a href="https://vespa.ai/resources">resource site</a>.
+</p>
+<p>
+  Use <a href="../reference/vespa-cmdline-tools.html#vespa-sentinel-cmd">vespa-sentinel-cmd</a>
+  to stop/start individual <span style="text-decoration: underline">services</span>.
+</p>
+{% include important.html content="Running <em>vespa-stop-services</em> on a content node will call
+<a href='../reference/vespa-cmdline-tools.html#vespa-proton-cmd'>prepareRestart</a> to optimize restart time,
+and is the recommended way to stop Vespa on a node." %}
+
+
+<h3 id="pre-start-check">Pre-start check</h3>
+<p>
+  To run an automated node check before Vespa is started, provide a check script at
+  <a href="../reference/files-processes-and-ports.html#environment-variables">VESPA_VALIDATIONSCRIPT</a>,
+  returning 0 if <em>vespa-start-services</em> is allowed to run:
+</p>
+<pre>
+$ export VESPA_VALIDATIONSCRIPT=/tmp/my-prestart-check.sh
+$ cat /tmp/my-prestart-check.sh
+#!/bin/sh
+echo detect some problem
+exit 1
+$ $VESPA_HOME/bin/vespa-start-services
+... starting ...
+detect some problem
+validation script '/tmp/my-prestart-check.sh' failed
+$VESPA_HOME/bin/vespa-start-services failed: exit code 1 from command:
+$VESPA_HOME/libexec/vespa/start-vespa-base.sh
+</pre>
+
+
+
 <h2 id="system-status">System status</h2>
 <ul>
   <li>Use <a href="../reference/vespa-cmdline-tools.html#vespa-config-status">vespa-config-status</a>
@@ -45,7 +95,7 @@ redirect_from:
   It is the same name which is used in the administration interface
   in the <a href="../config-sentinel.html">config sentinel</a>.
 </p><p>
-  Learn how to <a href="../reference/files-processes-and-ports.html#vespa-start-stop">start / stop</a> nodes.
+  Learn how to <a href="#vespa-start-stop-restart">start / stop</a> nodes.
 </p>
 
 
@@ -254,7 +304,7 @@ $ <a href="../reference/vespa-cmdline-tools.html#vespa-model-inspect">vespa-mode
     Prepare the node by installing software, set up the file systems/directories
     and set <a href="../reference/files-processes-and-ports.html#environment-variables">
     <code>VESPA_CONFIGSERVERS</code></a>.
-    <a href="../reference/files-processes-and-ports.html#vespa-start-stop">Start</a> the node.
+    <a href="#vespa-start-stop-restart">Start</a> the node.
   </li><li>
     <strong>Modify configuration:</strong>
     Add/remove a <a href="../reference/services-content.html#node">node</a>-element in <em>services.xml</em>

--- a/en/operations/configuration-server.html
+++ b/en/operations/configuration-server.html
@@ -193,7 +193,8 @@ Container.com.yahoo.vespa.config.server.session.SessionRepository	Session activa
     Technically, they can be started at any time.
     When troubleshooting, it is easier to make sure the config servers are started successfully,
     and deployment was successful - before starting any other nodes.
-    Refer to the <a href="../config-sentinel.html">Vespa start sequence</a>.
+    Refer to the <a href="../config-sentinel.html">Vespa start sequence</a>
+    and <a href="admin-procedures.html#vespa-start-stop-restart">Vespa start / stop / restart</a>.
   </li>
 </ol>
 <p>
@@ -320,15 +321,14 @@ $ vespa-zkcli get /config/v2/tenants/default/sessions/[sessionid]/userapp/servic
   One example of such a scenario is if <em>$VESPA_HOME/logs/vespa/zookeeper.configserver.0.log</em>
   says <em>java.io.IOException: Negative seek offset at java.io.RandomAccessFile.seek(Native Method)</em>,
   which indicates ZooKeeper has not been able to recover after a full disk.
-  There is no need to restart Vespa on other nodes during the procedure.
-  Refer to <a href="../reference/vespa-cmdline-tools.html">tools</a> for details:
+  There is no need to restart Vespa on other nodes during the procedure:
 </p>
 <ol>
-  <li>vespa-stop-configserver</li>
-  <li>vespa-configserver-remove-state</li>
-  <li>vespa-start-configserver</li>
-  <li>vespa-deploy prepare &lt;application path&gt;</li>
-  <li>vespa-deploy activate</li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-stop-configserver">vespa-stop-configserver</a></li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-configserver-remove-state">vespa-configserver-remove-state</a></li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-start-configserver">vespa-start-configserver</a></li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-deploy">vespa-deploy</a> prepare &lt;application path&gt;</li>
+  <li><a href="../reference/vespa-cmdline-tools.html#vespa-deploy">vespa-deploy</a> activate</li>
 </ol>
 <p>
   This procedure completely cleans out ZooKeeper's internal data snapshots and deploys from scratch.

--- a/en/operations/docker-containers.html
+++ b/en/operations/docker-containers.html
@@ -58,11 +58,11 @@ $ docker run --detach --name vespa --hostname vespa-container --volume $VESPA_VA
 
 <h2 id="transparent-huge-pages">Transparent Huge Pages</h2>
 <p>Vespa performance improves significantly by enabling
-  <a href="https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html">Transparent Huge Pages (THP)</a>, 
+  <a href="https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html">Transparent Huge Pages (THP)</a>,
   especially for memory intensive applications with large dense tensors with concurrent query and write workloads.
 </p>
-<p>  
-  One application improved query 99p latency from 950 ms to 150ms during concurrent query and write by enabling THP. 
+<p>
+  One application improved query 99p latency from 950 ms to 150ms during concurrent query and write by enabling THP.
   Using THP is even more important when running in virtualised environments like AWS and GCP due to nested page tables.
 </p>
 <p>
@@ -75,14 +75,14 @@ $ docker run --detach --name vespa --hostname vespa-container --volume $VESPA_VA
   </pre>
 
   <p>
-    To verify that the setting is active one should see that <em>AnonHugePages</em> is non-zero, in this case 75GB 
-    has been allocated using AnonHugePages. 
+    To verify that the setting is active one should see that <em>AnonHugePages</em> is non-zero, in this case 75GB
+    has been allocated using AnonHugePages.
     <pre>
       cat /proc/meminfo |grep AnonHuge
       AnonHugePages:  75986944 kB
     </pre>
   </p>
-  Note that the Vespa container needs to be restarted after modifying the base host OS settings to make the changes effective. 
+  Note that the Vespa container needs to be restarted after modifying the base host OS settings to make the changes effective.
   Vespa uses <em>MADV_HUGEPAGE</em> for memory allocations done by the <a href="../proton.html">content node process (proton)</a>.
 </p>
 
@@ -206,11 +206,11 @@ INFO    : config-sentinel  sentinel.sentinel.service	container: will delay start
   Example from <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA">multinode-HA</a>:
 </p>
 <pre>
-$ docker run --detach --name node0 --hostname node0.vespa_net \
-    -e VESPA_CONFIGSERVERS=node0.vespa_net,node1.vespa_net,node2.vespa_net \
+$ docker run --detach --name node0 --hostname node0.vespanet \
+    -e VESPA_CONFIGSERVERS=node0.vespanet,node1.vespanet,node2.vespanet \
     -e <span class="pre-hilite">VESPA_CONFIGSERVER_JVMARGS="-Xms32M -Xmx128M"</span>  \
     -e <span class="pre-hilite">VESPA_CONFIGPROXY_JVMARGS="-Xms32M -Xmx32M"</span> \
-    --network vespa_net \
+    --network vespanet \
     --publish 19071:19071 --publish 19100:19100 --publish 19050:19050 --publish 20092:19092 \
     vespaengine/vespa
 </pre>

--- a/en/operations/live-upgrade.html
+++ b/en/operations/live-upgrade.html
@@ -33,16 +33,15 @@ Use this procedure to upgrade without disruption to read or write traffic.
     After upgrading the config servers, the nodes of the application cannot receive config
     until they are upgraded themselves. We need to set all of them
     in standalone mode before continuing by running this command on each node:
-    <pre>
-    $ vespa-configproxy-cmd -m setmode memorycache
-    </pre>
+    <pre>$ vespa-configproxy-cmd -m setmode memorycache</pre>
     Each node will automatically reattach itself when it is upgraded.
   </li>
 
   <li id="upgrade-config-server"><strong>Upgrade config servers</strong>
     <ul><li>
-      Install the new Vespa version on the config servers and restart them one by one:
-      Restart config server. Wait until it is up again, look in vespa log for
+      Install the new Vespa version on the config servers and
+      <a href="admin-procedures.html#vespa-start-stop-restart">restart</a> them one by one.
+      Wait until it is up again, look in vespa log for
       "Changing health status code from 'initializing' to 'up'"
       or use <a href="configuration-server.html#troubleshooting">health checks</a>.
     </li><li>
@@ -54,14 +53,12 @@ Use this procedure to upgrade without disruption to read or write traffic.
   <li id="upgrade-all-other-nodes-one-by-one"><strong>Upgrade all other nodes one by one</strong>
     - for each of the other nodes in the system:
     <ul>
-      <li>Stop Vespa services on the node
-        <ul>
-          <li>Consider running <a href="../reference/vespa-cmdline-tools.html#vespa-proton-cmd">
-          prepareRestart</a> to reduce start time</li>
-        </ul>
+      <li><a href="admin-procedures.html#vespa-start-stop-restart">Stop services</a>
+        on the node.
       </li>
-      <li>Install the new Vespa version</li>
-      <li>Start Vespa services on the node</li>
+      <li>Install the new Vespa version.</li>
+      <li><a href="admin-procedures.html#vespa-start-stop-restart">Start services</a>
+        on the node.</li>
       <li>Wait until the node is fully up before doing the next node -
         metrics/interfaces to be used to evaluate if the next node can be stopped:
         <ul>

--- a/en/performance/practical-search-performance-guide.md
+++ b/en/performance/practical-search-performance-guide.md
@@ -317,7 +317,7 @@ the Vespa application — which services to run and how many nodes per service.
 The default [query profile](../query-profiles.html) can be used to override
 default query api settings for all queries.
 
-The following enables [presentation.timing](reference/query-api-reference.html#presentation.timing) and
+The following enables [presentation.timing](../reference/query-api-reference.html#presentation.timing) and
 renders `weightedset` fields as a JSON maps.
 
 <pre data-test="file" data-path="app/search/query-profiles/default.xml">
@@ -1764,7 +1764,7 @@ to a lower number than the global default.
 
 This adds a new `rank-profile` `similar-t2` using `num-threads-per-search: 2` instead
 of the global 4 setting. It's also possible to set the number of threads in the query request
-using [ranking.matching.numThreadsPerSearch](reference/query-api-reference.html#ranking.matching). 
+using [ranking.matching.numThreadsPerSearch](../reference/query-api-reference.html#ranking.matching).
 
 <pre data-test="file" data-path="app/schemas/track.sd">
 schema track {

--- a/en/reference/document-v1-api-reference.html
+++ b/en/reference/document-v1-api-reference.html
@@ -14,10 +14,11 @@ redirect_from:
 </p>
 
 <p>
-  Many of the examples uses <em>number</em> and <em>group</em> <a href="documents.html#document-ids">document id</a> 
-  modifiers. Do note that these are special cases that only work as expected for document types
-  with <a href="services-content.html#document">mode=streaming or mode=store-only</a>. Do 
-  not use group or number modifiers with regular indexed mode document types. 
+  Many of the examples uses <em>number</em> and <em>group</em>
+  <a href="../documents.html#document-ids">document id</a> modifiers.
+  Do note that these are special cases that only work as expected for document types
+  with <a href="services-content.html#document">mode=streaming or mode=store-only</a>.
+  Do not use group or number modifiers with regular indexed mode document types.
 </p>
 
 

--- a/en/reference/files-processes-and-ports.html
+++ b/en/reference/files-processes-and-ports.html
@@ -8,12 +8,9 @@ redirect_from:
 ---
 
 <p>
-This is a reference of directories used in a Vespa installation,
-processes that run on the Vespa nodes and ports used.
-It is not necessary to know the information
-in this file to operate Vespa in production as the system
-automatically manages its files and processes.
-See also <a href="logs.html">log files</a>.
+  This is a reference of directories used in a Vespa installation,
+  processes that run on the Vespa nodes and ports / environment variables used.
+  Also see <a href="logs.html">log files</a>.
 </p>
 
 
@@ -216,49 +213,8 @@ Use <a href="vespa-cmdline-tools.html#vespa-model-inspect">vespa-model-inspect</
 </tbody>
 </table>
 <p>
-  If the startup scripts are not able to set the maximum number of open files Vespa will not start.
+  Vespa will not start if the startup scripts are not able to set the maximum number of open files.
 </p>
-
-
-
-<h2 id="vespa-start-stop">Vespa start / stop</h2>
-<p>
-  Start and stop <em>all</em> services on a node:
-</p>
-<pre>
-$ $VESPA_HOME/bin/vespa-start-services
-$ $VESPA_HOME/bin/vespa-stop-services
-</pre>
-<p>Likewise, for the config server:</p>
-<pre>
-$ $VESPA_HOME/bin/vespa-start-configserver
-$ $VESPA_HOME/bin/vespa-stop-configserver
-</pre>
-<p>
-Learn more about which processes are run at
-<a href="../config-sentinel.html">Vespa startup</a>.
-</p>
-
-
-<h3 id="pre-start-check">Pre-start check</h3>
-<p>
-To run an automated node check before Vespa is started, provide a check script,
-returning 0 if <em>service vespa-services start</em> is allowed to run.
-This is useful when autostarting:
-</p>
-<pre>
-$ export VESPA_VALIDATIONSCRIPT=/tmp/foo.bar.sh
-$ cat /tmp/foo.bar.sh
-#!/bin/sh
-echo detect some problem
-exit 1
-$ $VESPA_HOME/bin/vespa-start-services
-... starting ...
-detect some problem
-validation script '/tmp/foo.bar.sh' failed
-$VESPA_HOME/bin/vespa-start-services failed: exit code 1 from command:
-$VESPA_HOME/libexec/vespa/start-vespa-base.sh
-</pre>
 
 
 
@@ -354,6 +310,12 @@ Each line  has the format <code>action variablename value</code> where the items
     <th>VESPA_CONFIGPROXY_JVMARGS</th>
     <td>JVM arguments for the config proxy -
       see <a href="../performance/container-tuning.html#config-server-and-config-proxy">tuning</a>.</td>
+  </tr>
+  <tr>
+    <th>VESPA_VALIDATIONSCRIPT</th>
+    <td>
+      Location of <a href="../operations/admin-procedures.html#pre-start-check">pre-start validation script</a>.
+    </td>
   </tr>
 </tbody>
 </table>

--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -299,9 +299,11 @@ Also have some backend specific configuration for whether documents should be se
         </p><p>
           Changing from <em>false</em> to <em>true</em> or vice versa requires a <em>global-document-change</em>
           <a href="validation-overrides.html">validation override</a>.
-          First, <a href="files-processes-and-ports.html#vespa-start-stop">stop services</a> on all content nodes.
+          First, <a href="../operations/admin-procedures.html#vespa-start-stop-restart">stop services</a>
+          on all content nodes.
           Then, deploy with the validation override.
-          Finally, <a href="files-processes-and-ports.html#vespa-start-stop">start services</a> on all content nodes.
+          Finally, <a href="../operations/admin-procedures.html#vespa-start-stop-restart">start services</a>
+          on all content nodes.
         </p><p>
           Note: <em>global</em> is only supported for <em>mode="index"</em>.
         </p>
@@ -1163,7 +1165,7 @@ Refer to <a href="../proton.html#proton-maintenance-jobs">Proton maintenance job
   The sync cost is amortized over multiple feed operations.
   The faster you feed the more operations it is amortized over.
   So with a local disk this is not known to be a performance issue.
-  However, if using NAS (Network Attached Storage) like EBS on AWS one can see significant 
+  However, if using NAS (Network Attached Storage) like EBS on AWS one can see significant
   feed performance impact. For one particular case, turning off sync-transactionlog for EBS gave a 60x improvement.
 </p>
 
@@ -1248,8 +1250,8 @@ For query timeout also see the request parameter <a href="query-api-reference.ht
 <p>
 Contained in <code><a href="#search">search</a></code>. Default 0, max 1 seconds.</p>
 </p>
-This setting controls the TTL caching for <a href="../parent-child.html">parent-child</a> imported fields. 
-See <a href="../performance/feature-tuning.html#parent-child-and-search-performance">feature tuning</a>. 
+This setting controls the TTL caching for <a href="../parent-child.html">parent-child</a> imported fields.
+See <a href="../performance/feature-tuning.html#parent-child-and-search-performance">feature tuning</a>.
 </p>
 
 
@@ -1697,7 +1699,7 @@ Tune the query dispatch behavior - child elements:
             <td>round-robins between the groups, putting uniform load on the groups.</td>
           </tr><tr>
             <th>adaptive</th>
-            <td>measures latency, preferring lower latency groups, handles soft-failing/slow nodes 
+            <td>measures latency, preferring lower latency groups, handles soft-failing/slow nodes
               in a group better than round-robin</td>
           </tr>
         </table>

--- a/en/reference/vespa-cmdline-tools.html
+++ b/en/reference/vespa-cmdline-tools.html
@@ -1864,13 +1864,14 @@ distributor @ myhost3.mydomain.com : content
 
 <h2 id="vespa-proton-cmd">vespa-proton-cmd</h2>
 <p>
-Use <em>vespa-proton-cmd</em> to send commands to a search node.
-</p><p>
-The <em>hostspec</em> argument is one of (port|spec|--local|--id=name)
-</p><p>
-Synopsis: <code>vespa-proton-cmd HOSTSPEC COMMAND [ARGS]</code>
-</p><p>
-Use <a href="#vespa-model-inspect">vespa-model-inspect</a> to locate the search node ADMIN RPC port:
+  Use <em>vespa-proton-cmd</em> to send commands to <a href="../proton.html">proton</a>.
+</p>
+<p>
+  Synopsis: <code>vespa-proton-cmd HOSTSPEC COMMAND [ARGS]</code>
+</p>
+<p>
+  The <em>hostspec</em> argument is one of <code>port|spec|--local|--id=name</code>.
+  Use <a href="#vespa-model-inspect">vespa-model-inspect</a> to locate the search node ADMIN RPC port:
 </p>
 <pre>
 $ vespa-model-inspect service searchnode
@@ -1888,8 +1889,8 @@ $ vespa-proton-cmd 19108 triggerFlush
   OK: flush trigger enabled
 </pre>
 <p>
-Unless the <strong>-h</strong> or <strong>--help</strong> option is used,
-one of these commands must be present:
+  Unless the <strong>-h</strong> or <strong>--help</strong> option is used,
+  one of these commands must be present:
 </p>
 <table class="table">
   <thead>
@@ -1902,29 +1903,29 @@ one of these commands must be present:
     <tr>
       <th>die</th>
       <td>
-        Exit the proton application without cleanup
+        Exit proton without cleanup.
       </td>
     </tr><tr>
       <th>getProtonStatus</th>
       <td>
-        Get the current state of proton and its components
+        Get the current proton state and its components.
       </td>
     </tr><tr>
       <th>getState</th>
       <td>
-        Get the current state of the search node
+        Get the current proton state.
       </td>
     </tr><tr>
       <th>triggerFlush</th>
       <td>
-        Tell the search node to trigger flush as soon as possible for all document types
+        Trigger <a href="../proton.html#proton-maintenance-jobs">flush</a> as soon as possible for all document types.
       </td>
     </tr><tr>
       <th>prepareRestart</th>
       <td>
-        Tell the search node to prepare for a restart by flushing a set of components to disk
-        such that the time it takes to flush these components plus the time it takes to replay the
-        <a href="../proton.html#transaction-log">transaction log</a> after restart is as low as possible
+        Estimates the cost of <a href="../proton.html#transaction-log">transaction log</a> replay,
+        and flushes data structures if that will speed up a subsequent start.
+        If this is not called before stopping proton, there is no estimation and no flush.
       </td>
     </tr>
   </tbody>
@@ -2155,8 +2156,13 @@ There are 2 hop(s):
   Use <em>vespa-sentinel-cmd</em> to list, start and stop services -
   refer to <a href="../config-sentinel.html">config sentinel</a> for examples.
   It can also check for connectivity between nodes.
-</p><p>
-Synopsis: <code>vespa-sentinel-cmd [-h] list|start &lt;service&gt;|restart &lt;service&gt;|stop &lt;service&gt;|connectivity</code>
+</p>
+{% include important.html content="
+See <a href='../operations/admin-procedures.html#vespa-start-stop-restart'>start / stop / restart</a>
+for how to stop all services on a node, optimizing for restart time -
+use this for tasks like software upgrade." %}
+<p>
+  Synopsis: <code>vespa-sentinel-cmd [-h] list|start &lt;service&gt;|restart &lt;service&gt;|stop &lt;service&gt;|connectivity</code>
 </p>
 <table class="table">
   <thead>
@@ -2250,9 +2256,9 @@ Synopsis: <code>vespa-sentinel-cmd [-h] list|start &lt;service&gt;|restart &lt;s
 <pre>
 $ vespa-sentinel-cmd connectivity
 vespa-sentinel-cmd 'connectivity' OK.
-node0.vespa_net -> ok
-node1.vespa_net -> ok
-node2.vespa_net -> ok
+node0.vespanet -> ok
+node1.vespanet -> ok
+node2.vespanet -> ok
 </pre>
       </td>
     </tr>
@@ -2357,6 +2363,26 @@ $ vespa-set-node-state -i 0 maintenance "Set to maintenance for software upgrade
 
 
 <!--h2 id="vespa-slobrok-cmd">vespa-slobrok-cmd</h2-->
+
+
+
+<h2 id="vespa-start-configserver">vespa-start-configserver</h2>
+<p>
+  Start a config server on a node, <a href="../operations/admin-procedures.html#vespa-start-stop-restart">details</a>.
+</p>
+<p>
+  Synopsis: <code>vespa-start-configserver</code>
+</p>
+
+
+
+<h2 id="vespa-start-services">vespa-start-services</h2>
+<p>
+  Start all services on a node, <a href="../operations/admin-procedures.html#vespa-start-stop-restart">details</a>.
+</p>
+<p>
+  Synopsis: <code>vespa-start-services</code>
+</p>
 
 
 
@@ -2511,6 +2537,28 @@ Synopsis: <code>vespa-status-filedistribution [--application &lt;applicationName
     </tr>
   </tbody>
 </table>
+
+
+
+<h2 id="vespa-stop-configserver">vespa-stop-configserver</h2>
+<p>
+  Stop a config server on a node, <a href="../operations/admin-procedures.html#vespa-start-stop-restart">details</a>.
+</p>
+<p>
+  Synopsis: <code>vespa-stop-configserver</code>
+</p>
+
+
+
+<h2 id="vespa-stop-services">vespa-stop-services</h2>
+<p>
+  Stop all services on a node, <a href="../operations/admin-procedures.html#vespa-start-stop-restart">details</a>.
+  Running <em>vespa-stop-services</em> on a content node will call
+  <a href="#vespa-proton-cmd">prepareRestart</a> to optimize restart time.
+</p>
+<p>
+  Synopsis: <code>vespa-stop-services</code>
+</p>
 
 
 


### PR DESCRIPTION
- document the stop/start commands in the reference, and link to these
- generally, make it easier to use the correct vespa-stop-services command for node restart
