### PR TITLE
Document linguistics key

### DIFF
--- a/en/lucene-linguistics.html
+++ b/en/lucene-linguistics.html
@@ -8,7 +8,8 @@ redirect_from:
 <p>
   Lucene Linguistics is a custom <a href="linguistics.html">linguistics</a> implementation on to of the
   <a href="https://lucene.apache.org">Apache Lucene</a> library.
-  It allows to provide a Lucene analyzer to handle text processing for a language.
+  It allows to provide a Lucene analyzer to handle text processing for a language
+  with an optional variation per <a href="https://github.com/vespa-engine/vespa/blob/master/linguistics/src/main/java/com/yahoo/language/process/StemMode.java">stemming mode</a>.
 </p>
 
 <p>
@@ -19,7 +20,7 @@ redirect_from:
 <h2 id="crash-course-on-lucene-text-analysis">Crash course on the Lucene text analysis</h2>
 
 <p>
-  A Lucene <a href="https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/analysis/package-summary.html">text
+  A Lucene <a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/package-summary.html">text
   analysis</a>
   is a process of converting text into searchable tokens.
   The text analysis consists of a series of components applied on the text in order.
@@ -27,28 +28,27 @@ redirect_from:
 </p>
 <ul>
   <li>
-    <a href="https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/analysis/CharFilter.html">CharFilters</a>:
+    <a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/CharFilter.html">CharFilters</a>:
     transform the text before it is tokenized, while providing corrected character offsets to account for these
     modifications.
   </li>
-  <li><a href="https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/analysis/Tokenizer.html">Tokenizers</a>:
+  <li><a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/Tokenizer.html">Tokenizers</a>:
     responsible for breaking up incoming text into tokens.
   </li>
   <li>
-    <a href="https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/analysis/TokenFilter.html">TokenFilters</a>:
+    <a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/TokenFilter.html">TokenFilters</a>:
     responsible for modifying tokens that have been created by the Tokenizer.
   </li>
 </ul>
 
 <p>
   A specific configuration of the above components is a wrapped into an
-  <a href="https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/analysis/Analyzer.html">Analyzer</a> object.
+  <a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/Analyzer.html">Analyzer</a> object.
 </p>
 
 The text analysis works as follows:
 <ol>
   <li>All char filters are applied in the specified order on the entire text string</li>
-  <li>Exactly one tokenizer is applied on the text string</li>
   <li>Token filters in the specified order are applied on each token.</li>
 </ol>
 
@@ -56,53 +56,54 @@ The text analysis works as follows:
 
 <p>
   Lucene Linguistics by out-of-the-box exposes these analysis components provided
-  by the <a href="https://lucene.apache.org/core/9_0_0/core/index.html">lucene-core</a>
+  by the <a href="https://lucene.apache.org/core/9_8_0/core/index.html">lucene-core</a>
   and the
-  <a href="https://lucene.apache.org/core/9_0_0/analysis/common/index.html">lucene-analysis-common</a>
+  <a href="https://lucene.apache.org/core/9_8_0/analysis/common/index.html">lucene-analysis-common</a>
   libraries.
   Other libraries with Lucene text analysis components
-  (e.g. <a href="https://lucene.apache.org/core/9_7_0/analysis/kuromoji/index.html">analysis-kuromoji</a>)
+  (e.g. <a href="https://lucene.apache.org/core/9_8_0/analysis/kuromoji/index.html">analysis-kuromoji</a>)
   can be added to the application package as a maven dependency.
 </p>
 
-<!--TODO: should the list of components with links be provided?-->
-
 <p>
-  Lucene Linguistics out-of-the-box provides configured analyzers for 37 languages:
+  Lucene Linguistics out-of-the-box provides configured analyzers for 40 languages:
 </p>
 <ul>
   <li>Arabic</li>
-  <li>Bulgarian</li>
+  <li>Armenian</li>
+  <li>Basque</li>
   <li>Bengali</li>
+  <li>Bulgarian</li>
   <li>Catalan</li>
-  <li>Kurdish</li>
+  <li>Chinese</li>
   <li>Czech</li>
   <li>Danish</li>
-  <li>German</li>
-  <li>Greek</li>
+  <li>Dutch</li>
   <li>English</li>
-  <li>Spanish</li>
   <li>Estonian</li>
-  <li>Basque</li>
-  <li>Persian</li>
   <li>Finnish</li>
   <li>French</li>
-  <li>Irish</li>
   <li>Galician</li>
+  <li>German</li>
+  <li>Greek</li>
   <li>Hindi</li>
   <li>Hungarian</li>
-  <li>Armenian</li>
   <li>Indonesian</li>
