### PR TITLE
fix(CI): push changes to the documentation with PR.

### DIFF
--- a/.github/actions/commit-updated-docs/action.yml
+++ b/.github/actions/commit-updated-docs/action.yml
@@ -1,0 +1,61 @@
+name: Commit via PR
+description: Commit changes to the Vespa documentation via a PR.
+
+inputs:
+  commit-message:
+    description: "The commit message to use when updating the documentation."
+    required: true
+  files:
+    description: "The files to commit."
+    required: true
+  push:
+    description: "Whether to push the changes to the repository, set to 'true' to push."
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup git
+      shell: bash
+      id: git-setup
+      run: |
+        git config --global user.email "bot+actions@vespa.ai"
+        git config --global user.name "${{ github.actor}}"
+
+        # Find a suitable branch name for the PR.
+        PR_BRANCH_NAME="update-docs-$(date +%s)"
+        echo "branch=$PR_BRANCH_NAME" >> $GITHUB_OUTPUT
+
+    - name: Commit
+      shell: bash
+      env:
+        PR_BRANCH_NAME: ${{ steps.git-setup.outputs.branch }}
+      run: |
+        git pull --rebase --autostash --quiet
+        git add ${{ inputs.files }}
+        git commit -m "${{ inputs.commit-message }}"
+
+    - name: Create PR
+      shell: bash
+      id: pr
+      if: ${{ inputs.push == 'true' }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_BRANCH_NAME: ${{ steps.git-setup.outputs.branch }}
+      run: |
+        git checkout -b "${PR_BRANCH_NAME}"
+        git push --set-upstream origin "${PR_BRANCH_NAME}"
+
+        PR_URL=$(gh pr create --base master --head "${PR_BRANCH_NAME}" \
+          --title "${{ inputs.commit-message }} MERGEOK" \
+          --body "This PR was created by a GitHub Action.")
+
+        echo "pr-url=${PR_URL}" >> $GITHUB_OUTPUT
+
+         # Allow some time for the "Merge Stop Enforcer" to run.
+         # This is a workaround as the 'Auto-Merge' feature is not set up.
+        sleep 15
+
+        # Merge the PR with a rebase to ensure a clean history.
+        gh pr merge --squash "${PR_URL}"

--- a/.github/workflows/auto-update-documentation.yml
+++ b/.github/workflows/auto-update-documentation.yml
@@ -9,11 +9,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-  repository_dispatch:
-    types:
-      - update-vespa-version
-      - update-vespa-cli-doc
-
 permissions:
   contents: write
   pull-requests: write
@@ -23,6 +18,10 @@ defaults:
     # This ensures that options "pipefail" and "errexit" are set for all steps.
     # Ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
     shell: bash
+
+# Limit concurrency to better handle commit and push operations.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   update-vespa-version:
@@ -39,33 +38,28 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xq
 
-      - name: Get Latest Vespa version
-        env:
-          ENABLE_PUSH: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && github.ref_name == 'master' }}
+      - name: Update Vespa version
+        id: update-docs
         run: |
           VESPA_VERSION=$(curl -sSL https://repo1.maven.org/maven2/com/yahoo/vespa/parent/maven-metadata.xml | \
            xq -x '/metadata/versioning/latest')
 
           echo "Vespa version: $VESPA_VERSION"
+          echo "version=$VESPA_VERSION" >> $GITHUB_OUTPUT
 
+          # Update the Vespa version in the documentation configuration file.
           sed -i'' "s/\(vespa_version:\) \"[0-9\.]*\"/\1 \"${VESPA_VERSION}\"/" _config.yml
+
           git diff
+          echo "has-changes=$(git status --short | wc -l)" >> $GITHUB_OUTPUT
 
-          # Check if there are changes to commit.
-          if [[ -n "$(git status --porcelain)" ]]; then
-            echo "Updating Vespa version in documentation to ${VESPA_VERSION}" >> $GITHUB_STEP_SUMMARY
-            git config --global user.email "bot+actions@vespa.ai"
-            git config --global user.name "${{ github.actor}}"
-
-            git add _config.yml
-            git commit -m "Update Vespa-version to ${VESPA_VERSION}. MERGEOK"
-            git pull --rebase
-
-            # Only push if the event is a push and the branch is the default branch.
-            if [[ "${{ env.ENABLE_PUSH }}" == "true" ]]; then
-              git push
-            fi
-          fi
+      - name: Commit changes
+        if: ${{ steps.update-docs.outputs.has-changes != '0' }}
+        uses: ./.github/actions/commit-updated-docs
+        with:
+          commit-message: "Update Vespa version to ${{ steps.update-docs.outputs.version }}."
+          files: _config.yml
+          push: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && github.ref_name == 'master' }}
 
   update-vespa-cli-doc:
     #
