### PR TITLE
Define parametrized pre-reqs

### DIFF
--- a/_includes/pre-req.html
+++ b/_includes/pre-req.html
@@ -6,6 +6,8 @@
     <li>Operating system: Linux, macOS or Windows 10 Pro</li>
     <li>Architecture: x86_64.
       <strong>M1 users: see <a href="https://blog.vespa.ai/preview-of-vespa-on-arm64/">vespa-on-arm64</a></strong></li>
-    <li>Memory: Minimum {{ include.memory }} dedicated to Docker (the default is 2 Gb on macOS)</li>
+    <li>Memory: Minimum {{ include.memory }} dedicated to Docker (the default is 2 Gb on macOS).
+      <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA#memory-usage">
+        Minimize memory usage</a>.</li>
   </ul>
 </div>

--- a/_includes/pre-req.html
+++ b/_includes/pre-req.html
@@ -1,0 +1,11 @@
+<div markdown="span" class="vespa-notification vespa-notification-prereqs" role="alert">
+  <p><strong>Prerequisites:</strong></p>
+  <ul>
+    <li>Docker: <a href="https://docs.docker.com/engine/install/">Docker Desktop for Mac/Windows</a>,
+      or Docker on Linux</li><!-- ToDo: something on podman / runc ? -->
+    <li>Operating system: Linux, macOS or Windows 10 Pro</li>
+    <li>Architecture: x86_64.
+      <strong>M1 users: see <a href="https://blog.vespa.ai/preview-of-vespa-on-arm64/">vespa-on-arm64</a></strong></li>
+    <li>Memory: Minimum {{ include.memory }} dedicated to Docker (the default is 2 Gb on macOS)</li>
+  </ul>
+</div>

--- a/css/style.scss
+++ b/css/style.scss
@@ -541,6 +541,12 @@ div.vespa-notification > a {
     border-color: #faebcc;
 }
 
+.vespa-notification-prereqs {
+    color: #8a6d3b;
+    background-color: #fcf8e3;
+    border-color: #faebcc;
+}
+
 .vespa-notification-warning {
     color: #a94442;
     background-color: #f2dede;

--- a/en/vespa-quick-start.html
+++ b/en/vespa-quick-start.html
@@ -11,17 +11,11 @@ it deploys an application, feeds some data and issues queries.
 See <a href="getting-started.html">Getting Started</a> for troubleshooting, next steps and other guides.
 </p>
 
-<p><strong>Prerequisites</strong>:</p>
-<ul>
-  <li><a href="https://docs.docker.com/engine/install/">Docker Desktop for Mac/Windows</a>, or Docker on Linux</li>
-  <li>Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)</li>
-  <li>Architecture: x86_64</li>
-  <li><b>Minimum 6GB</b> memory dedicated to Docker (the default is 2GB on macOS)</li>
-</ul>
+{% include pre-req.html memory="4 Gb" %}
 
 <p>
-This guide is tested with Docker for Mac, Community Edition-18.06.1-ce-mac73 (26764) and
-<em>vespaengine/vespa</em> Docker image built 2018-10-01.
+  This guide is tested with <em>docker desktop, 4.11.0 (83626)</em> on MacOS and
+  <em>vespaengine/vespa:8.28.12</em> Docker image.
 </p>
 
 


### PR DESCRIPTION
- All guides will have the same set of pre-requisites, possibly with different memory settings
- This gives a common look and feel and is easy to update in one place
- The quickstart runs well on 4G (was 6G)

FYI @jobergum 

ref https://github.com/vespa-engine/vespa/issues/20788

![Skjermbilde 2022-08-10 kl  15 57 50](https://user-images.githubusercontent.com/8989061/183919905-37644da8-6e6d-4fda-ae1c-9198ef1745d6.png)

