### PR TITLE
Improve parameter substitution doc

### DIFF
--- a/en/embedding.html
+++ b/en/embedding.html
@@ -170,7 +170,7 @@ redirect_from:
     This means that tokenization settings like max tokens should be set explicitly.
   </li>
 </ul>
-<p>See <a href="reference/embedding-reference.html#bert-embedder-reference-config">configuration reference</a> for all configuration options. 
+<p>See <a href="reference/embedding-reference.html#bert-embedder-reference-config">configuration reference</a> for all configuration options.
   Normalization and pooling strategy (mean, cls) can also be configured for the Bert embedder.
 </p>
 
@@ -180,30 +180,30 @@ redirect_from:
   Vespa ColBert embedder maps text to token embeddings, representing text as <strong>multiple</strong>
   contextualized vector embeddings. </p>
 
-<p> 
-This embedder distinguishes itself from the from the <a href="#bert-embedder">bert-embedder</a> and 
-<a href="#huggingface-embedder">hugging-face-embedder</a>, which utilize pooling operations to derive a single embedding representation for the entire text. 
-In contrast, ColBERT represents text using multiple vector representations, one for each token. 
-This approach is considered superior to compressing all tokens in the language model context window into a single vector. 
+<p>
+This embedder distinguishes itself from the from the <a href="#bert-embedder">bert-embedder</a> and
+<a href="#huggingface-embedder">hugging-face-embedder</a>, which utilize pooling operations to derive a single embedding representation for the entire text.
+In contrast, ColBERT represents text using multiple vector representations, one for each token.
+This approach is considered superior to compressing all tokens in the language model context window into a single vector.
 The utilization of individual vectors for each token enhances the contextualized representation of the text.</p>
 
 <p>
-In Vespa, the colbert bag of token embeddings are represented as a 
+In Vespa, the colbert bag of token embeddings are represented as a
 <a href="tensor-user-guide.html#tensor-concepts">mixed tensor</a>: <code>tensor&lt;float&gt;(t{}, x[dim])</code> where
 <code>dim</code> is the vector dimensionality of the contextualized token embeddings.  The <a href="https://huggingface.co/colbert-ir/colbertv2.0">colbert model checkpoint</a>
-on Hugging Face hub uses 128 dimensions.  
+on Hugging Face hub uses 128 dimensions.
 </p>
 <p>
-  The embedder destination tensor is defined in the Vespa <a href="schemas.html">schema</a>, and 
+  The embedder destination tensor is defined in the Vespa <a href="schemas.html">schema</a>, and
   depending on the target <a href="reference/tensor.html#tensor-type-spec">tensor cell precision</a> definition
   the embedder might compress the representation.
 
-  If using <code>int8</code> as the target tensor cell type, the colbert embedder compress the token embeddings with binarization for 
+  If using <code>int8</code> as the target tensor cell type, the colbert embedder compress the token embeddings with binarization for
   the document side embeddings to reduce storage footprint using 1-bit per dimension, reducing the token embedding storage footprint
-  by 32x (compared to using float with 4 bytes per dimension). The query representation is not compressed with binarization. 
-  The following schema snippet demonstrates two ways to use the colbert embedder in 
+  by 32x (compared to using float with 4 bytes per dimension). The query representation is not compressed with binarization.
+  The following schema snippet demonstrates two ways to use the colbert embedder in
   the document schema to <a href="#embedding-a-document-field">embed a document field</a>.
-</p> 
+</p>
 
 <pre>
 schema doc {
@@ -218,8 +218,8 @@ schema doc {
   }
 }
 </pre>
-<p>The first field <code>colbert_tokens</code> would store the original representation as the tensor destination 
-  cell type is float. The second field, the <code>colbert_tokens_compressed</code> tensor would be compressed. 
+<p>The first field <code>colbert_tokens</code> would store the original representation as the tensor destination
+  cell type is float. The second field, the <code>colbert_tokens_compressed</code> tensor would be compressed.
   When using <code>int8</code> tensor cell precision, one
   should divide the original dimensionality by 8 (128/8 = 16).</p>
 
@@ -229,7 +229,7 @@ field colbert_tokens type tensor&lt;bfloat16&gt;(t{}, x[128]) {
   indexing: input text | embed colbert | attribute
 }
 </pre>
