### PR TITLE
Install dependencies take 2

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -132,9 +132,9 @@ jobs:
     environment:
        GIT_SSH_COMMAND: "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
     steps:
-      - *install-deps-new
       - update-to-latest: |
-          python3 -m pip install -qqq requests --user
+          apt-get update && apt-get -y install python3-pip
+          python3 -m pip install -qqq requests pyaml --user
           # must checkout the repo again using ssh for the credentials to work
           cat << EOF > pushtogit.sh
             #!/bin/bash


### PR DESCRIPTION
install-deps-new does not work on buildpack-deps

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
