### PR TITLE
fix typos in elasticity and docker-container documents

### DIFF
--- a/en/elasticity.html
+++ b/en/elasticity.html
@@ -17,7 +17,7 @@ redirect_from:
      alt="A cluster growing in two dimensions" />
 
 <p>
-  Documents are management by Vespa in chunked called <a href="#buckets">buckets</a>.
+  Documents are managed by Vespa in chunked called <a href="#buckets">buckets</a>.
   The size and number of buckets are completely managed by Vespa and there is never any
   need to manually control sharding.
 </p>

--- a/en/operations/docker-containers.html
+++ b/en/operations/docker-containers.html
@@ -89,11 +89,11 @@ $ docker run --detach --name vespa --user vespa:vespa --hostname vespa-container
   especially for memory intensive applications with large dense tensors with concurrent query and write workloads.
 </p>
 <p>
-  One application improved query 99p latency from 950 ms to 150ms during concurrent query and write by enabling THP.
+  One application improved query p99 latency from 950 ms to 150ms during concurrent query and write by enabling THP.
   Using THP is even more important when running in virtualized environments like AWS and GCP due to nested page tables.
 </p>
 <p>
-  When running Vespa using the container image, <em>THP</em> settings needs to be set on the base host OS (Linux).
+  When running Vespa using the container image, <em>THP</em> settings need to be set on the base host OS (Linux).
   The recommended settings are:
 </p>
 <pre>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fix some typos error in elasticity and docker-container documents.