### PR TITLE
Fix "<>" in <pre> tags

### DIFF
--- a/en/onnx.md
+++ b/en/onnx.md
@@ -202,14 +202,14 @@ The corresponding input/output tensors should be defined as:
 <pre>
 document doc {
     ...
-    field flowercategory type tensor<float>(d0[1],d1[3]) {
+    field flowercategory type tensor&lt;float&gt;(d0[1],d1[3]) {
         indexing: attribute | summary
     }
 }
 
 rank-profile myRank {
     inputs {
-        query(myTensor) tensor<float>(d0[1],d1[4])
+        query(myTensor) tensor&lt;float&gt;(d0[1],d1[4])
     }
     onnx-model my_onnx_model {
         file: files/Network.onnx

--- a/en/tutorials/models-hot-swap.md
+++ b/en/tutorials/models-hot-swap.md
@@ -181,7 +181,7 @@ The `news_model` schema should look as follows:
 schema news_model {
     document news_model {
 
-        field embedding type tensor<float>(d0[51]) {
+        field embedding type tensor&lt;float&gt;(d0[51]) {
             indexing: attribute
             attribute {
                 distance-metric: euclidean
@@ -195,7 +195,7 @@ schema news_model {
             attribute: fast-search
         }
 
-        field news_ref type reference<news> {
+        field news_ref type reference&lt;news&gt; {
             indexing: attribute
         }
     }
@@ -245,7 +245,7 @@ The relevant portions of the `user` and `news` schemas will now look as follows:
             attribute: fast-search
         }
 
-        field config_ref type reference<config> {
+        field config_ref type reference&lt;config&gt; {
             indexing: attribute
         }
 

--- a/en/tutorials/text-search-semantic.md
+++ b/en/tutorials/text-search-semantic.md
@@ -227,7 +227,7 @@ This can be accomplished by defining a [rank-profile](../ranking.html):
 <pre>
 rank-profile bert_title_body_all inherits default {
     inputs {
-        query(tensor_bert) tensor<float>(x[768])
+        query(tensor_bert) tensor&lt;float&gt;(x[768])
     }    
     function dot_product_title() {
         expression: sum(query(tensor_bert)*attribute(title_bert))


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Hey, some pages are broken because of the usage of "<>" in the pre tag. I fixed the ones I found.

Broken pages:
- https://docs.vespa.ai/en/tutorials/text-search-semantic.html
- https://docs.vespa.ai/en/tutorials/models-hot-swap.html
- https://docs.vespa.ai/en/onnx.html (</pre> at the bottom of the page) 