### PR TITLE
Remove <pre> for better linkcheck

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -37,7 +37,7 @@ jobs:
             xargs grep -l "Click here if you are not redirected." | xargs rm
           #
           # htmlproofer does not check links inside <code>-elements
-          find _site -name \*.html | xargs sed -i.orig 's/<code[^>]*>//g; s/<\/code>//g;'
+          find _site -name \*.html | xargs sed -i.orig 's/<code[^>]*>//g; s/<\/code>//g; s/<pre[^>]*>//g; s/<\/pre>//g;'
           find _site -name \*.orig | xargs rm
           #
           bundle exec htmlproofer \


### PR DESCRIPTION
The linkchecker does not look inside &lt;pre&gt; so just remove them to check more links