### PR TITLE
Add description of `inputs` handling to rank profile inheritance section

### DIFF
--- a/en/schemas.html
+++ b/en/schemas.html
@@ -729,6 +729,11 @@ schema music {
   If a query's rank profile can not be found in a given schema,
   Vespa's default rank profile <a href="nativerank.html">nativerank</a> is used.
 </p>
+<p>
+  <a href="reference/schema-reference.html#inputs">Inputs</a> to a rank profile are automatically inherited from
+  the parent rank profile. If a new inputs block is defined in a child rank profile, those inputs will be
+  added cumulatively to those defined in the parent.
+</p>
 
 
 <h3 id="document-summary-inheritance">Document summary inheritance</h3>


### PR DESCRIPTION
This PR adds a few sentences making explicit the handling of `inputs` in rank profile inheritance.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
