### PR TITLE
Add tensor execution examples, reorganize

### DIFF
--- a/en/performance/feature-tuning.html
+++ b/en/performance/feature-tuning.html
@@ -207,14 +207,14 @@ search news {
   See also <a href="#multi-lookup-set-filtering">multi lookup set filter</a>
   for how to most efficiently search with large set filters.
 
-  The sub-tree result is then passed as a bit vector into the <em>DAAT</em> query evaluation,
-  which could speed up the overall evaluation significantly. 
+  The subtree result is then passed as a bit vector into the <em>DAAT</em> query evaluation,
+  which could speed up the overall evaluation significantly.
 </p>
 <p>
   Enabling hybrid <em>TAAT</em> is done by passing
   <code>ranking.matching.termwiselimit=0.1</code> as a request parameter. It's possible to
   evaluate the performance impact by changing this limit. Setting the limit to 0 will force
-  termwise evaluation, which might hurt performance. 
+  termwise evaluation, which might hurt performance.
 </p>
 <p>
   One can evaluate if using the hybrid evaluation improves search performance by adding the above parameter.
@@ -267,10 +267,10 @@ field uuid type string {
 <h2 id="parent-child-and-search-performance">Parent child and search performance</h2>
 <p>
   When searching imported attribute fields (with <code>fast-search</code>) from parent document types
-  there is an additional inderection that can be reduced significantly
+  there is an additional indirection that can be reduced significantly
   if the imported field is defined with <code>rank:filter</code>
   and <a href="../reference/services-content.html#visibility-delay">visibility-delay</a> is configured to &gt; 0.
-  The <a href="../reference/schema-reference.html#rank">rank:filter</a> setting impacts posting list graunularity
+  The <a href="../reference/schema-reference.html#rank">rank:filter</a> setting impacts posting list granularity
   and <code>visibility-delay</code> enables a cache for the indirection between the child and parent document.
 </p>
 
@@ -287,7 +287,7 @@ field uuid type string {
 </p><p>
   For <a href="../text-matching-ranking.html">text ranking</a> applications,
   consider using the <a href="../using-wand-with-vespa.html">WAND</a> query operator -
-  WAND can efficiently (sub-linear) find the top k documents using an inner scoring function.
+  WAND can efficiently (sublinear) find the top k documents using an inner scoring function.
 </p>
 
 
@@ -364,3 +364,288 @@ When selecting attribute field type, considering performance, this is a rule of 
 <p>
 Refer to <a href="../attributes.html">attributes</a> for details.
 </p>
+
+
+
+<h2 id="tensor-ranking">Tensor ranking</h2>
+<p>
+  Tensor expressions are fairly concise,
+  and since the expressions themselves are independent of the data size,
+  the actual workload during ranking can be significant for large tensors.
+</p>
+<p>
+  When using tensors in ranking,
+  it is important to have an understanding of the potential computational cost for each query.
+  As an example, assume the dot product of two tensors with 1000 values each,
+  e.g. <code>tensor&lt;double&gt;(x[1000])</code>.
+  Assuming one query tensor and one document tensor, the operation is:
+</p>
+<pre>
+sum(query(tensor1) * attribute(tensor2))
+</pre>
+<p>
+  If 8 bytes is used to store each value (e.g. using a double), each tensor is approximately 8 KB.
+  With for instance Haswell architecture,
+  the theoretical upper memory bandwidth is 68 GB/s,
+  which is around 9 million document ranking evaluations per second.
+  With 1 million documents, this means the maximum throughput, in regard to pure memory bandwidth,
+  is 9 queries per second (per node).
+</p>
+<p>
+  Even though you would typically not do the above without reducing the search space first
+  (using matching and first phase),
+  it is important to consider the memory bandwidth and other hardware limitations
+  when developing ranking expressions with tensors.
+</p>
+<p>
+  When using tensor types with at least one mapped dimension (sparse or mixed tensor),
+  <a href="../reference/schema-reference.html#attribute">attribute: fast-rank</a>
+  can be used to optimize the tensor attribute for ranking expression evaluation at the cost of using more memory.
+  This is a trade-off that can be worth taking
+  if benchmarking indicates significant latency improvements with <code>fast-rank</code>.
+</p>
+<p>
+  When optimizing ranking functions with tensors, try to avoid temporary objects.
+</p>
+<p>
+  Use the Tensor Playground to evaluate what the expressions map to,
+  using the execution details
+  <svg height="21" viewBox="0 0 21 21" width="21" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd" stroke="currentColor"
+       stroke-linecap="round" stroke-linejoin="round" transform="translate(2 2)">
+      <path d="m5.5.5h6v5h-6z"/>
+      <path d="m10.5 11.5h6v5h-6z"/>
+      <path d="m.5 11.5h6v5h-6z"/>
+      <path d="m3.498 11.5v-3h10v3"/>
+      <path d="m8.5 8.5v-3"/>
+    </g>
+  </svg>
+  to list the detailed steps.
+</p>
+
+
+<h3 id="cell-value-types">Performance considerations for cell value types</h3>
+<table class="table">
+  <thead>
+  <tr>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <th>double</th>
+    <td>
+      <p id="double">
+        The 64-bit floating-point "double" format is the default cell type.
+        It gives the best precision at the cost of high memory usage and somewhat slower calculations.
+        Using a smaller value type increases performance, trading off precision,
+        so consider changing to one of the cell types below before scaling the application.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>float</th>
+    <td>
+      <p id="float">
+        The 32-bit floating-point format "float" should usually be used for all tensors when scaling for production.
+        (Note that other frameworks, like tensorflow, will also prefer 32-bit floats)
+        A vector with 1000 dimensions,
+        <code>tensor&lt;float&gt;(x[1000])</code> would then use approximately 4K memory per tensor value.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>bfloat16</th>
+    <td>
+      <p id="bfloat16">
+        If memory (or memory bandwidth) is still a concern,
+        it's possible to change the most space-consuming tensors to use the <code>bfloat16</code> cell type.
+        This type has the range as a normal 32-bit float but only 8 bits of precision,
+        and can be thought of as "float with lossy compression".
+        See also <a href="https://en.wikipedia.org/wiki/Bfloat16_floating-point_format">
+        bfloat16 floating-point format</a> on Wikipedia.
+        Some careful analysis of the data is required before using this type.
+      </p>
+      <p>
+        Note that when doing calculations <code>bfloat16</code> will act as if it was a 32-bit float,
+        but the smaller size comes with a potential computational overhead.
+        In most cases, the <code>bfloat16</code> needs conversion to a 32-bit float
+        before the actual calculation can take place, adding an extra conversion step.
+      </p>
+      <p>
+        In some cases, having tensors with <code>bfloat16</code> cells might bypass some build-in optimizations
+        (like matrix multiplication) that will be hardware accelerated only if the cells are the same type.
+        To avoid this last case,
+        use the <a href="../reference/ranking-expressions.html#cell_cast">cell_cast</a> tensor operation
+        to make sure the cells are of the appropriate type before doing the more expensive operations.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>int8</th>
+    <td>
+      <p id="int8">
+        If one uses machine-learning to generate a model with data quantization,
+        you can target the <code>int8</code> cell value type,
+        which is a signed integer with range from -128 to +127 only.
+        This is also treated like a "float with limited range and lossy compression" by the Vespa tensor framework,
+        and gives results as if it was a 32-bit float when any calculation is done.
+        This type is also suitable when representing boolean values (0 or 1).
+        Note that if the input for an <code>int8</code> cell is not directly representable,
+        the resulting cell value is undefined,
+        so you should take care to only input numbers in the <code>[-128,127]</code> range.
+        It's also possible to use <code>int8</code> representing binary data for
+        <a href="../reference/schema-reference.html#distance-metric">hamming distance</a> Nearest-Neighbor search.
+      </p>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+
+<h3 id="Inner-outer-products">Inner/outer products</h3>
+<p>
+  Following is a primer into inner/outer products and execution details:
+</p>
+<table class="table">
+  <thead>
+  <tr>
+    <th>tensor a</th>
+    <th>tensor b</th>
+    <th>product</th>
+    <th>sum</th>
+    <th>comment</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td style="white-space: nowrap;">tensor(x[3]):[1.0, 2.0, 3.0]</td>
+    <td>tensor(x[3]):[4.0, 5.0, 6.0]</td>
+    <td style="white-space: nowrap;">tensor(x[3]):[4.0, 10.0, 18.0]</td>
+    <td>32</td>
+    <td>
+      <a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gEMSybIiFIAXA2gZywAnABQAPRAGYAugEo4iAIzEwAJmXTIrCAF9W20hmrlcDIgbaU0WugwBGLGpg5Qe-IWMmz5AFmUBWZQA2KU1HXQx9ViNME04zawp8aPJ6TlhzR3YGRgAqe2tw1EjDBNjCBwsk6whIVKhoAFdaAGMKzOdIPgaAW2Fc2xlQmkKdFCkQbSA">
+        Playground example</a>.
+      The dimension name and size is the same in both tensors - this is an inner product, with a scalar result.
+    </td>
+  </tr>
+  <tr>
+    <td>tensor(x[3]):[1.0, 2.0, 3.0]</td>
+    <td style="white-space: nowrap;">tensor(y[3]):[4.0, 5.0, 6.0]</td>
+    <td>tensor(x[3],y[3]):[<br/>[4.0, 5.0, 6.0],<br/>[8.0, 10.0, 12.0],<br/>[12.0, 15.0, 18.0] ]</td>
+    <td>90</td>
+    <td>
+      <a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gEMSybIiFIAXA2gZywAnABQAPRAGYAugEo4iAIzEwAJmXTIrCAF9W20hmrlcDIgbaU0WugwBGLGpg5Qe-IWMmz5AFmUBWZQA2KU1HXQx9ViNME04zawp8aPJ6TlhzR3YGRgAqe2tw1EjDBNjCBwsk6whIVKhoAFdaAGMKzOdIPgaAW2Fc2xlQmkKdFCkQbSA">
+        Playground example</a>.
+      The dimension size is the same in both tensors, but dimensions have different names -&gt;
+      this is an outer product, the result is a two-dimensional tensor.
+    </td>
+  </tr>
+  <tr>
+    <td>tensor(x[3]):[1.0, 2.0, 3.0]</td>
+    <td>tensor(x[2]):[4.0, 5.0]</td>
+    <td>undefined</td>
+    <td></td>
+    <td>
+      <a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gEMSybIiFIAXA2gZywAnABQAPRAGYAugEo4iAIzEwAJmXTIrCAF9W20hmrlcDIgbaU0WugwBGLGpg5Qe-IWMQrZ8gCzKArFKajroY+qxGmCacZtYU+JHk9Jyw5o7sDIwAVPbWoajhhnHRhA4WCdYQkMlQ0ACutADGZenOkHx1ALbC2bYywTT5OihSINpAA">
+        Playground example</a>.
+      Two tensors in same dimension, but with different length -&gt; undefined.
+    </td>
+  </tr>
+  <tr>
+    <td>tensor(x[3]):[1.0, 2.0, 3.0]</td>
+    <td>tensor(y[2]):[4.0, 5.0]</td>
+    <td>tensor(x[3],y[2]):[<br/>[4.0, 5.0],<br/>[8.0, 10.0],<br/>[12.0, 15.0] ]</td>
+    <td>54</td>
+    <td>
+      <a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gEMSybIiFIAXA2gZywAnABQAPRAGYAugEo4iAIzEwAJmXTIrCAF9W20hmrlcDIgbaU0WugwBGLGpg5Qe-IcICeiFbPkAWZQBWKU1HXQx9ViNME04zawp8aPJ6TlhzR3YGRgAqe2tw1EjDBNjCBwsk6whIVKhoAFdaAGMKzOdIPgaAW2Fc2xlQmkKdFCkQbSA">
+        Playground example</a>.
+      Two tensors with different names and dimensions -&gt;
+      this is an outer product, the result is a two-dimensional tensor.
+    </td>
+  </tr>
+  </tbody>
+</table>
+<p>
+  Inner product - observe optimized into <code>DenseDotProductFunction</code>
+  with no temporary objects:
+</p>
+<pre>{% highlight json %}
+[ {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::DenseDotProductFunction",
+    "symbol": "vespalib::eval::(anonymous namespace)::my_cblas_double_dot_product_op(vespalib::eval::InterpretedFunction::State&, unsigned long)"
+  } ]
+{% endhighlight %}</pre>
+<p>
+  Outer product, parsed into a tensor multiplication (<code>DenseSimpleExpandFunction</code>),
+  followed by a <code>Reduce</code> operation:
+</p>
+<pre>{% highlight json %}
+[ {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::DenseSimpleExpandFunction",
+    "symbol": "void vespalib::eval::(anonymous namespace)::my_simple_expand_op<double, double, double, vespalib::eval::operation::InlineOp2<vespalib::eval::operation::Mul>, true>(vespalib::eval::InterpretedFunction::State&, unsigned long)"
+  },
+  {
+    "class": "vespalib::eval::tensor_function::Reduce",
+    "symbol": "void vespalib::eval::instruction::(anonymous namespace)::my_full_reduce_op<double, vespalib::eval::aggr::Sum<double> >(vespalib::eval::InterpretedFunction::State&, unsigned long)"
+  } ]
+{% endhighlight %}</pre>
+<p>
+  Note that an inner product can also be run on mapped tensors
+  (<a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gEMSybIiFIAXA2gZywAnABQAPYAF8AlHGCiAjHHnEwogExw1K0QGY4OiZFYQJrCaQzVyuBkQttKaY3QYAjFjUwcoPfkLGSMnKKACwAdAAM2hoArJHaegBskYbOphjmrFaYNpx2zhT42eT0nACWtLQEgjiCWAAmAK4AxlwenoQMjABU7mlmKAC6IBJAA">Playground example</a>):
+</p>
+<pre>{% highlight json %}
+[ {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::SparseFullOverlapJoinFunction",
+    "symbol": "void vespalib::eval::(anonymous namespace)::my_sparse_full_overlap_join_op<double, vespalib::eval::operation::InlineOp2<vespalib::eval::operation::Mul>, true>(vespalib::eval::InterpretedFunction::State&, unsigned long)"
+  } ]
+{% endhighlight %}</pre>
+
+
+<h3 id="mapped-lookups">Mapped lookups</h3>
+<p>
+  Using a mapped dimension to select an indexed tensor can be considered a
+  <a href="../tensor-examples.html#using-a-tensor-as-a-lookup-structure">mapped lookup</a>.
+  This is similar to creating a slice, but optimized into a single <code>MappedLookup</code> -
+  see <a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gFssATAgGwGcSybIiEkAC4FanLACcAFIwD6ASxbAAvsQAeiAMwBdAJRxgjAIxxEAFgB0ABmJgArNdsA2a9tuMATKYDsjsAA4-AE5XZUheCGVeVV5qclwGIlIaKEo0CLoGZjZ2BRYeFIh+BhExSRk8lX1DLyNrMIyojBiMOMwEwSSMinw28npBTnZ5AGMuwsIGGVYOTgAqbI483UM8uE8GlKbUFtQ+qA7J5L40-aKBqEYAQxwcAhZZdiwsAGsAVzxjlOLBt8ZpnLzRa5RTEOSKXThLbRL7pb6HYqwoqnDLnLI3O4PJ6vD6yCT3N5jAqFH5QfEsQkEAGzBYzEEsYicP5g5ZQmjbSIobQgZRAA">
+  Tensor Playground</a> example.
+</p>
+<pre>{% highlight json %}
+[ {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::tensor_function::Inject",
+    "symbol": "<inject_param>"
+  },
+  {
+    "class": "vespalib::eval::MappedLookup",
+    "symbol": "void vespalib::eval::(anonymous namespace)::my_mapped_lookup_op<double>(vespalib::eval::InterpretedFunction::State&, unsigned long)"
+  } ]
+{% endhighlight %}</pre>

--- a/en/performance/practical-search-performance-guide.md
+++ b/en/performance/practical-search-performance-guide.md
@@ -1650,9 +1650,10 @@ $ vespa query \
 </div>
 
 The `querytime` dropped to 40 ms instead of 120 ms without the `fast-search` option. 
-See also [performance considerations](../tensor-user-guide.html#performance-considerations)
-when using tensor expression. Vespa supports `int8`, `bfloat16`, `float` and
-`double` precision cell types. A tradeoff between speed, accuracy and memory usage.
+See also [performance considerations](feature-tuning.html#tensor-ranking) when using tensor expression.
+Vespa supports `int8`, `bfloat16`, `float` and `double` precision cell types.
+A tradeoff between speed, accuracy and memory usage.
+
 
 ## Multithreaded search and ranking
 So far in this guide all search queries and ranking computations have been performed using 

--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -1785,7 +1785,7 @@ Actions required when <a href="#modifying-schemas">adding or modifying attribute
   <a href="ranking-expressions.html">ranking expression</a> evaluation. This comes at the cost of using more memory.
   Without this setting these tensors are serialized in-memory,
   which requires de-serialization as part of ranking expression evaluation.
-  See <a href="../tensor-user-guide.html#performance-considerations">tensor performance</a>.
+  See <a href="../performance/feature-tuning.html#tensor-ranking">tensor performance</a>.
 </td></tr>
 <tr><td>paged</td><td>
   This can reduce memory footprint by allowing paging the attribute data out of memory to disk.

--- a/en/tensor-examples.html
+++ b/en/tensor-examples.html
@@ -227,4 +227,48 @@ sum(query(query_vector) * attribute(document_matrix),x)
 <p>This is a sparse tensor product over the shared dimension <code>x</code>,
 followed by a sum over the same dimension.</p>
 
-<p><a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gEMAXZgJwEsAjAV2YIAUAEywBjHgFsCtZgH0JLTgA8AlCTI1IRBJH60AzljYAeaABssLAHwCliAMwBdYgE9EAJkcq4iRAEZiAHZnB2I-PxCAVjCnR0gNCABfDUTSDGpyXAYiNM1KNAS6BgBHHgI2FwFS8pdZADcCUWYjNVyaQgY9QxNzS2YbOydvf2J7Yki4wuSMVI0MzCydHMKKfHnyeh11dogtBn1JKrKKo5r6xua2FTAAKjAWdm4+QRFxKRl5RQ5VYlV49umqEBjhAiSAA">Play around with this example in the playground</a>
+<p>
+  <a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gEMAXZgJwEsAjAV2YIAUAEywBjHgFsCtZgH0JLTgA8AlCTI1IRBJH60AzljYAeaABssLAHwCliAMwBdYgE9EAJkcq4iRAEZiAHZnB2I-PxCAVjCnR0gNCABfDUTSDGpyXAYiNM1KNAS6BgBHHgI2FwFS8pdZADcCUWYjNVyaQgY9QxNzS2YbOydvf2J7Yki4wuSMVI0MzCydHMKKfHnyeh11dogtBn1JKrKKo5r6xua2FTAAKjAWdm4+QRFxKRl5RQ5VYlV49umqEBjhAiSAA">Play around with this example in the playground</a>
+</p>
+
+
+<h2 id="using-a-tensor-as-a-lookup-structure">Using a tensor as a lookup structure</h2>
+<p>
+  Tensors with mapped dimensions look similar to maps, but are more general.
+  What if all needed is a simple map lookup?
+  See <a href="performance/feature-tuning.html#mapped-lookups">tensor performance</a> for more details.
+</p>
+<p>
+  Assume a tensor attribute <code>my_map</code> and this is the value for a specific document:
+</p>
+<pre>
+tensor&lt;float&gt;(x{},y[3]):{a:[1,2,3],b:[4,5,6],c:[7,8,9]}
+</pre>
+<p>
+  To create a query to select which of the 3 named vectors (a,b,c) to use for some other calculation,
+  wrap the wanted label to look up inside a tensor.
+  Assume a query tensor <code>my_key</code> with type/value:
+</p>
+<pre>
+tensor&lt;float&gt;(x{}):{b:1.0}
+</pre>
+<p>Do the lookup, returning a tensor of type <code>tensor&lt;float&gt;(y[3])</code>:</p>
+<pre>
+sum(query(my_key)*attribute(my_map),x)
+</pre>
+<!-- same as reduce(query(my_key)*attribute(my_map),sum,x) -->
+<p>
+  If the key does not match anything, the result will be empty: <code>tensor&lt;float&gt;(y[3]):[0,0,0]</code>.
+  For something else, add a check up-front to check if the lookup will be successful
+  and run a fallback expression if it is not, like:
+</p>
+<pre>
+if(reduce(query(my_key)*attribute(my_map),count) == 3,
+  reduce(query(my_key)*attribute(my_map),sum,x),
+  tensor&lt;float&gt;(y[3]):[0.5,0.5,0.5])
+</pre>
+{% include note.html content='The above can be considered the same as creating a
+<a href="reference/ranking-expressions.html#slice">slice</a>, like <code>(y*x){x:b}</code>.
+The above syntax allows an optimized execution, find an example in the
+<a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QFNIAaFDSPBdDTAO30gFssATAgGwGcSybIiEkAC4FanLACcAFIwD6ASxbAAvsQAeiAMwBdAJRxgjAIxxEAFgB0ABmJgArNdsA2a9tuMATKYDsjsAA4-AE5XZUheCGVeVV5qclwGIlIaKEo0CLoGZjZ2BRYeFIh+BhExSRk8lX1DLyNrMIyojBiMOMwEwSSMinw28npBRgBDHBwCFll2LCwAawBXPGTC4sFOOcYZVg5OACpsjjziOUVdcJSm1BbUPqgOwgK+NJuigahOdnkAYy7C+8FNnK7fa5E6GPJwTwNc7RFDaEDKIA">
+  Tensor Playground</a>.' %}

--- a/en/tensor-user-guide.html
+++ b/en/tensor-user-guide.html
@@ -6,15 +6,15 @@ redirect_from:
 ---
 
 <p>
-Vespa provides a <i>tensor</i> data model and computation engine to support advanced computations over data,
+Vespa provides a <em>tensor</em> data model and computation engine to support advanced computations over data,
 such as neural nets.
 This guide explains the tensor support in Vespa. See also the <a href="reference/tensor.html">tensor reference</a>,
 and our <a href="https://dl.acm.org/doi/10.1145/3459104.3459152">published paper</a>
 (<a href="a_tensor_formalism_for_computer_science.pdf">pdf</a>).
 </p>
-
-<p>Content:</p>
-
+<p>
+  Content:
+</p>
 <ul>
     <li><a href="#tensor-concepts">Tensor concepts</a>
     <li><a href="#tensor-document-fields">Tensor document fields</a>
@@ -23,16 +23,16 @@ and our <a href="https://dl.acm.org/doi/10.1145/3459104.3459152">published paper
     <li><a href="#ranking-with-tensors">Ranking with tensors</a>
     <li><a href="#creating-tensors-from-document-fields">Creating tensors from document fields</a>
     <li><a href="#constant-tensors">Constant tensors</a>
-    <li><a href="#performance-considerations">Performance considerations</a>
 </ul>
 
 <p>See also:</p>
 <ul>
-    <li><a href="onnx.html">Using ONNX models</a> to use machine-learned models taking tensor input in Vespa.
-    <li>Some <a href="tensor-examples.html">examples of practical tensor computations</a>.
-    <li><a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QGNIAaFDSPBdDTAF30gAkBTAJ2bAE8sBXMAgIYA7MDgA2AzmAGteQgCbSFYZgA8cbAJYBbZkNpgA7ptoALMLT0BnLKytLFloTdYr17K1c1ZnAOjAs7GCa9gJgVqa2BgA6QmoC2uLMxFy8-MJg0JrK2rYc2dC22gK03iIlYLGIZhxOLmA8VmxgAOY8mvLMALoAFKa0tDhWcAD0I-JYBFa+AG7MVjgCvgKaI3ojdbYAtI1sW20dzL792mIAlJBkqAC+V9ekGNTkuAxEDzQU+E8f9AiQAIIWay2YKhMDyEphKy0Vg8Ai0HhBMwVELSVp6NgCMSaABeJTKYCw0HCggkdhSc3htlCORKrE0BHm-liABVgXYwKYBHM0UIeNoAEbNIngnTWMr2ZEGQQiIUqEymZqdZwcEELGRNQmuMIELCC7L4ny+WL-ETxRJiVXEqGLOy1dlwS40MC3DD3K7fCDYShQZgkK5en2ezBCBjqu0AfU2rH9zq9fr+0Z6qmA1zOcGAAjgAEZiAK4AAma5Omium7vCDB72vWMfIMBugMQHKzXRowKiyGLCi3TOCUpTS+I5o4owzSqR0NssQd2PBvVv5+iuYetxqChv4t5hR9m152QBNQJOqRAFrrETiIADMXXTiEQuYLxBvxEQABZiABWYgANi6XRLN07mXKsXj+N551XONIF+KA2Wcal0hELkeQFLAzHCW1NWERQtx7cUfCsFIPB4MRSiEFpgnKMBtHHZhHHZfxAg4YwMJqMAAANoDELASg42IIVoMJaE4DRJ2dacXRA+cwN9PcVy+BsvQ3KBaNUeidwQmNl3IQ8YPZAAebjeNoAA+ZNUwva9bwzLMH2IJ8X3zd8v1-LpiynYCPRkn1IAg-coP3WDIHglx7BQjgoWYAwRVwTFSkI6QxB44wKMyEEwnkTQ5jtcJosJYldUSHghISoR-AAMRBbJoWERkUjCDiACssGyDjxNLLy533WSD3kwNFLXSAVMgfrMD0lrsh6cMmk0lwUjUjToxSaAegEPMzjWgAqAUzguTy3WknrfP8utBug4KWVMVFUWYABHdoZixPQDFoLAOqAw7vOOhgl0g879xGsb4zDLDtzbLaaLo+Q5tsQCbi61BQJOsbPioJSjwYKrXFyIJzSSIi8o4RAJimWZ5kWZZVnWaMtnxy1phOMRen6QZhjGUnpjmdUqbWIQNnZOnVASAnjloU59oku4UC6EBriAA">tensor playground</a>
-which allows you to create and compute with tensors in your browser.
-    <li>The <a href="https://javadoc.io/doc/com.yahoo.vespa/vespajlib/latest/com/yahoo/tensor/Tensor.html">Tensor Java API</a>.
+  <li><a href="onnx.html">Using ONNX models</a> to use machine-learned models taking tensor input in Vespa.</li>
+  <li>Some <a href="tensor-examples.html">examples of practical tensor computations</a>.</li>
+  <li><a href="https://docs.vespa.ai/playground/#N4KABGBEBmkFxgNrgmUrWQPYAd5QGNIAaFDSPBdDTAF30gAkBTAJ2bAE8sBXMAgIYA7MDgA2AzmAGteQgCbSFYZgA8cbAJYBbZkNpgA7ptoALMLT0BnLKytLFloTdYr17K1c1ZnAOjAs7GCa9gJgVqa2BgA6QmoC2uLMxFy8-MJg0JrK2rYc2dC22gK03iIlYLGIZhxOLmA8VmxgAOY8mvLMALoAFKa0tDhWcAD0I-JYBFa+AG7MVjgCvgKaI3ojdbYAtI1sW20dzL792mIAlJBkqAC+V9ekGNTkuAxEDzQU+E8f9AiQAIIWay2YKhMDyEphKy0Vg8Ai0HhBMwVELSVp6NgCMSaABeJTKYCw0HCggkdhSc3htlCORKrE0BHm-liABVgXYwKYBHM0UIeNoAEbNIngnTWMr2ZEGQQiIUqEymZqdZwcEELGRNQmuMIELCC7L4ny+WL-ETxRJiVXEqGLOy1dlwS40MC3DD3K7fCDYShQZgkK5en2ezBCBjqu0AfU2rH9zq9fr+0Z6qmA1zOcGAAjgAEZiAK4AAma5Omium7vCDB72vWMfIMBugMQHKzXRowKiyGLCi3TOCUpTS+I5o4owzSqR0NssQd2PBvVv5+iuYetxqChv4t5hR9m152QBNQJOqRAFrrETiIADMXXTiEQuYLxBvxEQABZiABWYgANi6XRLN07mXKsXj+N551XONIF+KA2Wcal0hELkeQFLAzHCW1NWERQtx7cUfCsFIPB4MRSiEFpgnKMBtHHZhHHZfxAg4YwMJqMAAANoDELASg42IIVoMJaE4DRJ2dacXRA+cwN9PcVy+BsvQ3KBaNUeidwQmNl3IQ8YPZAAebjeNoAA+ZNUwva9bwzLMH2IJ8X3zd8v1-LpiynYCPRkn1IAg-coP3WDIHglx7BQjgoWYAwRVwTFSkI6QxB44wKMyEEwnkTQ5jtcJosJYldUSHghISoR-AAMRBbJoWERkUjCDiACssGyDjxNLLy533WSD3kwNFLXSAVMgfrMD0lrsh6cMmk0lwUjUjToxSaAegEPMzjWgAqAUzguTy3WknrfP8utBug4KWVMVFUWYABHdoZixPQDFoLAOqAw7vOOhgl0g879xGsb4zDLDtzbLaaLo+Q5tsQCbi61BQJOsbPioJSjwYKrXFyIJzSSIi8o4RAJimWZ5kWZZVnWaMtnxy1phOMRen6QZhjGUnpjmdUqbWIQNnZOnVASAnjloU59oku4UC6EBriAA">tensor playground</a>
+    which allows you to create and compute with tensors in your browser.</li>
+  <li>The <a href="https://javadoc.io/doc/com.yahoo.vespa/vespajlib/latest/com/yahoo/tensor/Tensor.html">Tensor Java API</a>.</li>
+  <li><a href="performance/feature-tuning.html#tensor-ranking">Tensor ranking performance</a>.</li>
 </ul>
 
 <h2 id="tensor-concepts">Tensor concepts</h2>
@@ -244,145 +244,3 @@ would be undefined for such "tensors". However, you can still represent sets of 
 by using the strings as keys in a mapped tensor dimensions, using e.g 1.0 as values.
 This allows you to perform set operations on strings and similar without making those tensors
 incompatible with other tensors and with normal tensor operations.</p>
-
-
-
-<h2 id="using-a-tensor-as-a-lookup-structure">Using a tensor as a lookup structure</h2>
-<p>
-  Tensors with mapped dimensions look similar to maps, but are more general.
-  What if all needed is a simple map lookup?
-  Assume a tensor attribute <code>my_map</code> and this is the value for a specific document:
-</p>
-<pre>
-attribute(my_map) -&gt; tensor&lt;float&gt;(x{},y[3]):{a:[1,2,3],b:[4,5,6],c:[7,8,9]}
-</pre>
-<p>
-  To create a query to select which of the 3 named vectors (a,b,c) to use for some other calculation,
-  wrap the wanted label to look up inside a tensor:</p>
-<pre>
-query(my_key) -&gt; tensor&lt;float&gt;(x{}):{b:1.0}     // I want the b vector
-</pre>
-<p>Do the lookup:</p>
-<pre>
-reduce(query(my_key)*attribute(my_map),sum,x)   // -&gt; tensor of type tensor&lt;float&gt;(y[3])
-</pre>
-<p>
-  If the key does not match anything, the result will be empty: <code>tensor&lt;float&gt;(y[3]):[0,0,0]</code>.
-  For something else, add a check up-front to check if the lookup will be successful
-  and run a fallback expression if it is not, like:
-</p>
-<pre>
-if(reduce(query(my_key)*attribute(my_map),count) == 3,
-  reduce(query(my_key)*attribute(my_map),sum,x),
-  tensor&lt;float&gt;(y[3]):[0.5,0.5,0.5])
-</pre>
-
-
-
-<h2 id="performance-considerations">Performance considerations</h2>
-
-<p>Tensor expressions are fairly concise, and since the expressions themselves
-are independent of the data size, the actual workload during ranking can be significant
-for large tensors.</p>
-
-<p>When using tensors in ranking it is important to have an understanding of the
-potential computational cost for each query. As an example, assume
-the dot product of two tensors with 1000 values each, e.g. <code>tensor&lt;double&gt;(x[1000])</code>.
-Assuming one query tensor and one document tensor, the operation is:
-</p>
-<pre>
-sum(query(tensor1) * attribute(tensor2))
-</pre>
-<p>
-If 8 bytes is used to store each value (e.g. using a double), each tensor is approximately 8 KB.
-With for instance Haswell architecture,
-the theoretical upper memory bandwidth is 68 GB/s, which is around 9 million
-document ranking evaluations per second.
-With 1 million documents, this means the maximum throughput, in regard to pure memory bandwidth,
-is 9 queries per second (per node).
-</p><p>
-Even though you would typically not do the above without reducing the
-search space first (using matching and first phase), it is important to consider
-the memory bandwidth and other hardware limitations when developing ranking expressions with tensors.
-</p>
-<p>
-When using tensor types with at least one mapped dimension (sparse or mixed tensor),
-<a href="reference/schema-reference.html#attribute">attribute: fast-rank</a>
-can be used to optimize the tensor attribute for ranking expression evaluation at the cost of using more memory.
-This is a trade-off that can be worth taking if benchmarking indicates significant latency improvements with <code>fast-rank</code>.
-</p>
-
-<h3 id="cell-value-types">Performance considerations for cell value types</h3>
-<table class="table">
-  <tr>
-    <th>double</th>
-    <td>
-      <p id="double">
-      The 64-bit floating-point "double"
-      format is the default cell type.  It gives best precision at
-      the cost of high memory usage and somewhat slower calculations.
-      Using a smaller value type increases performance, trading off
-      precision, so consider changing to one of the cell types below
-      before scaling your application.
-      </p>
-    </td>
-  </tr><tr>
-    <th>float</th>
-    <td>
-      <p id="float">
-      The usual 32-bit floating-point format "float" should usually
-      be used for all tensors when scaling for production.
-      (Note that other frameworks, like tensorflow, will also prefer 32-bit floats.)
-      A vector with 1000 dimensions, <code>tensor&lt;float&gt;(x[1000])</code> would then
-      use approx 4K memory per tensor value.
-      </p>
-    </td>
-  </tr><tr>
-    <th>bfloat16</th>
-    <td>
-      <p id="bfloat16">
-      If memory (or memory bandwidth) is still a concern, it's
-      possible to change the most space-consuming tensors to use
-      the <code>bfloat16</code> cell type.  This type has the range
-      as a normal 32-bit float but only 8 bits of precision, and
-      can be thought of as "float with lossy compression".  See also
-      <a href="https://en.wikipedia.org/wiki/Bfloat16_floating-point_format">bfloat16
-      floating-point format</a> on Wikipedia.  Some careful analysis
-      of your data is required before using this type.
-      </p><p>
-      Note that when doing calculations <code>bfloat16</code> will act as if
-      it was a 32-bit float, but the smaller size comes with a potential
-      computation overhead. In most cases, the <code>bfloat16</code> needs
-      to be converted to a 32-bit float before the actual calculation can
-      take place; adding an extra conversion step.
-      </p><p>
-      In some cases, having tensors with <code>bfloat16</code> cells might
-      bypass some build-in optimizations in the back-end (like matrix
-      multiplication) that will be hardware accelerated only if the cells
-      are the same type.  To avoid this last case, you can use the
-      <a href="reference/ranking-expressions.html#cell_cast">cell_cast</a>
-      tensor operation to make sure the cells are of the
-      appropriate type before doing the more expensive operations.
-      </p>
-    </td>
-  </tr><tr>
-    <th>int8</th>
-    <td>
-      <p id="int8">
-      If one uses machine-learning to generate a model with data
-      quantization you can target the <code>int8</code> cell value
-      type, which is a signed integer with range from -128 to +127 only.
-      This is also treated like a "float with limited range and lossy
-      compression" by the Vespa tensor framework, and gives results as if it
-      was a 32-bit float when any calculation is done.  This type is also
-      suitable when representing boolean values (0 or 1).  Note that if the input
-      for an <code>int8</code> cell is not directly representable, the
-      resulting cell value is undefined, so you should take care to only
-      input numbers in the <code>[-128,127]</code> range.
-      It's also possible to use <code>int8</code> representing binary
-      data for <a href="reference/schema-reference.html#distance-metric">hamming distance</a>
-      Nearest-Neighbor search.
-      </p>
-    </td>
-  </tr>
-</table>


### PR DESCRIPTION
- This PR puts the tensor performance together with the other tuning sections
- Put mapped lookup in the examples doc -> now easier to clean up the tensor guide doc
- First cut tensor execution examples. This needs more work, like how the enable/observe in trace, etc
- Some typos fixed

... or @lesters 