### PR TITLE
Add example of date indexing MERGEOK

### DIFF
--- a/en/indexing.html
+++ b/en/indexing.html
@@ -343,6 +343,44 @@ Use a different name for the indexing chain.
 
 
 
+<h2 id="date-indexing">Date indexing</h2>
+<p>
+  Vespa does not have a "date" field type.
+  Best practise is using a <a href="reference/schema-reference.html#long">long</a> field.
+  If the date is a string in the source data,
+  one can use <a href="reference/advanced-indexing-language.html#to_epoch_second">to_epoch_second</a>
+  to transform into a long-field:
+</p>
+<pre>
+schema docs {
+
+    document docs {
+        field date_string type string {
+            indexing: summary
+        }
+    }
+
+    field date type long {
+        indexing: input date_string | to_epoch_second | attribute | summary
+    }
+}
+</pre>
+<p>
+  Query results will have the two fields,
+  and the synthetic <code>date</code> field can be used in queries and <a href="grouping.html">grouping</a>:
+</p>
+<pre>{% highlight json %}
+"fields": {
+    "date": 1703437243,
+    "date_string": "2023-12-24T17:00:43.000Z"
+}
+{% endhighlight %}</pre>
+{% include note.html content='The <code>date</code> field above is placed
+<span style="text-decoration: underline">outside</span> the <code>document</code> section,
+as its content is generated from the document input.' %}
+
+
+
 <h2 id="multiple-container-clusters">Multiple container clusters</h2>
 <p>
 Vespa can be configured to use more than one container cluster.


### PR DESCRIPTION
- this is also an example of using a non-document field (synthetic) that is generated from another field.
- the indexing guide should maybe have more examples like this later