### PR TITLE
Hide field types in the TOC

### DIFF
--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -57,7 +57,7 @@ Names are <em>identifiers</em>, they must match <code>["a"-"z","A"-"Z", "_"]["a"
         <a href="#struct">struct</a>
             <a href="#field">field</a>
                 <a href="#match">match</a>
-        <a href="#field">field</a>
+        <a href="#field">field</a><span style="display:none"> <!-- Keep field types here for the doc search direct display, hide for clarity -->
             <a href="#annotationreference">annotationreference&lt;annotationtype&gt;</a>
             <a href="#array">array&lt;type&gt;</a>
             <a href="#bool">bool</a>
@@ -76,7 +76,7 @@ Names are <em>identifiers</em>, they must match <code>["a"-"z","A"-"Z", "_"]["a"
             <a href="#tensor">tensor(dimension-1,...,dimension-N)</a>
             <a href="#uri">uri</a>
             <a href="#weightedset">weightedset&lt;element-type&gt;</a>
-                <a href="#weightedset-properties">weightedset</a>
+                <a href="#weightedset-properties">weightedset</a></span>
             <a href="#alias">alias</a>
             <a href="#attribute">attribute</a>
                 <a href="#distance-metric">distance-metric</a>


### PR DESCRIPTION
- The field type is an attribute to field and not relevant in the TOC
- As we scan the TOC pre elements for the direct-link feature in the new doc search prototype, we will keep the anchors here, but hide them, in order not to litter the TOC - lets double check that this works after merging, @jobergum 