-<p>Note that the above schema examples did not specify the <code>index</code> keyword for enabling <a href="approximate-nn-hnsw.html">HNSW</a>, 
+<p>Note that the above schema examples did not specify the <code>index</code> keyword for enabling <a href="approximate-nn-hnsw.html">HNSW</a>,
 currently, the colbert representation is intended to be used as a ranking model, and not for retrieval with Vespa's nearestNeighbor query operator.</p>
 
 <p>
@@ -254,33 +254,33 @@ To reduce the in-memory footprint, it's supported to use <a href="#paged-attribu
     The <code>transformer-model</code> specifies the colbert embedding model in <a href="https://onnx.ai/">ONNX</a> format.
     See <a href="#onnx-export">exporting models to ONNX</a>,
     for how to export embedding models from Huggingface to compatible <a href="https://onnx.ai/">ONNX</a> format.
-    The <a href="https://huggingface.co/vespa-engine/col-minilm">vespa-engine/col-minilm</a> page on the HF 
-    model hub has a detailed example of how to export a colbert checkpoint to ONNX format for accelerated inference. 
+    The <a href="https://huggingface.co/vespa-engine/col-minilm">vespa-engine/col-minilm</a> page on the HF
+    model hub has a detailed example of how to export a colbert checkpoint to ONNX format for accelerated inference.
   </li>
   <li>
     The <code>tokenizer-model</code> specifies the Huggingface <code>tokenizer.json</code> formatted file.
     See <a href="https://huggingface.co/transformers/v4.8.0/fast_tokenizers.html#loading-from-a-json-file"> HF loading tokenizer from a json file.</a>
   </li>
   <li>
-    The <code>max-query-tokens</code> controls the maximum number of query text tokens that are represented as vectors and 
-    similarily <code>max-document-tokens</code> controls the document side. These parameters 
-    can be used to control resource usage. 
+    The <code>max-query-tokens</code> controls the maximum number of query text tokens that are represented as vectors and
+    similarily <code>max-document-tokens</code> controls the document side. These parameters
+    can be used to control resource usage.
   </li>
 </ul>
-<p>See <a href="reference/embedding-reference.html#colbert-embedder-reference-config">configuration reference</a> for all 
+<p>See <a href="reference/embedding-reference.html#colbert-embedder-reference-config">configuration reference</a> for all
   configuration options and defaults.</p>
 
 <h4 id="colbert-ranking">ColBert ranking</h4>
-<p>As mentioned above, Vespa's colbert embedder is not directly related to <em>retrieval</em> with 
+<p>As mentioned above, Vespa's colbert embedder is not directly related to <em>retrieval</em> with
   Vespa's <a href="approximate-nn-hnsw.html">approximate nearest neighbor search</a>. </p>
 
 <p>
-  The following <a href="ranking.html">rank-profile</a> is an example of 
-  using a <a href="reference/ranking-expressions.html#tensor-functions">Vespa tensor expression</a> to 
-  express the colbert MaxSim operator between the query and document representation. 
+  The following <a href="ranking.html">rank-profile</a> is an example of
+  using a <a href="reference/ranking-expressions.html#tensor-functions">Vespa tensor expression</a> to
+  express the colbert MaxSim operator between the query and document representation.
   The example uses <a href="phased-ranking.html">phased ranking</a>.
-  
-  This example uses the compressed version with <a href="reference/ranking-expressions.html#unpack-bits">unpack_bits</a>. 
+
+  This example uses the compressed version with <a href="reference/ranking-expressions.html#unpack-bits">unpack_bits</a>.
   Note that the query tensor is not compressed, this is an example
   of asymmetric compression, as the query does not need to be compressed.
 </p>
