### PR TITLE
Add missing full stop

### DIFF
--- a/en/overview.html
+++ b/en/overview.html
@@ -71,7 +71,7 @@ the content schemas, any machine-learned models and Java components,
 and other configuration or data files needed by various features.
 Application developers create a running application from their application package by
 <em>deploying</em> it to any node in the config cluster.
-Changes to a running application is made in the same way: By changing the application package and deploying again
+Changes to a running application is made in the same way: By changing the application package and deploying again.
 Once Vespa is installed and started on a node,
 it is managed by the config system such that the entire system can be treated as a single unit,
 and application owners do not need to perform any administration tasks locally on the nodes running the application.


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

I noticed a missing full stop in [`en/overview.html`](https://docs.vespa.ai/en/overview.html#:~:text=deploying%20again%20Once%20Vespa%20is) when reading, see screenshot 
<img width="366" alt="Screenshot 2022-08-23 at 10 04 57" src="https://user-images.githubusercontent.com/25904359/186106374-164cc076-ca84-4813-8e90-cc10a58e67b0.png">


Please let me know if I missed something that is required in order to submit a pr, thanks!