### PR TITLE
Kkraune/fix id parsing

### DIFF
--- a/feed-split.py
+++ b/feed-split.py
@@ -188,6 +188,13 @@ def move_linkable_item_to_single_entity(soup, item):
             new_h4.insert_after(item)
 
 
+def fix_pre_content(soup):
+    # Workaround: ensure no faux headings from pre content
+    for pre in soup.body.find_all('pre'):
+        pre_text = pre.get_text()
+        pre.string = re.sub(r'^#', ' #', pre_text, flags=re.MULTILINE)
+
+
 def main():
     with open(sys.argv[1]) as fp:
         random.seed(42)
@@ -198,6 +205,7 @@ def main():
             html_doc = xml_fixup(html_doc)
             soup = BeautifulSoup(html_doc, 'html5lib')
             remove_notext_tags(soup)
+            fix_pre_content(soup)
             add_header_to_tables_if_missing(soup)
             data = split_text(soup)
 

--- a/feed-split.py
+++ b/feed-split.py
@@ -103,7 +103,7 @@ def split_text(soup):
                 data.append((id, header, text))
                 text = ""
             header = line.lstrip("#")
-            id = "-".join(header.split()).lower()
+            id = "-".join(header.replace(',', '').split()).lower()
         else:
             text = text + "\n" + line
 


### PR DESCRIPTION
- this makes it a little better: do not confuse # comments in pre with markdown headings
- also always strip commas in id attributes

There are still known issues:
- the rank feature reference doc uses ids that do not work (this PR does not make it worse)
- get_html in _plugins-vespafeed/vespa_index_generator.rb uses Kramdown::Document.new(page.content).to_html that erroneously creates headings from # in pre (but not the first one!) - must apply same kind of workaround here

E.g. for https://docs.vespa.ai/en/reference/vespa-cli/vespa_config_set.html:
```
"html": "<h2 id=\"vespa-config-set\">vespa config set</h2>\n\n<p>Set a configuration option.</p>\n\n<p><code>\nvespa config set option-name value [flags]\n</code></p>\n\n<h3 id=\"examples\">Examples</h3>\n\n<p>```\n# Set the target to Vespa Cloud\n$ vespa config set target cloud</p>\n\n<h1 id=\"set-application-without-a-specific-instance-the-instance-will-be-named-default\">Set application, without a specific instance. The instance will be named “default”</h1>\n<p>$ vespa config set application my-tenant.my-application</p>\n\n<h1 id=\"set-application-with-a-specific-instance\">Set application with a specific instance</h1>\n<p>$ vespa config set application my-tenant.my-application.my-instance</p>\n\n<h1 id=\"set-the-instance-explicitly-this-will-take-precedence-over-an-instance-specified-as-part-of-the-application-option\">Set the instance explicitly. This will take precedence over an instance specified as part of the application option.</h1>\n<p>$ vespa config set instance other-instance</p>\n\n<h1 id=\"set-an-option-in-local-configuration-for-the-current-application-only\">Set an option in local configuration, for the current application only</h1>\n<p>$ vespa config set –local wait 600</p>\n\n<p>```</p>\n\n<h3 id=\"options\">Options</h3>\n\n<p><code>\n  -h, --help    help for set\n  -l, --local   Write option to local configuration, i.e. for the current application\n</code></p>\n\n<h3 id=\"options-inherited-from-parent-commands\">Options inherited from parent commands</h3>\n\n<p><code>\n  -a, --application string   The application to use (cloud only)\n  -C, --cluster string       The container cluster to use. This is only required for applications with multiple clusters\n  -c, --color string         Whether to use colors in output. Must be \"auto\", \"never\", or \"always\" (default \"auto\")\n  -i, --instance string      The instance of the application to use (cloud only)\n  -q, --quiet                Print only errors\n  -t, --target string        The target platform to use. Must be \"local\", \"cloud\", \"hosted\" or an URL (default \"local\")\n  -z, --zone string          The zone to use. This defaults to a dev zone (cloud only)\n</code></p>\n\n<h3 id=\"see-also\">SEE ALSO</h3>\n\n<ul>\n  <li><a href=\"vespa_config.html\">vespa config</a>\t - Manage persistent values for global flags</li>\n</ul>\n\n"
```