### PR TITLE
Simplify doc for group changes

### DIFF
--- a/en/elasticity.html
+++ b/en/elasticity.html
@@ -137,14 +137,35 @@ redirect_from:
 </tbody>
 </table>
 <p>
-  Data redistribution after changing cluster topology is automatic,
-  However, if you change between a grouped and non-grouped configuration,
-  there will be a period of reduced query coverage during the transition.
-  Read more in <a href="performance/sizing-examples.html">sizing examples</a>.
-</p>
-<p>
   Tuning group sizes and node resources enables applications to easily find the latency/cost sweet spot,
   the elasticity operations are automatic and queries and writes work as usual with no downtime.
+</p>
+
+
+<h3 id="topology-change">Topology change</h3>
+<p>
+  A great elasticity feature is the ability to change topology without service disruption.
+  This is a live change, and will auto-redistribute documents to the new topology.
+  If full query coverage is required during the transition,
+  make sure that there is always one or more "full" group(s):
+</p>
+<ol>
+  <li>Generally, do not move current nodes to new groups.</li>
+  <li>If starting from non-grouped, configure the current nodes in one group and new nodes is a new group.</li>
+  <li>
+    If changing both node count within group and group count, keep the current nodes in the current groups.
+  </li>
+</ol>
+<p>
+  It is possible to stage a migration in two steps:
+</p>
+<ol>
+  <li>Expand or shrink number of nodes within groups.</li>
+  <li>Add or remove groups.</li>
+</ol>
+<p>
+  A common way to increase capacity is then to add more nodes to existing groups,
+  wait for re-distribution to complete, then add groups.
 </p>
 
 

--- a/en/performance/sizing-examples.html
+++ b/en/performance/sizing-examples.html
@@ -6,16 +6,14 @@ redirect_from:
 ---
 
 <p>
-  This document has a set of example configurations
-  for content clusters using flat or grouped data distribution.
+  This guide has a set of example configurations for content clusters using flat or grouped data distribution.
   Data is distributed over nodes and groups
   using a Vespa's <a href="../reference/services-content.html#distribution">distribution algorithm</a>.
   See <a href="sizing-search.html">Scaling Vespa</a> for when to use grouped or flat data distribution.
   These examples illustrate common deployment patterns.
   In all examples, the number of stateless <a href="../jdisc/">container</a> nodes is fixed.
-  The examples are <em>services.xml</em> deployed using
+  The examples are <a href="../reference/services-content.html">services.xml</a> deployed using
   <a href="../application-packages.html">Application Packages</a>.
-  See <a href="../reference/services-content.html">services.xml - 'content' element</a> reference documentation.
 </p>
 <p>
   Refer to the <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA">
@@ -28,11 +26,9 @@ redirect_from:
 
 <h2 id="flat-distribution">Flat Distribution</h2>
 <p>
-  Flat (single group) distribution with <em>redundancy</em> 3 and <em>searchable-copies</em> 1.
-  Data is distributed and partitioned over 9 nodes and there are 3 copies of each document stored on 3 different nodes.
-  Queries are dispatched in parallel to all nodes, and with <em>searchable-copies</em> 1,
-  only one of the 3 copies of a document is indexed and active.
-  This means less resource usage (memory, disk, and cpu).
+  Flat (single group) distribution with <a href="../reference/services-content.html#min-redundancy">min-redundancy</a>=3.
+  Data is distributed and partitioned over 9 nodes and there are 3 replicas of each document, stored on 3 different nodes.
+  Queries are dispatched in parallel to all nodes.
   In case of a node failure, the remaining nodes will index (make ready)
   and activate the <em>not ready</em> (stored) copies to restore full search coverage.
 </p>
@@ -63,12 +59,7 @@ redirect_from:
         <documents>
             <document type="music" mode="index"/>
         </documents>
-        <redundancy>3</redundancy>
-        <engine>
-            <proton>
-                <searchable-copies>1</searchable-copies>
-            </proton>
-        </engine>
+        <min-redundancy>3</min-redundancy>
         <nodes>
             <node hostalias="node0" distribution-key="0"/>
             <node hostalias="node1" distribution-key="1"/>
@@ -93,13 +84,9 @@ redirect_from:
 <ul>
   <li>There can only be a single level of leaf groups under the top group</li>
   <li>Each leaf group must have the same number of nodes </li>
-  <li>The number of leaf groups must be a factor of the
-      <a href="../reference/services-content.html#redundancy">redundancy</a></li>
+  <li>The number of leaf groups must be a factor of the <em>redundancy</em></li>
   <li>The <a href="../reference/services-content.html#distribution">distribution partitions</a>
     must be specified such that the redundancy per group is equal</li>
-  <li>The number of <a href="../reference/services-content.html#searchable-copies">searchable-copies</a>
-      must be less than, or equal to, <em>redundancy</em>
-  <li>The number of leaf groups must be a factor of <em>searchable-copies</em></li>
 </ul>
 <p>
   With a low number of nodes per group, it's important to remember that a node failure
@@ -153,12 +140,7 @@ redirect_from:
         <documents>
             <document type="music" mode="index"/>
         </documents>
-        <redundancy>3</redundancy>
-        <engine>
-            <proton>
-                <searchable-copies>3</searchable-copies>
-            </proton>
-        </engine>
+        <min-redundancy>3</min-redundancy>
         <group>
             <distribution partitions="1|1|*"/>
             <group name="group0" distribution-key="0">
@@ -218,12 +200,7 @@ redirect_from:
         <documents>
             <document type="music" mode="index"/>
         </documents>
-        <redundancy>9</redundancy>
-        <engine>
-            <proton>
-                <searchable-copies>9</searchable-copies>
-            </proton>
-        </engine>
+        <min-redundancy>9</min-redundancy>
         <group>
             <distribution partitions="1|1|1|1|1|1|1|1|*"/>
             <group name="group0" distribution-key="0">
@@ -292,18 +269,10 @@ redirect_from:
 
 <h2 id="changing-group-configuration">Changing Group Configuration</h2>
 <p>
-  Migrating from flat distribution to a
-  <a href="../elasticity.html#grouped-distribution">hierarchy</a>
-  will temporarily reduce query coverage
-  (likewise for changing from grouped config to another).
-  When adding new group(s), it will take some time to populate the new nodes.
-  During this transition period, queries hitting these nodes will return partial results.
-  <a href="../reference/services-content.html#nodes">Reference documentation</a>.
+  It is easy to change the group topology without service disruption,
+  with a few caveats - read more in <a href="../elasticity.html#topology-change">elasticity</a>.
 </p>
-<p>
-  A possible workaround for some cases is increasing <em>redundancy</em>
-  and let replicas re-distribute, before changing the group configuration.
-</p>
+
 
 
 <h2 id="appendix-hosts-xml">Appendix: hosts.xml</h2>


### PR DESCRIPTION
- based on slack questions from users
- use min-redundancy
- with https://github.com/vespa-engine/vespa/pull/26881, there is one searchable copy in all groups - no need to litter doc with this
- put the live change in elasticity doc
