### PR TITLE
Don't use rank:filter for non fast-search fields

### DIFF
--- a/en/nearest-neighbor-search-guide.md
+++ b/en/nearest-neighbor-search-guide.md
@@ -214,7 +214,6 @@ schema track {
 
         field track_id type string {
             indexing: summary | attribute
-            rank: filter
             match: word
         }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
