### PR TITLE
Bugfix query parameter name inputs => input

### DIFF
--- a/en/ranking-expressions-features.html
+++ b/en/ranking-expressions-features.html
@@ -303,7 +303,7 @@ inputs {
 
 These variables can then be overridden in the query by adding:</p>
 <pre>
-inputs.query(myvalue)=0.1
+input.query(myvalue)=0.1
 </pre>
 <p>
 to it - see the <a href="reference/query-api-reference.html#ranking.features">Query API</a>.
@@ -325,7 +325,7 @@ Tensors can be passed in requests using the <a href="reference/tensor.html#tenso
 for example:
 </p>
 <pre>
-inputs.query(user_profile)=%7B%7Bcat%3Apop%7D%3A0.8%2C%7Bcat%3Arock%7D%3A0.2%2C%7Bcat%3Ajazz%7D%3A0.1%7D
+input.query(user_profile)=%7B%7Bcat%3Apop%7D%3A0.8%2C%7Bcat%3Arock%7D%3A0.2%2C%7Bcat%3Ajazz%7D%3A0.1%7D
 </pre>
 <p>
 However, it is usually preferable instead to create them in a <a href="searcher-development.html">Searcher</a>.


### PR DESCRIPTION
alias is `input.query` per https://docs.vespa.ai/en/reference/query-api-reference.html#ranking.features

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
