### PR TITLE
add a clarification message in `matches` MERGEOK

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -476,7 +476,9 @@ where attribute_field matches "mado[n]+a"
       {% include important.html content="Only <a href='schema-reference.html#attribute'>attribute</a>
       fields in <a href='services-content.html#document'>documents</a> is supported.
       It is not optimized for performance.
-      Having a prefix using the <code>^</code> will be faster than not having one."%}
+      Having a prefix using the <code>^</code> will be faster than not having one.
+      Additionally, fields that serve as both attributes and indexes are not compatible.
+      "%}
     </td>
   </tr>
 


### PR DESCRIPTION
so that a field that is both index and attribute won't work

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
