### PR TITLE
Link for zcurve in grouping reference

### DIFF
--- a/en/reference/grouping-syntax.html
+++ b/en/reference/grouping-syntax.html
@@ -430,7 +430,7 @@ for more examples.
   <tr><td colspan="4"><h3 id="other-expressions">Other expressions</h3></td></tr>
   <tr class="trx"><th class="thx">Name</th><th class="thx">Description</th><th class="thx">Arguments</th><th class="thx">Result</th></tr>
   <tr><td>zcurve.x</td><td>
-    Returns the X component of the given zcurve encoded 2d point.
+    Returns the X component of the given <a href="https://en.wikipedia.org/wiki/Z-order_curve">zcurve</a> encoded 2d point.
     All fields of type "position" have an accompanying "&lt;fieldName&gt;_zcurve" attribute
     that can be decoded using this expression, e.g. <code>zcurve.x(foo_zcurve)</code>
     </td><td>Long</td><td>Long</td>


### PR DESCRIPTION
I'm hoping to clarify the meaning, especially since Wikipedia says "Not to be confused with [Z curve](https://en.wikipedia.org/wiki/Z_curve) or [Z-order](https://en.wikipedia.org/wiki/Z-order)."

Now I hope I'm linking the right one 😅