### PR TITLE
Kkraune/querybuilder links

### DIFF
--- a/en/query-api.html
+++ b/en/query-api.html
@@ -350,51 +350,35 @@ $ curl http://localhost:8080/search/?yql=select+%2A+from+sources+%2A+where+defau
 
 <h3 id="using-post">Using POST</h3>
 <p>
-The general form of POST data is:
+  The format is based on the <a href="reference/query-api-reference.html">Query API reference</a>,
+  and has been converted from the <em>flat</em> dot notation to a <em>nested</em> JSON-structure.
+  The request-method must be POST and the <em>Content-Type</em> must be <em>"application/json"</em>, e.g.:
 </p>
 <pre>
-{
-    param1 : value1,
-    param2 : value2,
-    ...
-}
+$ curl -X POST -H "Content-Type: application/json" --data '
+  {
+      "yql": "select * from sources * where true",
+      "offset": 5,
+      "ranking": {
+          "matchPhase": {
+              "ascending": true,
+              "maxHits": 15
+          }
+      },
+      "presentation" : {
+          "bolding": false,
+          "format": "json"
+      }
+  }' \
+  http://localhost:8080/search/
 </pre>
-<p>
-The format is based on the <a href="reference/query-api-reference.html">Query API reference</a>,
-and has been converted from the <em>flat</em> dot notation to a <em>nested</em> JSON-structure.
-</p>
-<ul>
-  <li>
-    The request-method must be POST and the <em>Content-Type</em> must be <em>"application/json"</em>.
-  </li><li>
-    Also try the GUI for building queries at
-    <a href="http://localhost:8080/querybuilder/" data-proofer-ignore>localhost:8080/querybuilder/</a>
-    (with Vespa running).
-    This helps build queries, with e.g. autocompletion of YQL, pasting of already built queries and
-    conversion of JSON- to URL-queries.
-  </li>
-</ul>
-<p>Example:</p>
-<pre>{% highlight json %}
-{
-    "yql" : "select * from sources * where default contains \"coldplay\"",
-    "offset"  : 5,
-    "ranking" : {
-        "matchPhase" : {
-            "ascending" : true,
-            "maxHits"   : 15
-        },
-    },
-    "presentation" : {
-        "bolding" : false,
-        "format"  : "json"
-    }
-}
-{% endhighlight %}</pre>
-<p>
-  Note: Security filters can block GET and POST requests differently.
-  This can block POSTed queries.
-</p>
+
+{% include note.html content="Try the
+<a href='https://github.com/vespa-engine/vespa/tree/master/client/js/app#query-builder'>Query Builder</a>
+application!" %}
+
+{% include important.html content="Security filters can block GET and POST requests differently.
+This can block POSTed queries." %}
 
 
 <h3 id="jetty">Jetty</h3>

--- a/en/tutorials/news-2-basic-feeding-and-query.md
+++ b/en/tutorials/news-2-basic-feeding-and-query.md
@@ -372,9 +372,9 @@ $ curl -s -H "Content-Type: application/json" \
 </pre>
 </div>
 
-{% include note.html content="You can use the
+{% include note.html content="Try the
 <a href='https://github.com/vespa-engine/vespa/tree/master/client/js/app#query-builder'>Query Builder</a>
-which can help you build queries." %}
+application!" %}
 
 Looking at the output, please note:
 

--- a/en/vespa-quick-start-java.html
+++ b/en/vespa-quick-start-java.html
@@ -153,8 +153,9 @@ $ vespa query "select * from music where true" \
     {% endraw %}
     </div>
     This uses the <a href="query-api.html">Query API</a>.
-    You can also view query results in a browser at
-    <a href="http://localhost:8080/querybuilder/" data-proofer-ignore>localhost:8080/querybuilder/</a>.
+    {% include note.html content="Try the
+    <a href='https://github.com/vespa-engine/vespa/tree/master/client/js/app#query-builder'>Query Builder</a>
+    application!" %}
   </li>
 
   <li>

--- a/en/vespa-quick-start-kubernetes.html
+++ b/en/vespa-quick-start-kubernetes.html
@@ -234,10 +234,10 @@ $ curl "http://localhost:8080/search/?ranking=rank_albums&amp;yql=select%20%2A%2
 </pre>
     </div>
     <p>
-      You can also view query results in a browser with the query builder UI at
-      <a href="http://localhost:8080/querybuilder/" data-proofer-ignore>localhost:8080/querybuilder/</a>.
-      The query builder has guided queries and YQL autocompletion.
       Read more in the <a href="query-api.html">Query API</a>.
+      {% include note.html content="Try the
+      <a href='https://github.com/vespa-engine/vespa/tree/master/client/js/app#query-builder'>Query Builder</a>
+      application!" %}
     </p>
   </li>
 

--- a/en/vespa-quick-start-vagrant.html
+++ b/en/vespa-quick-start-vagrant.html
@@ -102,12 +102,10 @@ $ curl -s -H "Content-Type:application/json" --data-binary @/vespa-sample-apps/a
 <pre>
 $ curl "http://localhost:8080/search/?ranking=rank_albums&amp;yql=select%20%2A%20from%20sources%20%2A%20where%20sddocname%20contains%20%22music%22&amp;input.query(user_profile)=%7B%7Bcat%3Apop%7D%3A0.8%2C%7Bcat%3Arock%7D%3A0.2%2C%7Bcat%3Ajazz%7D%3A0.1%7D"
 </pre>
-    <p>
-    View query results in a browser with the query builder UI at
-    <a href="http://localhost:8080/querybuilder/" data-proofer-ignore>localhost:8080/querybuilder/</a>.
-    The query builder has guided queries and YQL autocompletion.
     Read more in the <a href="query-api.html">Query API</a>.
-</p>
+    {% include note.html content="Try the
+    <a href='https://github.com/vespa-engine/vespa/tree/master/client/js/app#query-builder'>Query Builder</a>
+    application!" %}
 </li>
 
 <li>

--- a/en/vespa-quick-start.html
+++ b/en/vespa-quick-start.html
@@ -142,8 +142,9 @@ $ vespa query "select * from music where true" \
 {% endraw %}</pre>
   </div>
 This uses the <a href="query-api.html">Query API</a>.
-You can also view query results in a browser at
-<a href="http://localhost:8080/querybuilder/" data-proofer-ignore>localhost:8080/querybuilder/</a>.
+  {% include note.html content="Try the
+  <a href='https://github.com/vespa-engine/vespa/tree/master/client/js/app#query-builder'>Query Builder</a>
+  application!" %}
 </li>
 
 <li>


### PR DESCRIPTION
- bonus: Query POST example that actually works.
- we can use the multiline POST examples wherever it is not natural to use vespa cli, instead of unreadable GET request