### PR TITLE
Ignore platform.openai.com, gives 403 - links are OK

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -46,7 +46,15 @@ jobs:
             --no-check-external-hash \
             --allow-missing-href \
             --ignore-files '/playground/index.html/' \
-            --ignore-urls '/localhost:8080/,/docs.vespa.ai/playground/,/javadoc.io.*#/,/readthedocs.io.*#/,/linux.die.net/,/arxiv.org/,/hub.docker.com/r/' \
+            --ignore-urls '\
+              /localhost:8080/,\
+              /docs.vespa.ai/playground/,\
+              /javadoc.io.*#/,\
+              /readthedocs.io.*#/,\
+              /linux.die.net/,\
+              /arxiv.org/,\
+              /hub.docker.com/r/,\
+              /platform.openai.com/' \
             --typhoeus '{"connecttimeout": 10, "timeout": 30, "accept_encoding": "zstd,br,gzip,deflate"}' \
             --hydra '{"max_concurrency": 1}' \
             --swap-urls '(https\://github.com.*/master/.*)#.*:\1,(https\://github.com.*/main/.*)#.*:\1' \


### PR DESCRIPTION
fyi @lesters 