### PR TITLE
First cut live query automation

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -47,27 +47,6 @@ jobs:
             --hydra '{"max_concurrency": 1}' \
             _site
 
-  check-live-queries:
-    requires: [~pr, ~commit]
-    image: vespaengine/vespa-build-centos-stream8:latest
-    annotations:
-      screwdriver.cd/cpu: HIGH
-      screwdriver.cd/ram: HIGH
-      screwdriver.cd/dockerEnabled: true
-      screwdriver.cd/dockerCpu: HIGH
-      screwdriver.cd/dockerRam: HIGH
-      screwdriver.cd/buildPeriodically: H H(0-5) * * 1-5 # some time between 12:00 AM UTC (midnight) to 5:59 AM UTC Mon-Fri
-    steps:
-      - *install-deps-new
-      - install-bundler: |
-          gem install bundler
-          export LANG=C.UTF-8
-          bundle install
-      - build-site: |
-          bundle exec jekyll build
-      - check-queries: |
-          ./test/test_queries.py _site
-
   verify-guides:
     requires: [~pr, ~commit]
     image: vespaengine/vespa-build-centos-stream8:latest

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -47,6 +47,31 @@ jobs:
             --hydra '{"max_concurrency": 1}' \
             _site
 
+  check-live-queries:
+    requires: [~pr, ~commit]
+    image: vespaengine/vespa-build-centos-stream8:latest
+    annotations:
+      screwdriver.cd/cpu: HIGH
+      screwdriver.cd/ram: HIGH
+      screwdriver.cd/dockerEnabled: true
+      screwdriver.cd/dockerCpu: HIGH
+      screwdriver.cd/dockerRam: HIGH
+      screwdriver.cd/buildPeriodically: H H(0-5) * * 1-5 # some time between 12:00 AM UTC (midnight) to 5:59 AM UTC Mon-Fri
+    steps:
+      - *install-deps-new
+      - install-bundler: |
+          gem install bundler
+      - check-links: |
+          export LANG=C.UTF-8
+          bundle install
+          bundle exec jekyll build
+          #
+          # Remove the redirect-files before query-check
+          find _site/en _site/documentation -name \*.html | \
+            xargs grep -l "Click here if you are not redirected." | xargs rm
+      - check-queries: |
+          ./test/test_queries.py _site
+
   verify-guides:
     requires: [~pr, ~commit]
     image: vespaengine/vespa-build-centos-stream8:latest

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -61,9 +61,9 @@ jobs:
       - *install-deps-new
       - install-bundler: |
           gem install bundler
-      - check-links: |
           export LANG=C.UTF-8
           bundle install
+      - build-site: |
           bundle exec jekyll build
           #
           # Remove the redirect-files before query-check

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -65,10 +65,6 @@ jobs:
           bundle install
       - build-site: |
           bundle exec jekyll build
-          #
-          # Remove the redirect-files before query-check
-          find _site/en _site/documentation -name \*.html | \
-            xargs grep -l "Click here if you are not redirected." | xargs rm
       - check-queries: |
           ./test/test_queries.py _site
 
@@ -84,6 +80,14 @@ jobs:
       screwdriver.cd/buildPeriodically: H H(0-5) * * 1-5 # some time between 12:00 AM UTC (midnight) to 5:59 AM UTC Mon-Fri
     steps:
       - *install-deps-new
+      - install-bundler: |
+          gem install bundler
+          export LANG=C.UTF-8
+          bundle install
+      - build-site: |
+          bundle exec jekyll build
+      - check-queries: |
+          ./test/test_queries.py _site
       - run-tests: |
           cd $SD_DIND_SHARE_PATH
           $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config.yml -w $SD_SOURCE_DIR

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -1,0 +1,55 @@
+#! /usr/bin/env python3
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+import os
+import sys
+import re
+import requests
+from urllib.parse import quote
+from bs4 import BeautifulSoup
+
+links = set()
+
+
+def extract_links(filename):
+    with open(filename) as fp:
+        soup = BeautifulSoup(fp, 'html.parser')
+        for anchor in soup.find_all('a', {"class": "docsearch-x"}):
+            sanitized_query = re.sub('\n', '', anchor.text)
+            links.add('https://doc-search.vespa.oath.cloud/search/?yql=' + quote(sanitized_query))
+        for anchor in soup.find_all('a', {"class": "cord19-x"}):
+            sanitized_query = re.sub('\n', '', anchor.text)
+            links.add('https://api.cord19.vespa.ai/search/?yql=' + quote(sanitized_query))
+
+
+def get_links(directory):
+    print("Scanning files in {}".format(directory))
+    for root, dirs, files in os.walk(directory):
+        for filename in files:
+            if filename.endswith('.html'):
+                extract_links(os.path.join(root, filename))
+
+
+def check_total_count(query):
+    r = requests.get(query)
+    d = r.json()
+    total_count = d["root"]["fields"]["totalCount"]
+    print("{0} results for {1}".format(total_count, query))
+    return total_count > 0
+
+
+def main():
+    if len(sys.argv) <= 1:
+        sys.exit(("Missing directory argument"))
+    directory = sys.argv[1]
+    if not os.path.exists(directory):
+        sys.exit(("{} does not exist".format(directory)))
+    get_links(directory)
+    print("Checking queries: {}".format(links))
+    for query in links:
+        if not check_total_count(query):
+            sys.exit("Query failed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Go through all anchors of class `docsearch-x` or `cord19-x` and test the queries
- See https://docs.vespa.ai/en/query-language.html for such queries

With this, we can write clear-text queries in the documentation, that is auto formatted to clickable links, and auto-tested, too - we should rewrite more of the docs to use these, so we know the queries work

FYI @jobergum 