@@ -293,7 +293,7 @@ rank-profile max-sim inherits default {
       expression: unpack_bits(attribute(colbert_tokens_compressed))
     }
     first-phase {
-      expression: nativeRank(text) # example   
+      expression: nativeRank(text) # example
     }
     second-phase {
       rerank-count: 1000
@@ -322,8 +322,11 @@ input.query(q)=<span class="pre-hilite">embed(myEmbedderId, "Hello%20world")</sp
 <p>If you have only configured a single embedder, you can skip the embedder id argument and optionally also the quotes. Prefer
   to specify the embedder id as introducing more embedder models requires specifying the embedding identifier.
 </p>
-<p>Both single(') and double quotes(") are permitted. </p>
-
+<p>
+  Both single(') and double quotes(") are permitted.
+  Using <em>parameter substitution</em> can simplify building the query,
+  find examples in the <a href="/en/query-api.html#parameter-substitution">query API guide</a>.
+</p>
 <p>Note that query <a href="reference/schema-reference.html#inputs">input tensors</a>
 must be defined in the schema's rank-profile. See <a href="reference/schema-reference.html#inputs">schema reference inputs</a>.</p>
 <pre>

--- a/en/query-api.html
+++ b/en/query-api.html
@@ -167,6 +167,59 @@ $ vespa query "select * from music where userQuery()" \
 </p>
 
 
+<h3 id="parameter-substitution">Parameter substitution</h3>
+<p>
+  Parameter substitution lets you provide query values as request parameters
+  instead of inserting this into the YQL string itself.
+  This simplifies query generation, separating the value of the string/set/array from the YQL string -
+  i.e. the value will not corrupt the YQL string if it contains YQL-like syntax:
+</p>
+<ul>
+  <li>
+    Simplify query generation, separating the value of the set/array from the YQL string.
+
+  </li>
+  <li>Speed up query parsing. Using parameter substitution accelerates string parsing.</li>
+  <li>Reduce duplication.</li>
+</ul>
+<p>
+  In its simplest form,
+  use <a href="/en/reference/query-language-reference.html#userinput">userInput()</a> for strings:
+</p>
+
+<pre>
+... where userInput(@user_input)&user_input=free+text
+</pre>
+<p>Lists, maps and arrays can also be used - examples:</p>
+<pre>
+# Simple example: provide a set for the IN operator
+... where id in (@my_set)&my_set=10,20,30
+
+# Same set, but use the set as a block-list (exclude items in the set)
+... where !(id in (@my_set))&my_set=10,20,30
+
+# Use a weightedSet operator
+... where weightedSet(field, @my_set)&my_set={a:1,b:2}
+</pre>
+<p>Parameter substitution is also great to eliminate data duplication:</p>
+<pre>
+$ vespa query \
+  'yql=select id, from product where {targetHits:10}nearestNeighbor(embedding, query_embedding) or <span class="pre-hilite">userQuery()</span>' \
+  'input.query(query_embedding)=embed(transformer, userInput(<span class="pre-hilite">@query</span>))' \
+  'input.query(query_tokens)=embed(tokenizer, userInput(<span class="pre-hilite">@query)</span>)' \
+  '<span class="pre-hilite">query=running shoes for kids, white</span>'
+</pre>
+<p>
+  Note the use of the parameter named <a href="/en/reference/query-api-reference.html#model.querystring">query</a>
+  used by the <a href="/en/reference/query-language-reference.html#userquery">userQuery()</a> operator.
+  Also note the value substituted in the <a href="/en/embedding.html#embedding-a-query-text">embed</a> functions.
+</p>
+<p>
+  See the <a href="/en/reference/query-language-reference.html#parameter-substitution">reference</a>
+  for a complete list of formats.
+</p>
+
+
 
 <h2 id="ranking">Ranking</h2>
 <p>

--- a/en/query-api.html
+++ b/en/query-api.html
@@ -205,8 +205,8 @@ $ vespa query "select * from music where userQuery()" \
 <pre>
 $ vespa query \
   'yql=select id, from product where {targetHits:10}nearestNeighbor(embedding, query_embedding) or <span class="pre-hilite">userQuery()</span>' \
-  'input.query(query_embedding)=embed(transformer, userInput(<span class="pre-hilite">@query</span>))' \
-  'input.query(query_tokens)=embed(tokenizer, userInput(<span class="pre-hilite">@query)</span>)' \
+  'input.query(query_embedding)=embed(transformer, <span class="pre-hilite">@query</span>)' \
+  'input.query(query_tokens)=embed(tokenizer, <span class="pre-hilite">@query</span>)' \
   '<span class="pre-hilite">query=running shoes for kids, white</span>'
 </pre>
 <p>

--- a/en/query-api.html
+++ b/en/query-api.html
@@ -201,7 +201,9 @@ $ vespa query "select * from music where userQuery()" \
 # Use a weightedSet operator
 ... where weightedSet(field, @my_set)&my_set={a:1,b:2}
 </pre>
-<p>Parameter substitution is also great to eliminate data duplication:</p>
+<p>
+  It is also great to eliminate data duplication,
+  from Vespa 8.287 one can use parameter substitution with <code>embed</code>:</p>
 <pre>
 $ vespa query \
   'yql=select id, from product where {targetHits:10}nearestNeighbor(embedding, query_embedding) or <span class="pre-hilite">userQuery()</span>' \

--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -1410,49 +1410,32 @@ whereas the native execution parameter <a href="query-api-reference.html#timeout
 
 <h2 id="parameter-substitution">Parameter substitution</h2>
 <p>
-  The query operators <a href="#in">field in (value)</a>,
-  <a href="#dotproduct">dotProduct(field, value)</a>,
-  <a href="#weightedset">weightedSet(field, value)</a> and <a href="#wand">wand(field, value)</a>
-  support parameter substitution for the <code>value</code> parameter - example of equivalent queries:
-</p>
-<pre>
-... where field in ("a", "b")
-... where field in (@my_values)&amp;my_values=a,b
-
-... where weightedSet(field, {"a":1, "b":2})
-... where weightedSet(field, @myset)&amp;myset={a:1,b:2}
-</pre>
-<p>
-  Use this to:
-</p>
-<ul>
-  <li>Simplify query generation, separating the value of the set/array from the YQL string.
-    Quotes can be skipped unless the keys contain <code>,</code> or <code>:</code>.</li>
-  <li>Speed up query parsing. Using parameter substitution accelerates string parsing.</li>
-</ul>
-<p>
-  The value string can be passed in one of:
-</p>
-<ul>
-  <li>List form: <code>value, ...</code>.
-    For <a href="#in">in</a> operator only.</li>
-  <li>Array form: <code>[[key, value], ...]</code>.
-    For <a href="#dotproduct">dotproduct</a>, <a href="#weightedset">weightedset</a> and <a href="#wand">wand</a>.</li>
-  <li>Map form: <code>{key: value, ...}</code>.
-    For <a href="#dotproduct">dotproduct</a>, <a href="#weightedset">weightedset</a> and <a href="#wand">wand</a>.</li>
-</ul>
-<p>
-  The query operator <a href="#userinput">userInput(value)</a>
+  Use parameter substitution to separate the YQL string from user input values.
+  E.g., the <a href="#userinput">userInput(value)</a> query operator
   supports parameter substitution for the <code>value</code> parameter:
 </p>
 <pre>
 ... where userInput(@userinput)&amp;userinput=free+text
 </pre>
 <p>
-  Use this to submit the user data unchanged for parsing in Vespa,
-  without risk of corrupting the YQL query.
+  The query operators <a href="#in">field in (value)</a>,
+  <a href="#dotproduct">dotProduct(field, value)</a>,
+  <a href="#weightedset">weightedSet(field, value)</a> and <a href="#wand">wand(field, value)</a>
+  support parameter substitution for the <code>value</code> parameter.
 </p>
-<!-- ToDo: Move the examples to the query-api guide instead -->
+<p>
+  The <code>value</code> string can be passed in one of the following forms
+  (quotes can be skipped unless the keys contain <code>,</code> or <code>:</code>.):
+</p>
+<ul>
+  <li>List: <code>value, ...</code>.
+    For the <a href="#in">in</a> operator only.</li>
+  <li>Array: <code>[[key, value], ...]</code>.
+    For <a href="#dotproduct">dotproduct</a>, <a href="#weightedset">weightedset</a> and <a href="#wand">wand</a>.</li>
+  <li>Map: <code>{key: value, ...}</code>.
+    For <a href="#dotproduct">dotproduct</a>, <a href="#weightedset">weightedset</a> and <a href="#wand">wand</a>.</li>
+</ul>
+<p>See the <a href="/en/query-api.html#parameter-substitution">query API guide</a> for examples.</p>
 
 
 


### PR DESCRIPTION
- clean up reference doc, move examples to guide
- better example
- link to/from `embed`, which now support this