### PR TITLE
Kkraune/trace

### DIFF
--- a/en/query-api.html
+++ b/en/query-api.html
@@ -344,7 +344,7 @@ and has been converted from the <em>flat</em> dot notation to a <em>nested</em> 
   </li>
 </ul>
 <p>Example:</p>
-<pre>
+<pre>{% highlight json %}
 {
     "yql" : "select * from sources * where default contains \"coldplay\"",
     "offset"  : 5,
@@ -359,7 +359,7 @@ and has been converted from the <em>flat</em> dot notation to a <em>nested</em> 
         "format"  : "json"
     }
 }
-</pre>
+{% endhighlight %}</pre>
 <p>
   Note: Security filters can block GET and POST requests differently.
   This can block POSTed queries.
@@ -372,17 +372,17 @@ and has been converted from the <em>flat</em> dot notation to a <em>nested</em> 
   Configure the <a href="reference/services-http.html#server">http server</a> -
   e.g. set <em>requestHeaderSize</em> to configure URL length (including headers):
 </p>
-<pre>
-&lt;container version="1.0"&gt;
-    &lt;http&gt;
-        &lt;server port="8080" id="myserver"&gt;
-            &lt;config name="jdisc.http.connector"&gt;
-                &lt;requestHeaderSize&gt;32768&lt;/requestHeaderSize&gt;
-            &lt;/config&gt;
-        &lt;/server&gt;
-    &lt;/http&gt;
-&lt;/container&gt;
-</pre>
+<pre>{% highlight xml %}
+<container version="1.0">
+    <http>
+        <server port="8080" id="myserver">
+            <config name="jdisc.http.connector">
+                <requestHeaderSize>32768</requestHeaderSize>
+            </config>
+        </server>
+    </http>
+</container>
+{% endhighlight %}</pre>
 <p>
   HTTP keepalive is supported.
 </p><p>

--- a/en/reference/default-result-format.html
+++ b/en/reference/default-result-format.html
@@ -346,13 +346,16 @@ redirect_from:
     <td>timing</td>
     <td>no</td>
     <td>Double</td>
-    <td>ToDo: FIXME</td>
+    <td></td><!-- ToDo: FIXME -->
   </tr>
   <tr>
     <td colspan="5"></td>
   </tr>
   <tr>
