### PR TITLE
Fix typo in scaling law documentation page

### DIFF
--- a/en/performance/sizing-search.html
+++ b/en/performance/sizing-search.html
@@ -642,7 +642,7 @@ By sampling these metrics,
 one can calculate the theoretical speedup we can achieve by increasing number of nodes using flat distribution,
 by using <em>Amdahl's law</em>:
 </p><p><!-- depends on mathjax -->
-  $$\text{max_speedup}_{\text{}} = \frac{1}{1 - \frac{query\_setup\_time}{query\_setup\_time+match\_time}}$$
+  $$\text{max_speedup}_{\text{}} = \frac{1}{1 - \frac{match\_time}{query\_setup\_time+match\_time}}$$
 </p><p>
 In addition, the following metrics are used to find number of matches per query, per node:
 <pre>


### PR DESCRIPTION
Amdahl's law is 1/(1-DQW/(DQW+SQW)) and not 1/(1-SQW/(DQW+SQW)) but DQW is match_time and SQW is query_setup_time

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
