### PR TITLE
Remove "client" under "container"

### DIFF
--- a/en/reference/services-container.html
+++ b/en/reference/services-container.html
@@ -15,9 +15,6 @@ container [version, id]
     <a href="#handler">handler [id, class, bundle]</a>
         <a href="#binding">binding</a>
         <a href="#component">component</a>
-    <a href="#client">client [id, class, bundle]</a>
-        <a href="#binding">binding</a>
-        <a href="#component">component</a>
     <a href="#server">server [id, class, bundle]</a>
     <a href="#components">components</a>
     <a href="#component">component</a>


### PR DESCRIPTION
Per https://github.com/vespa-engine/vespa/blob/master/config-model/src/main/resources/schema/containercluster.rnc there is no "client" element at the top level under container

This is 7-years old doc, probably an omission

See Vespa Cloud for clients > client, which is for a separate thing

@oyving  ref what we discussed yesterday