-    <td colspan="5"><h2 id="trace">trace</h2></td>
+    <td colspan="5"><h2 id="trace">trace</h2>
+      {% include note.html content="The tracing elements below is a subset of all elements.
+      Refer to the <a href='../performance/practical-search-performance-guide.html#advanced-query-tracing'>
+      search performance guide</a> for examples." %}</td>
   </tr>
   <tr>
     <th>trace</th>
@@ -370,17 +373,80 @@ redirect_from:
   </tr>
   <tr>
     <th>timestamp</th>
-    <td>trace</td>
+    <td>children</td>
     <td>no</td>
     <td>Long</td>
     <td>Number of milliseconds since the start of query execution this node was added to the trace.</td>
   </tr>
   <tr>
     <th>message</th>
-    <td>trace</td>
+    <td>children</td>
     <td>no</td>
     <td>String</td>
     <td>Descriptive text regarding this step of query execution.</td>
+  </tr>
+  <tr>
+    <th>message</th>
+    <td>children</td>
+    <td>no</td>
+    <td>Array of objects</td>
+    <td></td>
+  </tr>
+  <tr>
+    <th>start_time</th>
+    <td>message</td>
+    <td>no</td>
+    <td>String</td>
+    <td>Timestamp, e.g. 2022-07-27 09:51:21.938 UTC</td><!-- ToDo: why not an ISO 8601 string -->
+  </tr>
+  <tr>
+    <th>traces</th>
+    <td>message or threads</td>
+    <td>no</td>
+    <td>Array of traces or objects</td>
+    <td></td>
+  </tr>
+  <tr>
+    <th>distribution-key</th>
+    <td>message</td>
+    <td>no</td>
+    <td>Integer</td>
+    <td>The <a href="services-content.html#node">distribution key</a> of the content node creating this span.</td>
+  </tr>
+  <tr>
+    <th>duration_ms</th>
+    <td>message</td>
+    <td>no</td>
+    <td>float</td>
+    <td>duration of span</td>
+  </tr>
+  <tr>
+    <th>timestamp_ms</th>
+    <td>traces</td>
+    <td>no</td>
+    <td>float</td>
+    <td>time since start of parent, see <code>start_time</code>.</td>
+  </tr>
+  <tr>
+    <th>event</th>
+    <td>traces</td>
+    <td>no</td>
+    <td>String</td>
+    <td>Description of span</td>
+  </tr>
+  <tr>
+    <th>tag</th>
+    <td>traces</td>
+    <td>no</td>
+    <td>String</td>
+    <td>Name of span</td>
+  </tr>
+  <tr>
+    <th>threads</th>
+    <td>traces</td>
+    <td>no</td>
+    <td>Array of objects</td>
+    <td>Array of object that again has traces elements.</td>
   </tr>
   </tbody>
 </table>

--- a/en/reference/default-result-format.html
+++ b/en/reference/default-result-format.html
@@ -9,10 +9,11 @@ redirect_from:
   The default JSON result format is used when
   <code><a href="../reference/query-api-reference.html#presentation.format">presentation.format</a></code>
   is unset or set to <code>json</code>.
-  Results are rendered with one or two objects:
+  Results are rendered with one or more objects:
 </p>
 <ul>
   <li><code>root</code>: mandatory object with the tree of returned data</li>
+  <li><code>timing</code>: optional object with query timing information</li>
   <li><code>trace</code>: optional object for metadata about query execution</li>
 </ul>
 <p>
@@ -35,6 +36,9 @@ redirect_from:
   </thead>
   <tbody>
   <tr>
+    <td colspan="5"><h2 id="root">root</h2></td>
+  </tr>
+  <tr>
     <th>root</th>
     <td></td>
     <td>yes</td>
@@ -54,6 +58,30 @@ redirect_from:
     <td>no</td>
     <td>Map of string to object</td>
     <td></td>
+  </tr>
+  <tr>
+    <th>summaryfeatures</th>
+    <td>fields</td>
+    <td>no</td>
+    <td>String</td>
+    <td>
+      <p id="summaryfeatures">
+        Refer to <a href="schema-reference.html#summary-features">summary-features</a> and
+        <a href="../getting-started-ranking.html#observing-values-used-in-ranking">observing values used in ranking</a>.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>matchfeatures</th>
+    <td>fields</td>
+    <td>no</td>
+    <td>String</td>
+    <td>
+      <p id="matchfeatures">
+        Refer to <a href="schema-reference.html#match-features">match-features</a> and
+        <a href="../nearest-neighbor-search-guide.html#strict-filters-and-distant-neighbors">example use</a>.
+      </p>
+    </td>
   </tr>
   <tr>
     <th>totalCount</th>
@@ -286,32 +314,10 @@ redirect_from:
     <td>Used in grouping for value groups, the argument for the grouping data which is in the fields.</td>
   </tr>
   <tr>
-    <th>trace</th>
-    <td></td>
-    <td>no</td>
-    <td>Map of string to object</td>
-    <td>Metadata about query execution.</td>
+    <td colspan="5"></td>
   </tr>
   <tr>
-    <th>children</th>
-    <td>trace</td>
-    <td>no</td>
-    <td>Array of object</td>
-    <td>Array of maps with exactly the same structure as <code>trace</code> itself.</td>
-  </tr>
-  <tr>
-    <th>timestamp</th>
-    <td>trace</td>
-    <td>no</td>
-    <td>Long</td>
-    <td>Number of milliseconds since the start of query execution this node was added to the trace.</td>
-  </tr>
-  <tr>
-    <th>message</th>
-    <td>trace</td>
-    <td>no</td>
-    <td>String</td>
-    <td>Descriptive text regarding this step of query execution.</td>
+    <td colspan="5"><h2 id="timing">timing</h2></td>
   </tr>
   <tr>
     <th>timing</th>
@@ -343,28 +349,38 @@ redirect_from:
     <td>ToDo: FIXME</td>
   </tr>
   <tr>
-    <th>summaryfeatures</th>
-    <td>fields</td>
-    <td>no</td>
-    <td>String</td>
-    <td>
-      <p id="summaryfeatures">
-        Refer to <a href="schema-reference.html#summary-features">summary-features</a> and
-        <a href="../getting-started-ranking.html#observing-values-used-in-ranking">observing values used in ranking</a>
-      </p>
-    </td>
+    <td colspan="5"></td>
   </tr>
   <tr>
-    <th>matchfeatures</th>
-    <td>fields</td>
+    <td colspan="5"><h2 id="trace">trace</h2></td>
+  </tr>
+  <tr>
+    <th>trace</th>
+    <td></td>
+    <td>no</td>
+    <td>Map of string to object</td>
+    <td>Metadata about query execution.</td>
+  </tr>
+  <tr>
+    <th>children</th>
+    <td>trace</td>
+    <td>no</td>
+    <td>Array of object</td>
+    <td>Array of maps with exactly the same structure as <code>trace</code> itself.</td>
+  </tr>
+  <tr>
+    <th>timestamp</th>
+    <td>trace</td>
+    <td>no</td>
+    <td>Long</td>
+    <td>Number of milliseconds since the start of query execution this node was added to the trace.</td>
+  </tr>
+  <tr>
+    <th>message</th>
+    <td>trace</td>
     <td>no</td>
     <td>String</td>
-    <td>
-      <p id="matchfeatures">
-        Refer to <a href="schema-reference.html#match-features">match-features</a> and
-        <a href="../nearest-neighbor-search-guide.html#strict-filters-and-distant-neighbors">example use</a>.
-      </p>
-    </td>
+    <td>Descriptive text regarding this step of query execution.</td>
   </tr>
   </tbody>
 </table>

--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -391,7 +391,7 @@ The query is always encoded as UTF-8, independently of how the result will be en
 <p>
 Sets a filter to be combined with the <a href="#model.querystring">model.queryString</a>.
 Typical use of a filter is to add machine generated or preferences based filter terms
-to the user query. Terms which are passed in the filter are not <a href="#presentation.bolding">bolded</a>. 
+to the user query. Terms which are passed in the filter are not <a href="#presentation.bolding">bolded</a>.
 The filter is parsed the same way as a query of type <code>any</code>,
 the full syntax is available.
 The positive terms (preceded by +) and phrases act as AND filters,
@@ -886,8 +886,8 @@ The id of the page template to use for this result. This should be used with the
 <tr><td>Default</td><td>false</td></tr>
 </table>
 <p>
-Whether a result renderer should try to add optional timing information
-to the rendered page.
+  Whether a result renderer should try to add optional timing information to the rendered page -
+  see the <a href="default-result-format.html#timing">result reference</a>.
 </p>
 
 <h3 id="presentation.format.tensors">presentation.format.tensors</h3>


### PR DESCRIPTION
- the gist of this is splitting and reordering the table of result elements, to more easily separate query results, timing and trace info
- then add more to the tracing section

There is more to be done on tracing, but the doc is a little less wrong now and safe to merge. Added a few links for better navigation. FYI @jobergum @Ethnas 