### PR TITLE
Reorder some operations-related side bar entries

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -296,8 +296,6 @@ docs:
 
   - title: Operations - selfhosted
     documents:
-      - page: Routing
-        url: /en/operations-selfhosted/routing.html
       - page: Multinode Systems
         url: /en/operations-selfhosted/multinode-systems.html
       - page: Administrative Procedures
@@ -310,10 +308,10 @@ docs:
         url: /en/operations-selfhosted/content-node-recovery.html
       - page: Using Kubernetes with Vespa
         url: /en/operations-selfhosted/using-kubernetes-with-vespa.html
-      - page: mTLS
-        url: /en/operations-selfhosted/mtls.html
       - page: Securing a Vespa installation
         url: /en/operations-selfhosted/securing-your-vespa-installation.html
+      - page: mTLS
+        url: /en/operations-selfhosted/mtls.html
       - page: Configuration Servers
         url: /en/operations-selfhosted/configuration-server.html
       - page: Live Vespa upgrade procedure
@@ -336,6 +334,8 @@ docs:
         url: /en/operations-selfhosted/container.html
       - page: Monitoring
         url: /en/operations-selfhosted/monitoring.html
+      - page: Routing
+        url: /en/operations-selfhosted/routing.html
 
   - title: Configuration reference
     documents:


### PR DESCRIPTION
@bjorncs please review
@kkraune FYI

The infamously complicated routing doc should _not_ be the first thing that people see in the list. Also, move mTLS doc _after_ "Securing a Vespa installation", as the latter should be read before the former.

We probably want to move Routing into a separate reference section at some point.

