### PR TITLE
fix zh-hant example

### DIFF
--- a/en/text-matching.html
+++ b/en/text-matching.html
@@ -288,7 +288,7 @@ ull	1
 </p>
 <p>
     Example  - the album name translated to traditional Chinese,
-    满脑子的梦想, will index the album title to:
+    滿腦子的夢想, will index the album title to:
 </p>
 <pre>
 field album type string {
@@ -303,10 +303,10 @@ field album type string {
 }
 
 子的	1
-梦想	1
-满脑	1
-的梦	1
-脑子	1
+夢想	1
+滿腦	1
+的夢	1
+腦子	1
 </pre>
 <p>
     This will enable matching of any 2-term substring, which makes more sense in traditional Chinese than in English.
@@ -321,7 +321,7 @@ field album type string {
 </p>
 <ul>
   <li><em>Are robust to misspelling in user queries eg: "Amsterdam" --> "amstredam"</em></li>
-  <li><em>Are cross-lingual for search, e.g.: "America" --> "美国"</em></li>
+  <li><em>Are cross-lingual for search, e.g.: "America" --> "美國"</em></li>
 </ul>
 <p>
   To make this multilingual,


### PR DESCRIPTION
The original examples are using zh-hans.
Fix the Chinese characters in the examples.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
