### PR TITLE
- Remove ancient round-robin dispatch-policy from documentation. It h…

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -1732,7 +1732,7 @@ Tune the query dispatch behavior - child elements:
         see <a href="../performance/sizing-search.html">Vespa Serving Scaling Guide</a>.</p></td></tr>
     <tr><th>dispatch-policy</th>
       <td>optional</td>
-      <td>round-robin / adaptive</td>
+      <td>best-of-random-2 / adaptive</td>
       <td>adaptive</td>
       <td>
         <p id="dispatch-policy">
@@ -1743,12 +1743,11 @@ Tune the query dispatch behavior - child elements:
         </p>
         <table class="table">
           <tr>
-            <th style="white-space: nowrap">round-robin</th>
-            <td>round-robins between the groups, putting uniform load on the groups.</td>
+            <th style="white-space: nowrap">best-of-random-2</th>
+            <td>Selects 2 random groups and selects the one with lowest latency.</td>
           </tr><tr>
             <th>adaptive</th>
-            <td>measures latency, preferring lower latency groups, handles soft-failing/slow nodes
-              in a group better than round-robin</td>
+            <td>measures latency, preferring lower latency groups, selecting group with probability latency/(sum latency over all groups)</td>
           </tr>
         </table>
     <tr><th style="white-space: nowrap">min-active-docs-coverage</th>


### PR DESCRIPTION
…as too many caveats.

- Document best-of-random-2 dispatch-policy.

@kkraune PR
@geirst @yngveaasheim FYI