### PR TITLE
Clarify character normalization semantics for regex/fuzzy

### DIFF
--- a/en/text-matching.html
+++ b/en/text-matching.html
@@ -229,8 +229,7 @@ $ vespa query 'select * from music where album contains ({maxEditDistance: 1}fuz
   reference</a>.
 </p>
 <p>
-  When fuzzy matching is used in <a href="/en/streaming-search.html">streaming</a> mode,
-  character <a href="/en/linguistics.html#normalization">normalization</a> is not performed.
+  Character <a href="/en/linguistics.html#normalization">normalization</a> is not performed for fuzzy matches.
 </p>
 <!-- ToDo: Add a note on why fast-search is better here (posting list lookup) -->
 <!-- ToDo: More examples illustrating edit distance / prefix -->
@@ -259,8 +258,7 @@ $ vespa query 'select * from music where album matches "head"'
 </pre>
 
 <p>
-  When regular expression matching is used in <a href="/en/streaming-search.html">streaming</a> mode,
-  character <a href="/en/linguistics.html#normalization">normalization</a> is not performed.
+  Character <a href="/en/linguistics.html#normalization">normalization</a> is not performed for regular expression matches.
 </p>
 
 <h2 id="n-gram-match">N-Gram match</h2>


### PR DESCRIPTION
@geirst or @kkraune please review.

Fuzzy and regex matching not using character normalization applies to _both_ indexed and streaming search modes, so remove explicit mention of streaming search.

