### PR TITLE
Add missing whitespace between 'wand' and 'and'

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1911,7 +1911,7 @@ where myUrlField.hostname contains ({startAnchor: true}uri("vespa.ai"))
     <td>int</td>
     <td>
       <p id="targethits">
-        Used by <a href="#wand">wand</a>and <a href="#weakand">weakAnd</a>, where the default is 100.
+        Used by <a href="#wand">wand</a> and <a href="#weakand">weakAnd</a>, where the default is 100.
       </p>
       <p>
         It is also used with <a href="#nearestneighbor">nearestNeighbor</a>,


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
