### PR TITLE
Handle empty summary in doc search

### DIFF
--- a/js/handle_results.js
+++ b/js/handle_results.js
@@ -41,19 +41,20 @@ const handleResults = (data) => {
       }) => {
         const modifiedURL = baseURL[namespace] + path;
 
-        const modifiedContent = (
-          content
-        )
-          .replace(/<sep \/>/g, " ... ")
-          .replace(/<hi>/g, "<mark>")
-          .replace(/<\/hi>/g, "</mark>");
+        const modifiedContent =
+          typeof content == "undefined"
+            ? ""
+            : content
+              .replace(/<sep \/>/g, " ... ")
+              .replace(/<hi>/g, "<mark>")
+              .replace(/<\/hi>/g, "</mark>");
 
         const modifiedTitle =
           typeof title == "undefined"
             ? "No title"
             : title
-                .replace(/<hi>/g, "<mark>")
-                .replace(/<\/hi>/g, "</mark>");
+              .replace(/<hi>/g, "<mark>")
+              .replace(/<\/hi>/g, "</mark>");
 
         const listItem = document.createElement("li");
         listItem.className = "search-result-item";


### PR DESCRIPTION
- for some reason, a dynamic summary field is empty for `xgboost` query for https://docs.vespa.ai/en/xgboost.html