### PR TITLE
Remove outdated notice on visitor semantics

### DIFF
--- a/en/visiting.html
+++ b/en/visiting.html
@@ -270,25 +270,6 @@ $ <a href="/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-visit">vespa
 <p>The '-v' option emits progress information on standard error.</p>
 
 
-<h3 id="notes">Notes</h3>
-<p>
-With multiple search clusters with one document type each,
-and one content cluster storing all document types,
-there are a few adjustments that must be made.
-A visitor on a content node reads documents from disk,
-and sends batches of documents in messages over the network.
-If a visitor is set to visit all document types,
-one message may thus contain more than one document type.
-Since indexing is done in a separate indexing cluster for each search cluster,
-these indexing clusters can only handle documents of their own type.
-In the case where all documents regardless of document type are visited,
-some documents will thus end up in the wrong indexing cluster, and indexing will fail.
-In this use case, the solution is simple -
-use a selection string to reprocess one document type at a time.
-</p>
-
-
-
 <h2 id="request-handling">Request handling</h2>
 <p>
   In short, <em>visit</em> iterates over all, or a set of, <a href="content/buckets.html">buckets</a>


### PR DESCRIPTION
@kkraune please review. Unless this refers to something I'm not aware of, this paragraph is very outdated. Additionally, the reprocessing example just above it still uses `vespa-visit` (not the Vespa CLI), so maybe it should be either rewritten or removed entirely?

Visiting has not sent document batch operations towards the client since the pre Vespa 5.1-days, so it should not be necessary to do anything special to avoid multioperation-related problems when reprocessing.
