### PR TITLE
Update params for FieldCollapsingSearcher

### DIFF
--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -102,7 +102,8 @@ get methods as Java objects from the Query to Searcher components.
     <li><a href="#select">select</a></li>
     <li><a href="#collapse.summary">collapse.summary</a></li>
     <li><a href="#collapsefield">collapsefield</a></li>
-    <li><a href="#collapsesize">collapsesize</a></li>
+    <li><a href="#collapsesize">collapsesize</a>
+    <li><a href="#collapsesize.fieldname">collapsesize</a> [<em>fieldname</em>]</li>
     <li><a href="#grouping.defaultmaxgroups">grouping.defaultMaxGroups</a></li>
     <li><a href="#grouping.defaultmaxhits">grouping.defaultMaxHits</a></li>
     <li><a href="#grouping.globalmaxgroups">grouping.globalMaxGroups</a></li>
@@ -1250,10 +1251,10 @@ These parameters are defined in the <code>native</code> query profile type.
     <td></td>
     <td>
       <p id="collapsefield">
-        Any document summary field name - <!-- ToDo: add link -->
-        collapse (i.e. aggregate) results using this field.
+        Comma-separated list of <a href="schema-reference.html#summary">document summary field names</a> -
+        collapse (i.e. aggregate) results using the fields one after another.
         Collapsing is run in the container, not content node level.
-        Define a <code>collapsefield</code> to remove duplicates if the corpus has few duplicates -
+        Define one or more <code>collapsefields</code> to remove duplicates if the corpus has few duplicates -
         this is more efficient than using <a href="#select">grouping</a>.
         Otherwise, use grouping.
       </p>
@@ -1269,7 +1270,19 @@ These parameters are defined in the <code>native</code> query profile type.
     <td>1</td>
     <td>
       <p id="collapsesize">
-        The number of hits to keep in each collapsed bucket.
+        The number of hits to keep in each collapsed bucket - used for all collapsefields.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>collapsesize.<em>fieldname</em></th>
+    <td></td>
+    <td>Number</td>
+    <td>1</td>
+    <td>
+      <p id="collapsesize.fieldname">
+        The number of hits to keep in each collapsed bucket - used for the specified field.
+        This value takes precedence over the value specified in <code>collapsesize</code>.
       </p>
     </td>
   </tr>
@@ -1281,7 +1294,7 @@ These parameters are defined in the <code>native</code> query profile type.
     <td>
       <p id="collapse.summary">
         A valid name of a document summary class.
-        Use this summary class to fetch the field used for collapsing.
+        Use this summary class to fetch the fields used for collapsing.
       </p>
       <p>Default: Use default summary or attributes.</p>
     </td>


### PR DESCRIPTION
Reflect the changes from https://github.com/vespa-engine/vespa/pull/29733 in the Docs.


Collapsing can be done on multiple fields.
collapsesize can be specified per field.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.