### PR TITLE
Trim ? from FAQ headings

### DIFF
--- a/feed-split.py
+++ b/feed-split.py
@@ -209,6 +209,8 @@ def main():
 
                 paragraph = remove_jekyll(paragraph)
 
+                paragraph_id = re.sub(r"\?", "", paragraph_id)
+
                 if paragraph:
                     paragraph_doc = create_text_doc(doc, paragraph, paragraph_id, header)
                     operations.append(paragraph_doc)


### PR DESCRIPTION
- The '?' are trimmed from the heading IDs generated from markdown docs
- test this on docs first, add to other sites when fully tested
- could be we must trim more