+  <li>Irish</li>
   <li>Italian</li>
-  <li>Lithuanian</li>
+  <li>Japanese</li>
+  <li>Korean</li>
+  <li>Kurdish</li>
   <li>Latvian</li>
+  <li>Lithuanian</li>
   <li>Nepali</li>
-  <li>Dutch</li>
-  <li>Norwegian_bokmal</li>
+  <li>Norwegian</li>
+  <li>Persian</li>
   <li>Portuguese</li>
   <li>Romanian</li>
   <li>Russian</li>
   <li>Serbian</li>
+  <li>Spanish</li>
   <li>Swedish</li>
   <li>Tamil</li>
   <li>Telugu</li>
@@ -112,9 +113,29 @@ The text analysis works as follows:
 
 <p>
   The Lucene
-  <a href="https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/analysis/standard/StandardAnalyzer.html">StandardAnalyzer</a>
+  <a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/standard/StandardAnalyzer.html">StandardAnalyzer</a>
   is used for the languages that doesn't have neither a custom nor a default analyzer.
 </p>
+
+<h2 id="linguistics-key">Linguistics key</h2>
+
+<p>
+  Linguistics keys identify a configuration of text analysis.
+  A key has 2 parts: a mandatory <a href="https://github.com/vespa-engine/vespa/blob/master/linguistics/src/main/java/com/yahoo/language/Language.java">
+  language code</a> and an optional stemming mode.
+  The format is <code>LANGUAGE_CODE[/STEM_MODE]</code>.
+  There are 5 stemming modes: <code>NONE, DEFAULT, ALL, SHORTEST, BEST</code> (they can be specified in the <a href="reference/schema-reference.html#stemming">field schema</a>).
+</p>
+
+<p>Examples of linguistics key:</p>
+<ul>
+  <li>
+    <code>en</code>: English language.
+  </li>
+  <li>
+    <code>en/BEST</code>: English language with the <code>BEST</code> stemming mode.
+  </li>
+</ul>
 
 <h2 id="custom-analysis">Customizing text analysis</h2>
 
@@ -134,7 +155,7 @@ The text analysis works as follows:
 
 <p>
   In the <code>services.xml</code> out of all text analysis components
-  that are available on the classpath
+  (that are available on the classpath)
   it is possible to construct an analyzer by providing
   <a href="https://github.com/vespa-engine/vespa/blob/master/lucene-linguistics/src/main/resources/configdefinitions/lucene-analysis.def">configuration for the</a>
   <code>LuceneLinguistics</code> component.
@@ -172,21 +193,22 @@ The text analysis works as follows:
 <p>Notes:</p>
 <ul>
   <li>
+    <code>item key="en"</code> value is a <a href="#linguistics-key">linguistics key</a>.
+  </li>
+  <li>
     the <code>en/stopwords.txt</code> file must be placed in your application package under
     the <code>lucene-linguistics</code> directory.
   </li>
   <li>
-    Exactly one analyzer per language can be specified.
-  </li>
-  <li>
-    If the `configDir` is not provided the files must be on the classpath.
+    If the <code>configDir</code> is not provided the files must be on the classpath.
   </li>
 </ul>
 
 <h3 id="components-registry">Components registry</h3>
 
 <p>
-  The <a href="jdisc/injecting-components.html#depending-on-all-components-of-a-specific-type">ComponentsRegistry</a> mechanism can be used to set a Lucene Analyzer for a language.
+  The <a href="jdisc/injecting-components.html#depending-on-all-components-of-a-specific-type">ComponentsRegistry</a>
+  mechanism can be used to set a Lucene Analyzer for a language.
 </p>
 
 <p>
@@ -204,7 +226,7 @@ The text analysis works as follows:
 </p>
 <ul>
   <li>
-    <code>id</code> must be a Language code;
+    <code>id</code> must be a <a href="#linguistics-key">linguistics key</a>;
   </li>
   <li>
     <code>class</code> is the implementation class that extends the `Analyzer` class;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

In https://github.com/vespa-engine/vespa/pull/28682 the key for an analyzer was extended to support an optional `StemMode`. This PR documents the usage.

I've invented a term `linguistics key`. In the code the class is called `[AnalyzerKey](https://github.com/vespa-engine/vespa/blob/dd71247befb38345586504d49941665b1245257d/lucene-linguistics/src/main/java/com/yahoo/language/lucene/AnalyzerFactory.java#L164)`. If the `analyzer key` sounds like a better name, then I can change in docs.

Also, added 3 new supported languages introduced in https://github.com/vespa-engine/vespa/pull/28752.

Other minor readability improvements.
