### PR TITLE
Mention the safe startup option

### DIFF
--- a/en/config-sentinel.html
+++ b/en/config-sentinel.html
@@ -126,33 +126,26 @@ slobrok state=RUNNING mode=AUTO pid=28000 exitstatus=0 id="admin/slobrok.0"
 
 <h2 id="cluster-startup">Cluster startup</h2>
 <p>
-  One can configure Vespa to do a <em>Safe Cluster Startup</em>,
-  setting a minimum node available ratio.
-  Use this to control the Vespa cluster start sequence.
-  The config sentinel will not start services on a node unless it has connectivity to a minimum other nodes.
-</p>
-<p>
+  The config sentinel will not start services on a node unless it has connectivity to a minimum of other nodes,
+  default 50%.
   Find an example of this feature in the
   <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA#start-the-admin-server">
   multinode-HA</a> example application.
-</p>
-<p>
-  The safe mode is disabled by default,
-  enable it by setting configuration on top level in <em>services.xml</em> (since Vespa-7.415):
+  Example configuration:
 </p>
 <pre>{% highlight xml %}
 <services>
     <config name="cloud.config.sentinel">
         <connectivity>
-            <minOkPercent>40</minOkPercent>
+            <minOkPercent>20</minOkPercent>
             <maxBadCount>1</maxBadCount>
         </connectivity>
     </config>
 {% endhighlight %}</pre>
 <p>
-  Example: <code>minOkPercent 40</code> means that services will be started only if
-  more than or equal to 40% of nodes are up.
-  If there are 5 nodes (container + content nodes) in the application,
+  Example: <code>minOkPercent 10</code> means that services will be started only if
+  more than or equal to 10% of nodes are up.
+  If there are 11 nodes in the application,
   the first node started will not start its services -
   when the second node is started, services will be started on both.
 </p>

--- a/en/config-sentinel.html
+++ b/en/config-sentinel.html
@@ -132,6 +132,11 @@ slobrok state=RUNNING mode=AUTO pid=28000 exitstatus=0 id="admin/slobrok.0"
   The config sentinel will not start services on a node unless it has connectivity to a minimum other nodes.
 </p>
 <p>
+  Find an example of this feature in the
+  <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA#start-the-admin-server">
+  multinode-HA</a> example application.
+</p>
+<p>
   The safe mode is disabled by default,
   enable it by setting configuration on top level in <em>services.xml</em> (since Vespa-7.415):
 </p>

--- a/en/reference/vespa-cmdline-tools.html
+++ b/en/reference/vespa-cmdline-tools.html
@@ -2397,6 +2397,10 @@ $ vespa-set-node-state -i 0 maintenance "Set to maintenance for software upgrade
   It is also useful to read up on the <a href="../operations/configuration-server.html#start-sequence">
   start sequence</a> and make sure the config server is running - Vespa will not start with a running config server.
 </p>
+<p>
+  Vespa has a <em>Safe Cluster Startup</em> mode to only start vespa services after X% of nodes are running -
+  see <a href="../config-sentinel.html#cluster-startup">cluster startup</a>.
+</p>
 
 
 


### PR DESCRIPTION
@arnej27959 : the docs says "The safe mode is disabled by default" - but it seems is is default on for self-hosted Vespa, ref https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA#start-the-admin-server ?