### PR TITLE
Kkraune/metrics reference

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -280,8 +280,8 @@ docs:
     documents:
       - page: Vespa Command-line Tools
         url: /en/reference/vespa-cmdline-tools.html
-      - page: Metrics and Health API reference
-        url: /en/reference/metrics.html
+      - page: Metrics
+        url: /en/operations/metrics.html
       - page: Log Files
         url: /en/reference/logs.html
       - page: Files, Processes, Ports, Environment

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -379,6 +379,10 @@ docs:
         url: /en/reference/cluster-v2.html
       - page: /metrics/v1 API Reference
         url: /en/reference/metrics-v1.html
+      - page: /metrics/v2 API Reference
+        url: /en/reference/metrics-v2.html
+      - page: /prometheus/v1 API Reference
+        url: /en/reference/prometheus-v1.html
 
   - title: Ranking and ML models reference
     documents:

--- a/en/api.html
+++ b/en/api.html
@@ -76,7 +76,7 @@ redirect_from:
 
 <h2 id="status">Status and state</h2>
 <ul>
-  <li><a href="reference/metrics.html">Health and Metric APIs</a></li>
+  <li><a href="operations/metrics.html">Health and Metric APIs</a></li>
   <li><a href="reference/cluster-v2.html">/cluster/v2 API</a></li>
 </ul>
 

