### PR TITLE
ignore javadoc links with hashes

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -37,7 +37,7 @@ jobs:
             --enforce_https false \
             --allow-missing-href true \
             --ignore-files '/playground/index.html/' \
-            --ignore-urls '/localhost:8080/,/docs.vespa.ai/playground/' \
+            --ignore-urls '/localhost:8080/,/docs.vespa.ai/playground/,/javadoc.io.*#/' \
             --typhoeus '{"connecttimeout": 10, "timeout": 30, "accept_encoding": "zstd,br,gzip,deflate"}' \
             --hydra '{"max_concurrency": 1}' \
             _site


### PR DESCRIPTION
- could not find a working way right now, revisit later
- using static, like https://javadoc.io/static/com.yahoo.vespa/documentapi/{{site.variables.vespa_version}}/com/yahoo/documentapi/UpdateResponse.html is required, but not enough, still fails in the use of () / something else
