### PR TITLE
fix: add resource-limits under tuning

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -98,6 +98,7 @@ redirect_from:
         <a href="#maintenance">maintenance</a>
         <a href="#merges">merges</a>
         <a href="#persistence-threads">persistence-threads</a>
+        <a href="#resource-limits">resource-limits</a>
         <a href="#visitors">visitors</a>
             <a href="#max-concurrent">max-concurrent</a>
         <a href="#dispatch-tuning">dispatch</a>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The tuning section does not have a link to resource-limits, let's add it.