### PR TITLE
Added a reference to query evaluation

### DIFF
--- a/en/query-api.html
+++ b/en/query-api.html
@@ -307,7 +307,7 @@ use this to write code to manipulate results.
     <p>
     The query arrives at the content nodes which performs matching,
     <a href="ranking.html">ranking</a> and aggregation/grouping over the set of documents
-    in the <a href="proton.html">Ready sub database</a>.
+    in the <a href="proton.html">Ready sub database</a>. By default, Vespa uses <a href="../performance/feature-tuning.html#hybrid-taat-daat">DAAT</a> where the matching and first-phase score calculation is interleaved and not two separate, sequential phases.
     <em>vespa-proton</em> does matching over the <em>ready</em> documents
     and <a href="ranking.html">ranks</a> as specified with the request/schema.
     Each content node matches and ranks a subset of the total document corpus


### PR DESCRIPTION
Added a reference to query evaluation in the section that describes query processing in the content cluster e.g. matching, ranking, and grouping. This is to clarify the ordering of these processing steps.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