@@ -73,9 +67,15 @@ jobs:
     #
     runs-on: ubuntu-latest
 
+    # Make sure each job runs after the previous one, regardless of the outcome.
+    # This trick is useful to prevent two jobs from running concurrently and trying to
+    #  push changes to the repository at the same time.
+    if: ${{ success() || failure() }}
+    needs:
+      - update-vespa-version
+
     env:
       VESPA_CLI_DOC_DIR: en/reference/vespa-cli
-      ENABLE_PUSH: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && github.ref_name == 'master' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -84,6 +84,7 @@ jobs:
         uses: vespa-engine/setup-vespa-cli-action@v1
 
       - name: Generate Vespa CLI Documentation
+        id: update-docs
         working-directory: ${{ env.VESPA_CLI_DOC_DIR }}
         run: |
           vespa gendoc .
@@ -102,21 +103,15 @@ jobs:
           sed -i'' 's#\(https://[a-z.]*vespa.ai/[^[:space:]]*\)#[\1](\1)#g' *.md
 
           git diff
+          echo "has-changes=$(git status --short | wc -l)" >> $GITHUB_OUTPUT
 
-          # Check if there are changes to commit.
-          if [[ -n "$(git status --short)" ]]; then
-            echo "Updating Vespa CLI reference documentation" >> $GITHUB_STEP_SUMMARY
-            git config --global user.email "bot+actions@vespa.ai"
-            git config --global user.name "${{ github.actor}}"
-
-            git add vespa*.md
-            git commit -m "Update 'Vespa-CLI' reference documentation. MERGEOK"
-            git pull --rebase
-
-            if [[ "${{ env.ENABLE_PUSH }}" == "true" ]]; then
-              git push
-            fi
-          fi
+      - name: Commit changes
+        if: ${{ steps.update-docs.outputs.has-changes != '0' }}
+        uses: ./.github/actions/commit-updated-docs
+        with:
+          commit-message: "Update 'Vespa-CLI' reference documentation."
+          files: ${{ env.VESPA_CLI_DOC_DIR }}
+          push: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && github.ref_name == 'master' }}
 
   update-metric-reference:
     #
@@ -125,8 +120,12 @@ jobs:
     #
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 for the xq dependency
 
-    env:
-      ENABLE_PUSH: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && github.ref_name == 'master' }}
+    # Make sure each job runs after the previous one, regardless of the outcome.
+    # This trick is useful to prevent two jobs from running concurrently and trying to
+    #  push changes to the repository at the same time.
+    if: ${{ success() || failure() }}
+    needs:
+      - update-vespa-cli-doc
 
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +147,8 @@ jobs:
           echo "Using version: $VESPA_VERSION"
           echo "version=$VESPA_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Update to latest
+      - name: Update Metric Reference
+        id: update-docs
         env:
           VESPA_VERSION: ${{ steps.vespa-metadata.outputs.version }}
         run: |
@@ -157,16 +157,10 @@ jobs:
 
           git diff
 
-          if [[ -n "$(git status --short en/reference/*-metrics-reference.html)" ]]; then
-            echo "Updating metric reference" >> $GITHUB_STEP_SUMMARY
-            git config --global user.email "bot+actions@vespa.ai"
-            git config --global user.name "${{ github.actor}}"
-
-            git add en/reference/*-metrics-reference.html
-            git commit -m "Update 'Metric' reference documentation. MERGEOK"
-            git pull --rebase
-
-            if [[ "${{ env.ENABLE_PUSH }}" == "true" ]]; then
-              git push
-            fi
-          fi
+      - name: Commit changes
+        if: ${{ steps.update-docs.outputs.has-changes != '0' }}
+        uses: ./.github/actions/commit-updated-docs
+        with:
+          commit-message: "Update 'Metric' reference documentation."
+          files: "en/reference/*-metrics-reference.html"
+          push: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && github.ref_name == 'master' }}


### PR DESCRIPTION
## What

- updates the CI pipelines to ensure we do not encur in branch protections by using PRs when updating the documentation
- uses the same process to push changes instead of repeating the same steps
- prevents to job from running at the same time using job dependencies

## Why

As shown in [this Action Run](https://github.com/vespa-engine/documentation/actions/runs/10355521837) the branch protection rules do not allow the github bot to push directly to the `master` branch, by using a PR we shoulod be able to update the documentation as part of the CI process.
