### PR TITLE
Fix colbert embedder tokenizer-model

### DIFF
--- a/en/embedding.html
+++ b/en/embedding.html
@@ -243,7 +243,7 @@ To reduce the in-memory footprint, it's supported to use <a href="#paged-attribu
 <container version="1.0">
     <component id="colbert" type="colbert-embedder">
       <transformer-model url="https://huggingface.co/colbert-ir/colbertv2.0/resolve/main/model.onnx"/>
-      <tokenizer-vocab url="https://huggingface.co/colbert-ir/colbertv2.0/raw/main/tokenizer.json"/>
+      <tokenizer-model url="https://huggingface.co/colbert-ir/colbertv2.0/raw/main/tokenizer.json"/>
       <max-query-tokens>32</max-query-tokens>
       <max-document-tokens>128</max-document-tokens>
     </component>

--- a/en/reference/embedding-reference.html
+++ b/en/reference/embedding-reference.html
@@ -234,7 +234,7 @@ redirect_from:
 <container version="1.0">
   <component id="colbert" type="colbert-embedder">
     <transformer-model path="models/colbertv2.onnx"/>
-    <tokenizer-vocab url="https://huggingface.co/colbert-ir/colbertv2.0/raw/main/tokenizer.json"/>
+    <tokenizer-model url="https://huggingface.co/colbert-ir/colbertv2.0/raw/main/tokenizer.json"/>
     <max-query-tokens>32</max-query-tokens>
     <max-document-tokens>256</max-document-tokens>
   </component>


### PR DESCRIPTION
`tokenizer-model` instead of `tokenizer-vocab`

An example in the [pyvespa](https://github.com/vespa-engine/pyvespa/blob/master/docs/sphinx/source/examples/chat_with_your_pdfs_using_colbert_langchain_and_Vespa-cloud.ipynb) uses `tokenizer-model`. 

@jobergum 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
