### PR TITLE
Remove doc for non-func Vespa-7 config MERGEOK

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -36,7 +36,6 @@ redirect_from:
                                 <a href="#flushstrategy-native-component-diskbloatfactor">diskbloatfactor</a>
                                 <a href="#flushstrategy-native-component-maxage">maxage</a>
                             <a href="#flushstrategy-native-transactionlog">transactionlog</a>
-                                <a href="#flushstrategy-native-transactionlog-maxentries">maxentries <strong>DEPRECATED</strong></a>
                                 <a href="#flushstrategy-native-transactionlog-maxsize">maxsize</a>
                             <a href="#flushstrategy-native-conservative">conservative</a>
                                 <a href="#flushstrategy-native-conservative-memory-limit-factor">memory-limit-factor</a>
@@ -78,7 +77,6 @@ redirect_from:
                                 <a href="#summary-store-logstore-maxfilesize">maxfilesize</a>
                                 <a href="#summary-store-logstore-chunk">chunk</a>
                                     <a href="#summary-store-logstore-chunk-maxsize">maxsize</a>
-                                    <a href="#summary-store-logstore-chunk-maxentries">maxentries</a>
                                     <a href="#summary-store-logstore-chunk-compression">compression</a>
                                         <a href="#summary-store-logstore-chunk-compression-type">type</a>
                                         <a href="#summary-store-logstore-chunk-compression-level">level</a>
@@ -798,11 +796,6 @@ Optional sub-elements:
         </ul>
         </li><li id="flushstrategy-native-transactionlog"><code>transactionlog</code>
         <ul>
-            <li id="flushstrategy-native-transactionlog-maxentries"><code>maxentries</code>:
-            The maximum number of entries in the <a href="../proton.html#transaction-log">transaction log</a>
-            for a document type before running flush, default 1000000 (1 M).
-            {% include deprecated.html content="use <code>maxsize</code> instead."%}
-            </li>
             <li id="flushstrategy-native-transactionlog-maxsize"><code>maxsize</code>:
             The total maximum size (in bytes) of <a href="../proton.html#transaction-log">transaction logs</a>
             for all document types before running flush, default 21474836480 (20 GB)
@@ -1095,11 +1088,6 @@ proton.def</a> to look for parameter values and defaults. Optional sub-elements:
             <ul>
               <li id="summary-store-logstore-chunk-maxsize"><code>maxsize</code>:
                 Maximum size (in bytes) of a chunk. See <em>summary.log.chunk.maxbytes</em></li>
-              <li id="summary-store-logstore-chunk-maxentries"><code>maxentries</code>:
-                Maximum number of documents in a chunk.
-                See <em>summary.log.chunk.maxentries</em>.
-                {% include deprecated.html content="use <code>maxsize</code> instead."%}
-              </li>
               <li id="summary-store-logstore-chunk-compression"><code>compression</code>
                 <ul>
                   <li id="summary-store-logstore-chunk-compression-type"><code>type</code>:

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -462,7 +462,7 @@ The following defaults have changed:
     <td>Client bindings are no longer supported.
   </tr>
   <tr>
-    <td rowspan="3">&lt;content&gt;</td>
+    <td rowspan="5">&lt;content&gt;</td>
     <td>&lt;dispatch&gt;</td>
     <td>Removed due to removal of <em>vespa-dispatch-bin</em>,
       <a href="#vespa-dispatch-bin-process-is-removed">details.</a></td>
@@ -474,6 +474,24 @@ The following defaults have changed:
   <tr>
     <td>&lt;tuning&gt;&lt;dispatch&gt;&lt;use-local-node&gt;</td>
     <td>Ignored, the local node will automatically be preferred when appropriate.</td>
+  </tr>
+  <tr>
+    <td>&lt;engine&gt;&lt;proton&gt;&lt;tuning&gt;&lt;searchnode&gt;&lt;flushstrategy&gt;&lt;native&gt;&lt;transactionlog&gt;&lt;maxentries&gt;</td>
+    <td>
+      Use <a href="reference/services-content.html#flushstrategy-native-transactionlog-maxsize">maxsize</a> instead.
+      Vespa 7 documentation:
+      The maximum number of entries in the <a href="../proton.html#transaction-log">transaction log</a>
+      for a document type before running flush, default 1000000 (1 M).
+    </td>
+  </tr>
+  <tr>
+    <td>&lt;engine&gt;&lt;proton&gt;&lt;tuning&gt;&lt;searchnode&gt;&lt;summary&gt;&lt;store&gt;&lt;logstore&gt;&lt;chunk&gt;&lt;maxentries&gt;</td>
+    <td>
+      Use <a href="reference/services-content.html#summary-store-logstore-chunk-maxsize">maxsize</a> instead.
+      Vespa 7 documentation:
+      Maximum number of documents in a chunk.
+      See <em>summary.log.chunk.maxentries</em>.
+    </td>
   </tr>
   <tr>
     <td rowspan="3">&lt;services&gt; (root)</td>

--- a/en/vespa8-release-notes.html
+++ b/en/vespa8-release-notes.html
@@ -480,7 +480,7 @@ The following defaults have changed:
     <td>
       Use <a href="reference/services-content.html#flushstrategy-native-transactionlog-maxsize">maxsize</a> instead.
       Vespa 7 documentation:
-      The maximum number of entries in the <a href="../proton.html#transaction-log">transaction log</a>
+      The maximum number of entries in the <a href="proton.html#transaction-log">transaction log</a>
       for a document type before running flush, default 1000000 (1 M).
     </td>
   </tr>


### PR DESCRIPTION
- For some reason, these were not in the vespa8 release notes - I have verified that deployment fails if using any of the two on Vespa 8, so they are gone
- I kept the few Vespa 7 doc lines just for reference, in case people search for this / upgrade - but moved them to the release notes