### PR TITLE
Fix text search test

### DIFF
--- a/en/tutorials/text-search.md
+++ b/en/tutorials/text-search.md
@@ -418,11 +418,11 @@ It is important to note that the following approach for query time term boosting
 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre data-test="exec" data-test-assert-contains="What Is A  Dad Bod">
+<pre data-test="exec" data-test-assert-contains="What is the name of the mountain range">
 $ vespa query \
   'yql=select * from msmarco where rank(userInput(@user-query), url contains ({weight:1000, significance:1.0}"www.answers.com"))' \
   'user-query=what is dad bod' \
-  'hits=3' \
+  'hits=1' \
   'language=en'
 </pre>
 </div>


### PR DESCRIPTION
Follow-up to https://github.com/vespa-engine/documentation/pull/3252, where I didn't notice the Screwdriver verify-guides PR failure:

```
15:56:32 ********************************************************************************
15:56:32 * vespa query  'yql=select * from msmarco where rank(userInput(@user-query), url contains ({weight:1000, significance:1.0}"www.answers.com"))'  'user-query=what is dad bod'  'hits=3'  'language=en'
15:56:32 * (Expecting 'What Is A  Dad Bod')
15:56:32 ********************************************************************************
15:56:32 {
15:56:32     "root": {
15:56:32         "id": "toplevel",
15:56:32         "relevance": 1.0,
15:56:32         "fields": {
15:56:32             "totalCount": 560
15:56:32         },
15:56:32         "coverage": {
15:56:32             "coverage": 100,
15:56:32             "documents": 996,
15:56:32             "full": true,
15:56:32             "nodes": 1,
15:56:32             "results": 1,
15:56:32             "resultsFull": 1
15:56:32         },
15:56:32         "children": [
15:56:32             {
15:56:32                 "id": "id:msmarco:msmarco::D1583301",
15:56:32                 "relevance": 0.17486507062389434,
15:56:32                 "source": "msmarco",
15:56:32                 "fields": {
15:56:32                     "sddocname": "msmarco",
15:56:32                     "documentid": "id:msmarco:msmarco::D1583301",
15:56:32                     "id": "D1583301",
15:56:32                     "title": "What is the name of the mountain range running along the eastern coast of Australia ",
15:56:32                     "url": "http://www.answers.com/Q/What_is_the_name_of_the_mountain_range_running_along_the_eastern_coast_of_Australia"
15:56:32                 }
15:56:32             },
15:56:32             {
15:56:32                 "id": "id:msmarco:msmarco::D1924509",
15:56:32                 "relevance": 0.16523809043493143,
15:56:32                 "source": "msmarco",
15:56:32                 "fields": {
15:56:32                     "sddocname": "msmarco",
15:56:32                     "documentid": "id:msmarco:msmarco::D1924509",
15:56:32                     "id": "D1924509",
15:56:32                     "title": "What is the average price for a Stressless Chair ",
15:56:32                     "url": "http://www.answers.com/Q/What_is_the_average_price_for_a_Stressless_Chair"
15:56:32                 }
15:56:32             },
15:56:32             {
15:56:32                 "id": "id:msmarco:msmarco::D896130",
15:56:32                 "relevance": 0.1573835398928982,
15:56:32                 "source": "msmarco",
15:56:32                 "fields": {
15:56:32                     "sddocname": "msmarco",
15:56:32                     "documentid": "id:msmarco:msmarco::D896130",
15:56:32                     "id": "D896130",
15:56:32                     "title": "What is the taxonomy of a human ",
15:56:32                     "url": "http://www.answers.com/Q/What_is_the_taxonomy_of_a_human"
15:56:32                 }
15:56:32             }
15:56:32         ]
15:56:32     }
15:56:32 }
15:56:32 sentinel-404624> exit code: 0
15:56:32 
15:56:32 ERROR: Expected output 'What Is A  Dad Bod' not found in command 'vespa query  'yql=select * from msmarco where rank(userInput(@user-query), url contains ({weight:1000, significance:1.0}"www.answers.com"))'  'user-query=what is dad bod'  'hits=3'  'language=en''
```

This PR fixes the test failure by asserting that the top ranked document is a different document, due to the weight for `answers.com` URLs now being applied successfully.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
