### PR TITLE
Correct the weight in the explanation in news 3 tutorial

### DIFF
--- a/en/tutorials/news-3-searching.md
+++ b/en/tutorials/news-3-searching.md
@@ -513,14 +513,14 @@ schema news {
   article with a low number of impressions can score high on such a value,
   even though uncertainty is high.
 
-- `expression: nativeRank + 100 * popularity`
+- `expression: nativeRank + 10 * popularity`
 
   This expression is used to rank documents.
   Here, the default ranking expression — the `nativeRank` of the `default` fieldset —
   is included to make the query relevant,
   while the second term calls the `popularity` function.
   The weighted sum of these two terms is the final relevance for each document.
-  Note that the weight here, `100`, is set by observation.
+  Note that the weight here, `10`, is set by observation.
   A better approach would be to learn such values using machine learning.
 
 More information can be found in the [schema reference](../reference/schema-reference.html#rank-profile).


### PR DESCRIPTION
In the last part of the [news 3 tutorial](https://docs.vespa.ai/en/tutorials/news-3-searching.html), the weight in the explanation is not the same as in the code above (100 in the explanation and 10 in the code). See screenshot. The explanation is therefore changed to 10.

<img width="1022" alt="Screenshot 2022-08-24 at 10 28 18" src="https://user-images.githubusercontent.com/25904359/186369881-891aee63-12f7-40ce-b6b9-48af284f35df.png">

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
