### PR TITLE
fix link to jetty HttpClient javadoc

### DIFF
--- a/en/performance/http2.html
+++ b/en/performance/http2.html
@@ -108,7 +108,7 @@ redirect_from:
   For Java there are 4 good alternatives:
 </p>
 <ol>
-  <li><a href="https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/client/HttpClient.html">Jetty Client</a>
+  <li><a href="https://javadoc.jetty.org/jetty-11/org/eclipse/jetty/client/HttpClient.html">Jetty Client</a>
   <li><a href="https://square.github.io/okhttp/">OkHttp</a></li>
   <li><a href="https://hc.apache.org/httpcomponents-client-5.1.x/">Apache HttpClient 5.x</a></li>
   <li><a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html">java.net.http.HttpClient (JDK11+)</a> </li>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
