### PR TITLE
Remove `distributor-base-port` from documentation

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -154,11 +154,6 @@ Contained in <a href="services.html">services</a>.
     see https://docs.vespa.ai/en/reference/validation-overrides.html</code>."%}
   </td>
 </tr>
-<tr><th>distributor-base-port</th>
-  <td>optional</td>
-  <td>number</td>
-  <td></td>
-  <td>If a specific port is required for access to the distributor, override it with this attribute.</td></tr>
 </tbody>
 </table>
 <p>Subelements:</p>


### PR DESCRIPTION
@kkraune please review.

This property likely hasn't worked for many years. My guess is that it's a leftover from the previous generation of content clusters.

At the very least we shouldn't document a broken feature.

This relates to https://github.com/vespa-engine/vespa/issues/31145
