### PR TITLE
Fix query examples / link from reference

### DIFF
--- a/en/query-language.html
+++ b/en/query-language.html
@@ -19,70 +19,69 @@ redirect_from:
 <p>
   The following are live YQL examples:
 </p>
-
+<hr/>
+<p>
+  Selection: Select all documents from the <code>doc</code> source.
+  This is the easiest way to count all documents in a source:
+</p>
 <p><a class="docsearch-x">select * from doc where true</a></p>
-<p>
-  Selection: Select all documents from the "doc" source.
-  This is the easiest way to count all documents in a source.
-</p>
+<hr/>
 
+<p>Filtering: Find all documents with <code>ranking</code> in the <code>title</code> field:</p>
 <p><a class="docsearch-x">select * from doc where title contains "ranking"</a></p>
-<p>
-  Filtering: Find all documents with "ranking" in the "title" field.
-</p>
+<hr/>
 
+<p>Filtering: Find all documents with <code>ranking</code> in the <code>default</code> <a href="schemas.html#fieldset">fieldset</a>.</p>
 <p><a class="docsearch-x">select * from doc where default contains "ranking"</a></p>
-<p>
-  Filtering: Find all documents with "ranking" in the "default" <a href="schemas.html#fieldset">fieldset</a>.
-</p>
+<hr/>
 
+<p>Ordering: Order by number of terms in the document, descending.</p>
 <p><a class="docsearch-x">select * from doc where true order by term_count desc</a></p>
-<p>
-  Ordering: Order by number of terms in the document, descending.
-</p>
+<hr/>
 
+<p>Pagination: Select all documents, return hits 6-15.</p>
 <p><a class="docsearch-x">select * from doc where true limit 15 offset 5</a></p>
-<p>
-  Pagination: Select all documents, return hits 6-15.
-</p>
+<hr/>
 
+<p>Grouping:</p>
+<ul>
+  <li>Select all documents from the <code>doc</code> source.</li>
+  <li>Group by term count in buckets of 100, display average term count per bucket.</li>
+  <li>Note on <code>limit 0</code>: This returns zero regular hits, only the grouping result.</li>
+</ul>
 <p><a class="docsearch-x">select * from doc where true limit 0 |
   all(
     group( fixedwidth(term_count,100) )
     each( output( avg(term_count) ) )
   )</a></p>
-<p>
-  Grouping:
-</p>
-<ul>
-  <li>Select all documents from the "doc" source.</li>
-  <li>Group by term count in buckets of 100, display average term count per bucket.</li>
-  <li>Note "limit 0": This will return 0 regular hits, so only the grouping result.</li>
-</ul>
-<p>
-  Find more <a href="grouping.html">grouping examples</a>.
-</p>
+<p>Find more <a href="grouping.html">grouping examples</a>.</p>
+<hr/>
 
+<p>Numeric: Select documents with attribute "last_updated" > 1646167144:</p>
 <p><a class="docsearch-x">select * from doc where last_updated > 1646167144</a></p>
 <p>
-  Numeric: Select documents with attribute "last_updated" > 1646167144.
+  Numeric: Select documents with integer in field - works both for single-value fields and multivalue,
+  like array&lt;int&gt;:
 </p>
+<p><a class="docsearch-x">select * from doc where term_count = 1083</a></p>
+<hr/>
 
+<p>Phrase: Select documents with the phrase "question answering":</p>
 <p><a class="docsearch-x">select * from doc where default contains phrase("question","answering")</a></p>
-<p>
-  Phrase: Select documents with the phrase "question answering".
-</p>
+<hr/>
 
-<p><a class="docsearch-x">select * from doc where true timeout 100</a></p>
 <p>
   Timeout: Time out query execution after 100 ms, returning hits found before timing out -
-  see <a href="reference/query-api-reference.html#ranking.softtimeout.enable">ranking.softtimeout.enable</a>.
+  see <a href="reference/query-api-reference.html#ranking.softtimeout.enable">ranking.softtimeout.enable</a>:
 </p>
+<p><a class="docsearch-x">select * from doc where true timeout 100</a></p>
+<hr/>
 
-<p><a class="docsearch-x">select * from doc where namespace matches "op.*"</a></p>
 <p>
-  Regular expressions: Select documents matching the regular expression in the "namespace" attribute field.
-</p>
+  Regular expressions: Select documents matching the regular expression
+  in the <code>namespace</code> <a href="attributes.html">attribute</a> field:</p>
+<p><a class="docsearch-x">select * from doc where namespace matches "op.*"</a></p>
+<hr/>
 
 
 <h3 id="command-line-queries">Command-line queries</h3>

--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1,6 +1,6 @@
 ---
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-title: "Query Language Reference"
+title: "YQL Query Language Reference"
 redirect_from:
 - /documentation/reference/query-language-reference.html
 ---
@@ -9,13 +9,16 @@ redirect_from:
 Vespa accepts unstructured human input and structured queries for application logic separately,
 then combines them into a single data structure for executing.
 Human input is parsed heuristically, while application queries are formulated in YQL.
-</p><p>
+</p>
+{% include note.html content='See the <a href="../query-language.html">Query Language Guide</a>
+for query examples'%}
+<p>
 A query URL looks like:
 </p>
 <pre>
 http://myhost.mydomain.com:8080/search/?yql=select%20%2A%20from%20sources%20%2A%20where%20text%20contains%20%22blues%22
 </pre>
-<p>In other words, <em>yql</em> contains:</p>
+<p>In other words, <code>yql</code> contains:</p>
 <pre>
 select * from sources * where text contains "blues"
 </pre>
@@ -24,12 +27,15 @@ This <a href="schema-reference.html#match">matches</a> all documents
 where the field named <em>text</em> contains the word <em>blues</em>.
 </p>
 <p>
-  Quote <code>"</code> and backslash <code>\</code> characters in text values must be escaped by a backslash.
+  Quote <code>"</code> and backslash <code>\</code> characters in text values must be escaped by a backslash,
+  also see <a href="../faq.html#how-does-backslash-escapes-work">how does backslash escapes work</a>.
 </p>
 {% include important.html content='There is no way to query for a field that is not set
 / equals <code>null</code> or <code>NaN</code>.
 Work around using a "magic" value (like MAXINT) that is not normally used in the documents.'%}
-{% include note.html content="Since Vespa 7.520.3, YQL queries do not require a semicolon at the end."%}
+<p>
+  Since Vespa 7.520.3, YQL queries do not require a semicolon at the end.
+</p>
 
 
 
@@ -327,7 +333,7 @@ field identities type map&lt;string, person&gt; {
             <em>AND</em> any element with a matching <em>last_name</em>.
             So you will get a lot of false positives since there is nothing limiting them to the same element.
             However, that is what <em>sameElement</em> ensures. Note that <em>sameElement</em> uses
-	    <em>AND</em> to connect the operands. To use <em>OR</em>, use multiple sameElement operators using logical OR. 
+	    <em>AND</em> to connect the operands. To use <em>OR</em>, use multiple sameElement operators using logical OR.
           </p>
 <pre>
 where persons contains sameElement(first_name contains 'Joe', last_name contains 'Smith', year_of_birth < 1940)


### PR DESCRIPTION
- we can add more examples to this
- js/query_examples autocreates a link to correct live search backend, and we can also use this to autogenerate a nicer style, too
- anchors of class `docsearch-x` and the likes are also auto-tested