### PR TITLE
build(link-checker): Add GitHub Actions workflow for link checking on documentation

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,66 @@
+name: Link Checker
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "2 0 * * *"
+
+  # START Temporary for testing.
+  pull_request:
+    branches: [main]
+  push:
+    branches: ["link-checker-workflow-configuration"]
+  # END Temporary for testing.
+
+defaults:
+  run:
+    # Specify to ensure "pipefail and errexit" are set.
+    # Ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+    shell: bash
+
+jobs:
+  link-checker-documentation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+
+      - name: check links
+        env:
+          LANG: "C.UTF-8"
+        run: |
+          bundle exec jekyll build
+          #
+          # Remove the redirect-files before link-check
+          find _site/en _site/documentation -name \*.html | \
+            xargs grep -l "Click here if you are not redirected." | xargs rm
+          #
+          # htmlproofer does not check links inside <code>-elements
+          find _site -name \*.html | xargs sed -i.orig 's/<code[^>]*>//g; s/<\/code>//g; s/<pre[^>]*>//g; s/<\/pre>//g;'
+          find _site -name \*.orig | xargs rm
+          #
+          bundle exec htmlproofer \
+            --assume-extension .html \
+            --no-enforce-https \
+            --no-check-external-hash \
+            --allow-missing-href \
+            --ignore-files '/playground/index.html/' \
+            --ignore-urls '\
+              /localhost:8080/,\
+              /docs.vespa.ai/playground/,\
+              /javadoc.io.*#/,\
+              /readthedocs.io.*#/,\
+              /linux.die.net/,\
+              /arxiv.org/,\
+              /hub.docker.com/r/,\
+              /platform.openai.com/' \
+            --typhoeus '{"connecttimeout": 10, "timeout": 30, "accept_encoding": "zstd,br,gzip,deflate"}' \
+            --hydra '{"max_concurrency": 1}' \
+            --swap-urls '(https\://github.com.*/master/.*)#.*:\1,(https\://github.com.*/main/.*)#.*:\1' \
+            _site

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -19,47 +19,6 @@ shared:
           ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/
 
 jobs:
-  link-checker-documentation:
-    image: ruby:3.1
-    annotations:
-      screwdriver.cd/buildPeriodically: H 2 * * *
-    steps:
-      - install-bundler: |
-          gem update --system 3.3.3
-          gem install bundler
-      - check-links: |
-          export LANG=C.UTF-8
-          bundle install
-          bundle exec jekyll build
-          #
-          # Remove the redirect-files before link-check
-          find _site/en _site/documentation -name \*.html | \
-            xargs grep -l "Click here if you are not redirected." | xargs rm
-          #
-          # htmlproofer does not check links inside <code>-elements
-          find _site -name \*.html | xargs sed -i.orig 's/<code[^>]*>//g; s/<\/code>//g; s/<pre[^>]*>//g; s/<\/pre>//g;'
-          find _site -name \*.orig | xargs rm
-          #
-          bundle exec htmlproofer \
-            --assume-extension .html \
-            --no-enforce-https \
-            --no-check-external-hash \
-            --allow-missing-href \
-            --ignore-files '/playground/index.html/' \
-            --ignore-urls '\
-              /localhost:8080/,\
-              /docs.vespa.ai/playground/,\
-              /javadoc.io.*#/,\
-              /readthedocs.io.*#/,\
-              /linux.die.net/,\
-              /arxiv.org/,\
-              /hub.docker.com/r/,\
-              /platform.openai.com/' \
-            --typhoeus '{"connecttimeout": 10, "timeout": 30, "accept_encoding": "zstd,br,gzip,deflate"}' \
-            --hydra '{"max_concurrency": 1}' \
-            --swap-urls '(https\://github.com.*/master/.*)#.*:\1,(https\://github.com.*/main/.*)#.*:\1' \
-            _site
-
   verify-guides:
     requires: [~pr, ~commit]
     image: vespaengine/vespa-build-almalinux-8:latest
@@ -109,7 +68,7 @@ jobs:
     secrets:
       - VESPA_DOC_DEPLOY_KEY
     environment:
-       GIT_SSH_COMMAND: "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+      GIT_SSH_COMMAND: "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
     steps:
       - update-to-latest: |
           # must checkout the repo again using ssh for the credentials to work
@@ -190,7 +149,7 @@ jobs:
     secrets:
       - VESPA_DOC_DEPLOY_KEY
     environment:
-       GIT_SSH_COMMAND: "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+      GIT_SSH_COMMAND: "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
     steps:
       - update-to-latest: |
           # Ref https://github.com/vespa-engine/vespa/blob/master/metrics/src/main/java/ai/vespa/metrics/docs/MetricDocumentation.java


### PR DESCRIPTION
## What

- Setup a Github Actions workflow to check documentation links.
- Removed the existing job from Screwdriver

## Why

- Migrate the ["link-checker-documentation" Screwdriver](https://github.com/vespa-engine/documentation/blob/946949d717a3564bfe309164ccf3bb92de1a2d71/screwdriver.yaml#L22-L61) job.
- Work package: [Move jobs from Screwdriver (public+internal) to GitHub Actions or mark as Buildkite candidate](https://docs.google.com/document/d/17x_zLlrLkYgpTtx9aN4EIzLDnjjBX9xyQVY6pscRvbo/edit#heading=h.ko6y2erzv1ll)

## Additional Info

- I did not enable/setup notifications to "kraune@yahooinc.com" because I assume we will use a badge in the page shown in the standup meeting.
- The section "Temporary for testing" is used to trigger the CI workflow in this PR and will be removed before the merge.