### PR TITLE
Fix minor typo, removed duplicate word

### DIFF
--- a/en/ranking.html
+++ b/en/ranking.html
@@ -13,7 +13,7 @@ redirect_from:
   Ranking in Vespa is configured using 
   declarative <a href="ranking-expressions-features.html">ranking expressions</a>, 
   These expressions vary from basic mathematical operations with <a href="reference/rank-features.html">rank features</a> to
-  more complex tensor <a href="tensor-examples.html">tensor expressions</a> or 
+  more complex <a href="tensor-examples.html">tensor expressions</a> or 
   machine-learned models. These ranking expressions are configured in <a href="#rank-profiles">rank profiles</a> within document <a href="schemas.html">schemas</a>.
 </p>
 


### PR DESCRIPTION
Removed the `tensor` word since its duplicated. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
