### PR TITLE
Support <code> elements with attributes

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -37,7 +37,7 @@ jobs:
             xargs grep -l "Click here if you are not redirected." | xargs rm
           #
           # htmlproofer does not check links inside <code>-elements
-          find _site -name \*.html | xargs sed -i.orig 's/<code>//g; s/<\/code>//g;'
+          find _site -name \*.html | xargs sed -i.orig 's/<code[^>]*>//g; s/<\/code>//g;'
           find _site -name \*.orig | xargs rm
           #
           bundle exec htmlproofer \


### PR DESCRIPTION
htmlproofer does not check links inside code-elements - these elements are removed.

make sure to remove elements with attributes, too

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