--- a/en/document-summaries.html
+++ b/en/document-summaries.html
@@ -123,7 +123,7 @@ schema music {
 </p>
 <ul>
   <li>The document summary latency on the content node,
-    tracked by <a href="reference/metrics.html">content_proton_search_protocol_docsum_latency_average</a>.</li>
+    tracked by <a href="operations/metrics.html">content_proton_search_protocol_docsum_latency_average</a>.</li>
   <li>Getting data across from content nodes to containers.</li>
   <li>Deserialization from internal binary formats (potentially) to Java objects
     if touched in a <a href="searcher-development.html">Searcher</a>,

--- a/en/documents.html
+++ b/en/documents.html
@@ -259,7 +259,7 @@ field timestamp type long {
     unless preempted by higher priority operations.
     If the cluster is too heavily loaded by client feed operations, there's a risk of starving
     GC from running. To verify that garbage collection is not starved, check the
-    <code><a href="reference/metrics.html"> vds.idealstate.max_observed_time_since_last_gc_sec.average</a></code>
+    <code><a href="operations/metrics.html"> vds.idealstate.max_observed_time_since_last_gc_sec.average</a></code>
     distributor metric.
     If it significantly exceeds <code>garbage-collection-interval</code> it is an indication that GC is starved.
   </li>

--- a/en/operations/feed-block.html
+++ b/en/operations/feed-block.html
@@ -42,7 +42,7 @@ As most Vespa applications are set up on homogeneous nodes, changing node capaci
 and more data copy than just adding more nodes of the same kind.
 Copying data will in itself stress nodes, adding one node is normally the smallest and safest change."%}
 <p>
-  These <a href="../reference/metrics.html">metrics</a> are used to monitor resource usage and whether feeding is blocked:
+  These <a href="metrics.html">metrics</a> are used to monitor resource usage and whether feeding is blocked:
 </p>
 <table class="table">
   <tr>
@@ -58,7 +58,6 @@ Copying data will in itself stress nodes, adding one node is normally the smalle
     <th>content.proton.resource_usage.memory</th>
     <td>A number between 0 and 1, indicating how much memory (of total available) is used on the content node.
     Transient memory used by <a href="../proton.html#memory-index-flush">memory indexes</a> is not included.</td>
-    </td>
   </tr>
 </table>
 <p>

--- a/en/operations/metrics.html
+++ b/en/operations/metrics.html
@@ -1,8 +1,9 @@
 ---
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "Metrics and Health API reference"
+title: "Metrics"
 redirect_from:
 - /documentation/reference/metrics.html
+- /en/reference/metrics.html
 ---
 
 
@@ -21,10 +22,10 @@ redirect_from:
   The aggregation metrics APIs will all return metrics from the
   <a href="https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv">default</a> metric set.
   While this should cover the most basic operational Vespa metrics, the set of metrics returned
-  can be customized through the <em><a href="services-admin.html#metrics">metrics</a></em> section in
-  <em><a href="services.html">services.xml</a></em>. You can control the metric set by either including a pre-defined
-  <em><a href="services-admin.html#metric-set">metric-set</a></em> or configure a specific
-  <em><a href="services-admin.html#metric">metric</a></em>. The latter way is also how you include any
+  can be customized through the <em><a href="../reference/services-admin.html#metrics">metrics</a></em> section in
+  <em><a href="../reference/services.html">services.xml</a></em>. You can control the metric set by either including a pre-defined
+  <em><a href="../reference/services-admin.html#metric-set">metric-set</a></em> or configure a specific
+  <em><a href="../reference/services-admin.html#metric">metric</a></em>. The latter way is also how you include any
   <a href="#metrics-from-custom-components">metrics from custom components</a>.
 </p>
 <p>
@@ -58,7 +59,7 @@ redirect_from:
   Since increasing the number of metrics returned by Vespa will increase both network data to transfer, computing
   resources required to process, and metrics storage cost, it is recommended to keep the set of metrics to what
   you need to monitor your application. Also note that when configuring your own metric set, you need to pass
-  the ID of your <em><a href="services-admin.html#consumer">consumer</a></em> as GET parameter
+  the ID of your <em><a href="../reference/services-admin.html#consumer">consumer</a></em> as GET parameter
   <em>?consumer=my-consumer</em> to the APIs above (e.g. <em>/metrics/v2/values?consumer=my-consumer</em>).
 </p>
 <p>

--- a/en/operations/monitoring.html
+++ b/en/operations/monitoring.html
@@ -29,14 +29,14 @@ There are two main approaches to transfer metrics to an external system:
   <li><code><a href="#state-v1-metrics">/state/v1/metrics</a></code> is the process metrics api,
     and exposes all metrics from an individual service -
     here each node runs a container and a content node.</li>
-  <li><code><a href="../reference/metrics.html#metrics-v2-values">/metrics/v2/values</a></code> is an aggregation of
+  <li><code><a href="#metrics-v2-values">/metrics/v2/values</a></code> is an aggregation of
     <code><a href="#metrics-v1-values">/metrics/v1/values</a></code>, for all nodes.
     Served on the metrics-proxy port.</li>
-  <li><code><a href="../reference/metrics.html#prometheus-v1-values">/prometheus/v1/values</a></code> is the same as
-    <code><a href="../reference/metrics.html#metrics-v2-values">/metrics/v2/values</a></code>, in prometheus format.
+  <li><code><a href="../reference/prometheus-v1.html#prometheus-v1-values">/prometheus/v1/values</a></code> is the same as
+    <code><a href="#metrics-v1-values">/metrics/v1/values</a></code>, in prometheus format.
     Served on the metrics-proxy port.</li>
-  <li><code><a href="../reference/metrics.html#prometheus-v1-values">/prometheus/v1/values</a></code> and
-    <code><a href="../reference/metrics.html#metrics-v2-values">/metrics/v2/values</a></code>
+  <li><code><a href="../reference/prometheus-v1.html#prometheus-v1-values">/prometheus/v1/values</a></code> and
+    <code><a href="#metrics-v2-values">/metrics/v2/values</a></code>
     are also replicated on the container port, default 8080.</li>
 </ul>
 {% include note.html content="
@@ -190,9 +190,84 @@ These apps also include examples for how to find ports used by using
 {% endhighlight %}</pre>
 
 
+<h3 id="metrics-v2-values">/metrics/v2/values</h3>
+<pre>$ curl http://localhost:19092/metrics/v2/values</pre>
+<p>
+  A container service on the same node as the metrics proxy might forward <code>/metrics/v2/values</code>
+  on its own port, normally 8080.
+</p>
+<p>
+  <code>/metrics/v2/values</code> exposes a selected set of metrics for every service on all nodes for the application.
+  For example, it can be used to
+  <a href="https://github.com/vespa-engine/metrics-emitter/tree/master/cloudwatch">
+    pull Vespa metrics to Cloudwatch</a> using an AWS lambda function.
+</p>
+<p>
+  The <a href="#metrics-v2-values">metrics API</a> exposes a
+  <a href="https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv">selected
+    set of metrics</a> for the whole application, or for a single node,
+  to allow integration with graphing and alerting services.
+</p>
+<p>
+  The response is a <code>nodes</code> list with metrics (see example output below),
+  see the <a href="../reference/metrics-v2.html">reference</a> for details.
+</p>
+<pre>{% highlight json %}
+{
+    "nodes": [
+        {
+            "hostname": "vespa-container",
+            "role": "hosts/vespa-container",
+            "services": [
+                {
+                    "name": "vespa.container",
+                    "timestamp": 1634127924,
+                    "status": {
+                        "code": "up",
+                        "description": "Data collected successfully"
+                    },
+                    "metrics": [
+                        {
+                            "values": {
+                                "memory_virt": 3685253120,
+                                "memory_rss": 1441259520,
+                                "cpu": 29.1900152827305
+                            },
+                            "dimensions": {
+                                "serviceId": "container"
+                            }
+                        },
+                        {
+                            "values": {
+                                "jdisc.gc.ms.average": 0
+                            },
+                            "dimensions": {
+                                "gcName": "G1OldGeneration",
+                                "serviceId": "container"
+                            }
+                        },
+{% endhighlight %}</pre>
+
+
+<h3 id="prometheus-v1-values">/prometheus/v1/values</h3>
+<p>
+  Vespa provides a <em>node metrics API</em> on each <em>node</em> at <em>http://host:port/prometheus/v1/values</em>
+</p>
+<p>
+  Port and content is the same as <em>/metrics/v1/values</em>.
+</p>
+<p>
+  The prometheus API on each node exposes metrics in a text based
+  <a href="https://prometheus.io/docs/instrumenting/exposition_formats/">format</a> that can be
+  scraped by <a href="https://prometheus.io/docs/introduction/overview/">Prometheus</a>.
+  See <a href="../operations/monitoring.html">monitoring</a> for a Prometheus / Grafana example.
+</p>
+
+
+
 <h2 id="pulling-metrics-from-vespa">Pulling metrics from Vespa</h2>
 <p>
-All pull-based solutions use Vespa's <a href="../reference/metrics.html#metrics-v2-values">metrics API</a>,
+All pull-based solutions use Vespa's <a href="#metrics-v2-values">metrics API</a>,
 which provides metrics in JSON format, either for the full system or for a single node.
 The polling frequency should be limited to max once every 30 seconds as more frequent polling would
 not give increased granularity but only lead to unnecessary load on your systems.

--- a/en/operations/monitoring.html
+++ b/en/operations/monitoring.html
@@ -89,7 +89,7 @@ These apps also include examples for how to find ports used by using
   Refer to the <a href="../reference/state-v1.html#state-v1-metrics">reference</a> for details.
 </p>
 <p>
-  Vespa supports <a href="../reference/metrics.html#metrics-from-custom-components">custom metrics</a>.
+  Vespa supports <a href="metrics.html#metrics-from-custom-components">custom metrics</a>.
 </p>
 <p>
   Example:

--- a/en/performance/container-tuning.html
+++ b/en/performance/container-tuning.html
@@ -51,8 +51,8 @@ generic config overrides</a>.
 </p>
 <p>
     The effective thread pool configuration and utilization statistics can be observed through the
-    <a href="../reference/metrics.html#container-metrics">Container Metrics</a>.
-    See <a href="../reference/metrics.html#thread-pool-metrics">Thread Pool Metrics</a> for a list of metrics exported.
+    <a href="../operations/metrics.html#container-metrics">Container Metrics</a>.
+    See <a href="../operations/metrics.html#thread-pool-metrics">Thread Pool Metrics</a> for a list of metrics exported.
 </p>
 
 <h3 id="container-worker-threads-example">Example configuration override</h3>

--- a/en/performance/practical-search-performance-guide.md
+++ b/en/performance/practical-search-performance-guide.md
@@ -894,7 +894,7 @@ $ docker exec vespa /opt/vespa/bin/vespa-sentinel-cmd restart searchnode
 </pre>
 </div>
 
-This step requires waiting for the searchnode, use the [health state api](../reference/metrics.html):
+This step requires waiting for the searchnode, use the [health state api](../operations/metrics.html):
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre>
@@ -1161,7 +1161,7 @@ Tensor computations can be used to calculate dense dot products, sparse
 dot products, matrix multiplication, neural networks and more. Tensor computations can be performed 
 on documents that are retrieved by the query matching operators. The only exception to this is
 dense single order tensors (vectors) where Vespa also supports "matching" using [(approximate) nearest
-neighbor search](..//approximate-nn-hnsw.html). 
+neighbor search](../approximate-nn-hnsw.html). 
 
 
 The `track` schema was defined with a `similar` tensor field with one named *mapped* dimension. 

--- a/en/performance/rate-limiting-searcher.html
+++ b/en/performance/rate-limiting-searcher.html
@@ -148,6 +148,6 @@ redirect_from:
 
 <h2 id="metrics">Metrics</h2>
 <p>
-  The searcher will emit the <a href="../reference/metrics.html">count metric</a>
+  The searcher will emit the <a href="../operations/metrics.html">count metric</a>
   <code>requestsOverQuota</code> with the dimension <code>[rate.idDimension=rate.id]</code>.
 </p>

--- a/en/performance/sizing-search.html
+++ b/en/performance/sizing-search.html
@@ -626,7 +626,7 @@ Also see <a href="sizing-feeding.html#feed-vs-search">sizing write versus read</
 
 <h2 id="metrics-for-vespa-sizing">Metrics for Vespa Sizing</h2>
 <p>
-The relevant <a href="../reference/metrics.html">Vespa Metrics</a> for measuring the cost factors,
+The relevant <a href="../operations/metrics.html">Vespa Metrics</a> for measuring the cost factors,
 in addition to system level metrics like cpu util, are:
 </p>
 <em>Metric capturing static query work (SQW) at content nodes </em>

--- a/en/performance/vespa-benchmarking.html
+++ b/en/performance/vespa-benchmarking.html
@@ -30,7 +30,7 @@ Before benchmarking, consider:
     What is the expected query mix?
     Having a representative query mix to test with is essential in order to get valid results.
     Splitting up in different types of queries
-    is also a useful way to get an idea of which query classes are resource intensive. 
+    is also a useful way to get an idea of which query classes are resource intensive.
   </li><li>
     What is the expected SLA, both in terms of latency and query throughput?
   </li><li>
@@ -88,7 +88,7 @@ A typical vespa-fbench command looks like:
 $ vespa-fbench -n 8 -q queries.txt -s 300 -c 0 myhost.mydomain.com 8080
 </pre>
 <p>
-This starts 8 clients, using requests read from <code>queries.txt</code>. 
+This starts 8 clients, using requests read from <code>queries.txt</code>.
 
 The <code>-s</code> parameter indicates that the benchmark will run for 300 seconds.
 The <code>-c</code> parameter, states that each client thread should wait for 0 milliseconds between each query.
@@ -107,7 +107,7 @@ $ docker run -v /Users/myself/tmp:/testfiles \
           myapp.mytenant.aws-us-east-1c.z.vespa-app.cloud 443
 </pre>
 When using a query file with HTTP POST requests (<code>-P</code> option) one also need
-to pass the <em>Content-Type</em> header using the <code>-H</code> header option. 
+to pass the <em>Content-Type</em> header using the <code>-H</code> header option.
 
 <pre>
   $ docker run -v /Users/myself/tmp:/testfiles \
@@ -116,7 +116,7 @@ to pass the <em>Content-Type</em> header using the <code>-H</code> header option
             -C data-plane-public-cert.pem -K data-plane-private-key.pem -T /etc/ssl/certs/ca-bundle.crt \
             -n 10 -P -H "Content-Type: application/json" -q queries_post.txt -o output.txt -s 300 -c 0 \
             myapp.mytenant.aws-us-east-1c.z.vespa-app.cloud 443
-  
+
           </pre>
 
 
@@ -203,7 +203,7 @@ $ vespa-stop-services && vespa-start-services && sleep 60 && vespa-proton-cmd --
 <h3 id="metrics">Metrics</h3>
 <p>
 The <em>container</em> nodes expose the
-<a href="../reference/metrics.html">/metrics/v2/values</a> interface -
+<a href="../operations/metrics.html">/metrics/v2/values</a> interface -
 use this to dump metrics during benchmarks.
 Example - output all metrics from content node:
 <pre>

--- a/en/proton.html
+++ b/en/proton.html
@@ -333,7 +333,7 @@ Use this to correlate observed performance with job runs - see <em>Run metric</e
 Refer to the implementation of
 <a href="https://github.com/vespa-engine/vespa/blob/master/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java">
   performance metrics</a>, see <em>getSearchNodeMetrics()</em>.
-Metrics are available at the <a href="reference/metrics.html">Metrics API</a>.
+Metrics are available at the <a href="operations/metrics.html">Metrics API</a>.
 </p>
 <table class="table">
   <thead>

--- a/en/ranking-expressions-features.html
+++ b/en/ranking-expressions-features.html
@@ -403,7 +403,7 @@ or as a result of changing user behavior.
 </p><p>
 The relevance metrics are <code>relevance.at_1</code>,
 <code>relevance.at_3</code> and <code>relevance.at_10</code>.
-See <a href="reference/metrics.html">metrics</a> for more information.
+See <a href="operations/metrics.html">metrics</a> for more information.
 </p>
 
 

--- a/en/reference/component-reference.html
+++ b/en/reference/component-reference.html
@@ -234,7 +234,7 @@ redirect_from:
       MetricReceiver</a></code></th>
     <td>
       Use to emit metrics from a component.
-      Find an example in the <a href="metrics.html#metrics-from-custom-components">metrics</a> guide.
+      Find an example in the <a href="../operations/metrics.html#metrics-from-custom-components">metrics</a> guide.
     </td>
   </tr>
   <tr>

--- a/en/reference/files-processes-and-ports.html
+++ b/en/reference/files-processes-and-ports.html
@@ -149,7 +149,7 @@ Use <a href="vespa-cmdline-tools.html#vespa-model-inspect">vespa-model-inspect</
   <td>Vespa Log server</td>
   </tr>
 <tr>
-  <td><a href="metrics.html">Metrics proxy</a></td>
+  <td><a href="../operations/metrics.html">Metrics proxy</a></td>
   <td>All nodes</td>
   <td>19092-19095</td>
   <td>java (...) -jar $VESPA_HOME/lib/jars/container-disc-with-dependencies.jar</td>

--- a/en/reference/logs.html
+++ b/en/reference/logs.html
@@ -16,7 +16,7 @@ The log archive and rotation is explained in <a href="#log-server">log server</a
 
 <h2 id="log-file-fields">Log file fields</h2>
 <p>
-Log files are in a machine-readable log format, made more human-readable by 
+Log files are in a machine-readable log format, made more human-readable by
 <a href="vespa-cmdline-tools.html#vespa-logfmt">vespa-logfmt</a> -
 it can filter out log messages from specific programs, only show certain log levels,
 print the time in a more directly understandable format and so on.
@@ -130,7 +130,7 @@ processing performed by a particular component.
 such as queue lengths and latencies.
 <em>COUNTER</em> are numbers increasing monotonically with each processing step,
 such as number of documents processes, or number of queries.
-Refer to the <a href="metrics.html">metrics API</a>.
+Refer to the <a href="../operations/metrics.html">metrics API</a>.
 </p><p>
 Each event has an event <em>type</em>, a <em>version</em> and an optional <em>payload</em>.
 In the log format, event types are expressed as a single word, versions as a simple integer,

--- a/en/reference/metrics-v1.html
+++ b/en/reference/metrics-v1.html
@@ -4,7 +4,7 @@ title: "/metrics/v1 API reference"
 ---
 
 <p>
-  Vespa provides a <em>node metrics API</em> on each <em>node</em> at
+  The <em>node metrics API</em> is available on each <em>node</em> at
   the metrics proxy port, default <em>http://host:19092/metrics/v1/values</em>.
 </p>
 <p>
@@ -84,7 +84,7 @@ title: "/metrics/v1 API reference"
     <td><p id="services">services</p></td>
     <td></td>
     <td>Object</td>
-    <td>Root element for /metrics/v1/values.</td>
+    <td>Root for /metrics/v1/values. Contains service objects.</td>
   </tr>
   <tr>
     <td><p id="name">name</p></td>

--- a/en/reference/metrics-v2.html
+++ b/en/reference/metrics-v2.html
@@ -1,0 +1,117 @@
+---
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+title: "/metrics/v2 API reference"
+---
+
+<p>
+  The <em>application metrics API</em> is available on each <em>node</em> at
+  the metrics proxy port, default <em>http://host:19092/metrics/v2/values</em>.
+  A container service on the same node as the metrics proxy might forward <em>/metrics/v2/values</em>
+  on its own port, normally 8080.
+</p>
+<p>
+  <em>/metrics/v2/values</em> is an aggregation of the application instance nodes <em>/metrics/v1/values</em>.
+  Refer to <a href="../operations/monitoring.html">monitoring</a>
+  for an overview of nodes, services and metrics APIs.
+</p>
+
+
+
+<h2 id="http-requests">HTTP requests</h2>
+<table class="table">
+  <thead>
+  <tr>
+    <th>HTTP request</th>
+    <th>metrics/v2 operation</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <th>GET</th>
+    <td colspan="2">
+      <p id="get">
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td></td>
+    <th>Application metrics</th>
+    <td>
+      <p id="metrics-v2-values"></p>
+      <pre>/metrics/v2/values</pre>
+      <p>
+        See <a href="../operations/monitoring.html#metrics-v2-values">monitoring</a> for examples.
+      </p>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+
+
+<h2 id="http-status-codes">HTTP status codes</h2>
+<p>
+  Non-exhaustive list of status codes:
+</p>
+<table class="table">
+  <thead>
+  <tr>
+    <th>Code</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <th>200</th>
+    <td>OK.</td>
+  </tr> <!-- ToDo: more codes -->
+  </tbody>
+</table>
+
+
+
+<h2 id="response-format">Response format</h2>
+<p>
+  Responses are in JSON format, with the following fields:
+</p>
+<table class="table">
+  <thead>
+  <tr>
+    <th>Element</th>
+    <th>Parent</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><p id="nodes">nodes</p></td>
+    <td></td>
+    <td>Array</td>
+    <td>Root element for /metrics/v2/values. Returns an array of node objects with metrics</td>
+  </tr>
+  <tr>
+    <td><p id="hostname">hostname</p></td>
+    <td>nodes</td>
+    <td>String</td>
+    <td>Node hostname.</td>
+  </tr>
+  <tr>
+    <td><p id="role">role</p></td>
+    <td>nodes</td>
+    <td>String</td>
+    <td>Node role.</td>
+  </tr>
+  <tr>
+    <td><p id="services">services</p></td>
+    <td>nodes</td>
+    <td>Array</td>
+    <td>
+      Array of service objects, the are services running on the node.
+      The <code>service</code> object is defined in
+      <a href="metrics-v1.html#metrics-v1-values">/metrics/v1/values</a>.
+    </td>
+  </tr>
+  </tbody>
+</table>

--- a/en/reference/metrics.html
+++ b/en/reference/metrics.html
@@ -5,161 +5,73 @@ redirect_from:
 - /documentation/reference/metrics.html
 ---
 
-<h2 id="aggregated-metrics">Aggregated metrics</h2>
-<p>
-    For most cases, metrics should be collected aggregated on an application-level through the
-    <em><a href="#metrics-v2-values">/metrics/v2/values</a></em> API or at node-level through either the
-    <em><a href="metrics-v1.html#metrics-v1-values">/metrics/v1/values</a></em> or
-    <em><a href="#prometheus-v1-values">/prometheus/v1/values</a></em> API.
-</p>
 
-<h3 id="metrics-v2-values">/metrics/v2/values</h3>
 <p>
-  The API is found on all nodes running a Container node at <em>http://host:port/metrics/v2/values</em>
-</p>
-<p>
-  Port is the same as the container's query/feed endpoint, default 8080.
-</p>
-<p>
-  The Vespa container exposes a selected set of metrics for every service on all nodes for the application.
-  The metrics API can, for example, be used to
-  <a href="https://github.com/vespa-engine/metrics-emitter/tree/master/cloudwatch">
-    pull Vespa metrics to Cloudwatch</a> using an AWS lambda function.
-</p>
-<p>
-  The <a href="#metrics-v2-values">metrics API</a> exposes a
-  <a href="https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv">selected
-    set of metrics</a> for the whole application, or for a single node,
-  to allow integration with graphing and alerting services.
-</p>
-<p>
-  The response is a <code>nodes</code> list (see example output below),
-  where each element represents a node in the application and contains:
-</p>
-<ul>
-  <li>The node's <code>hostname</code>.</li>
-  <li>The node's <code>role</code> in the Vespa application.</li>
-  <li>A <code>node</code> element containing the node's system metrics, e.g. cpu usage.</li>
-  <li>A <code>services</code> list containing metrics for the node's services.
-    The format of this list is described <a href="metrics-v1.html#metrics-v1-values">below</a>.</li>
-</ul>
-<pre>
-$ curl http://localhost:8080/metrics/v2/values
-</pre>
-<pre>{% highlight json %}
-{
-    "nodes": [
-        {
-            "hostname": "vespa-container",
-            "role": "hosts/vespa-container",
-            "services": [
-                {
-                    "name": "vespa.container",
-                    "timestamp": 1634127924,
-                    "status": {
-                        "code": "up",
-                        "description": "Data collected successfully"
-                    },
-                    "metrics": [
-                        {
-                            "values": {
-                                "memory_virt": 3685253120,
-                                "memory_rss": 1441259520,
-                                "cpu": 29.1900152827305
-                            },
-                            "dimensions": {
-                                "serviceId": "container"
-                            }
-                        },
-                        {
-                            "values": {
-                                "jdisc.gc.ms.average": 0
-                            },
-                            "dimensions": {
-                                "gcName": "G1OldGeneration",
-                                "serviceId": "container"
-                            }
-                        },
-{% endhighlight %}</pre>
-
-
-
-<h3 id="prometheus-v1-values">/prometheus/v1/values</h3>
-<p>
-  Vespa provides a <em>node metrics API</em> on each <em>node</em> at <em>http://host:port/prometheus/v1/values</em>
-</p>
-<p>
-  Port is the same as the container's query/feed endpoint, default 8080.
-</p>
-<p>
-  The prometheus API on each node exposes metrics in a text based
-  <a href="https://prometheus.io/docs/instrumenting/exposition_formats/">format</a> that can be
-  scraped by <a href="https://prometheus.io/docs/introduction/overview/">Prometheus</a>.
-  The metrics is the same as in <code><a href="#metrics-v2-values">/metrics/v2/values</a></code>.
-  See <a href="../operations/monitoring.html">monitoring</a> for a Prometheus / Grafana example.
+  Metrics can be accessed aggregated on an application-level using
+  <em><a href="../reference/metrics-v2.html#metrics-v2-values">/metrics/v2/values</a></em>
+  or at node-level using either
+  <em><a href="../reference/metrics-v1.html#metrics-v1-values">/metrics/v1/values</a></em> or
+  <em><a href="../reference/prometheus-v1.html#prometheus-v1-values">/prometheus/v1/values</a></em>.
 </p>
 
 
 
-
-
-<h3 id="customizing-metric-sets">Customizing Metric Sets</h3>
+<h2 id="customizing-metric-sets">Customizing Metric Sets</h2>
 <p>
-    The aggregation metrics APIs will all return metrics from the
-    <a href="https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv">default</a> metric set.
-    While this should cover the most basic operational Vespa metrics, the set of metrics returned
-    can be customized through the <em><a href="services-admin.html#metrics">metrics</a></em> section in
-    <em><a href="services.html">services.xml</a></em>. You can control the metric set by either including a pre-defined
-    <em><a href="services-admin.html#metric-set">metric-set</a></em> or configure a specific
-    <em><a href="services-admin.html#metric">metric</a></em>. The latter way is also how you include any
-    <a href="#metrics-from-custom-components">metrics from custom components</a>.
+  The aggregation metrics APIs will all return metrics from the
+  <a href="https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv">default</a> metric set.
+  While this should cover the most basic operational Vespa metrics, the set of metrics returned
+  can be customized through the <em><a href="services-admin.html#metrics">metrics</a></em> section in
+  <em><a href="services.html">services.xml</a></em>. You can control the metric set by either including a pre-defined
+  <em><a href="services-admin.html#metric-set">metric-set</a></em> or configure a specific
+  <em><a href="services-admin.html#metric">metric</a></em>. The latter way is also how you include any
+  <a href="#metrics-from-custom-components">metrics from custom components</a>.
 </p>
-
 <p>
-    Vespa comes with two pre-defined metric sets:
+  Vespa comes with two pre-defined metric sets:
 </p>
 <table class="table">
-    <thead>
-        <tr>
-            <td>Metric set ID</td>
-            <td>Description</td>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>default</td>
-            <td>
-                The default <a href="https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv">set of metrics</a>
-            </td>
-        </tr>
-        <tr>
-            <td>vespa</td>
-            <td>
-                A <a href="https://github.com/vespa-engine/vespa/blob/master/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java">comprehensive list of metrics</a>
-                used to inspect low-level behavior of Vespa.<br/>
-                <b>NOTE:</b>This is a comprehensive set with a lot of metrics. See paragraph on cost below.
-            </td>
-        </tr>
-    </tbody>
+  <thead>
+  <tr>
+    <td>Metric set ID</td>
+    <td>Description</td>
+  </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>default</td>
+      <td>
+        The default <a href="https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv">set of metrics</a>
+      </td>
+    </tr>
+    <tr>
+      <td>vespa</td>
+      <td>
+        A <a href="https://github.com/vespa-engine/vespa/blob/master/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java">comprehensive list of metrics</a>
+        used to inspect low-level behavior of Vespa.
+        {% include note.html content='This is a comprehensive set with a lot of metrics. See paragraph on cost below.' %}
+      </td>
+    </tr>
+  </tbody>
 </table>
-
 <p>
-    Since increasing the number of metrics returned by Vespa will increase both network data to transfer, computing
-    resources required to process, and metrics storage cost, it is recommended to keep the set of metrics to what
-    you need to monitor your application. Also note that when configuring your own metric set, you need to pass
-    the ID of your <em><a href="services-admin.html#consumer">consumer</a></em> as GET parameter
-    <em>?consumer=my-consumer</em> to the APIs above (e.g. <em>/metrics/v2/values?consumer=my-consumer</em>).
+  Since increasing the number of metrics returned by Vespa will increase both network data to transfer, computing
+  resources required to process, and metrics storage cost, it is recommended to keep the set of metrics to what
+  you need to monitor your application. Also note that when configuring your own metric set, you need to pass
+  the ID of your <em><a href="services-admin.html#consumer">consumer</a></em> as GET parameter
+  <em>?consumer=my-consumer</em> to the APIs above (e.g. <em>/metrics/v2/values?consumer=my-consumer</em>).
 </p>
-
 <p>
-    Example:
+  Example:
 </p>
-<pre>&lt;metrics&gt;
+<pre>
+&lt;metrics&gt;
     &lt;consumer id=&quot;my-consumer&quot;&gt;
         &lt;metric-set id=&quot;default&quot; /&gt;
         &lt;metric id=&quot;vds.idealstate.garbage_collection.documents_removed.count&quot; /&gt;
     &lt;/consumer&gt;
-&lt;/metrics&gt;</pre>
+&lt;/metrics&gt;
+</pre>
 
 
 

--- a/en/reference/prometheus-v1.html
+++ b/en/reference/prometheus-v1.html
@@ -1,0 +1,81 @@
+---
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+title: "/prometheus/v1 API reference"
+---
+
+<p>
+  The <em>prometheus node metrics API</em> is available on each <em>node</em> at
+  the metrics proxy port, default <em>http://host:19092/prometheus/v1/values</em>.
+</p>
+<p>
+  This API has the same content as in <em>/metrics/v1/values</em>,
+  in a <a href="https://prometheus.io/docs/instrumenting/exposition_formats/">format</a> that can be
+  scraped by <a href="https://prometheus.io/docs/introduction/overview/">Prometheus</a>.
+</p>
+<p>
+  Refer to <a href="../operations/monitoring.html">monitoring</a>
+  for an overview of nodes, services and metrics APIs.
+</p>
+
+
+
+<h2 id="http-requests">HTTP requests</h2>
+<table class="table">
+  <thead>
+  <tr>
+    <th>HTTP request</th>
+    <th>prometheus/v1 operation</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <th>GET</th>
+    <td colspan="2">
+      <p id="get">
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td></td>
+    <th>Node metrics</th>
+    <td>
+      <p id="prometheus-v1-values"></p>
+      <pre>/prometheus/v1/values</pre>
+      <p>
+        See <a href="../operations/monitoring.html#prometheus-v1-values">monitoring</a> for examples.
+      </p>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+
+
+<h2 id="http-status-codes">HTTP status codes</h2>
+<p>
+  Non-exhaustive list of status codes:
+</p>
+<table class="table">
+  <thead>
+  <tr>
+    <th>Code</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <th>200</th>
+    <td>OK.</td>
+  </tr> <!-- ToDo: more codes -->
+  </tbody>
+</table>
+
+
+
+<h2 id="response-format">Response format</h2>
+<p>
+  Responses are in Prometheus format, the values are the same as in
+  <a href="metrics-v1.html#metrics-v1-values">/metrics/v1/values</a>
+</p>
+


### PR DESCRIPTION
- metrics API reference doc is now clean. It is missing request params, though, at least `consumer`, but there are maybe more @gjoranv / @hmusum ? That is for next PR
- moved the residual doc into a metrics guide, that I will refine / clean up next

FYI @bratseth 