### PR TITLE
typo: fix guides

### DIFF
--- a/.github/workflows/verify-guides-large.yml
+++ b/.github/workflows/verify-guides-large.yml
@@ -1,4 +1,4 @@
-name: Verify Giudes (Large)
+name: Verify Guides (Large)
 
 on:
   workflow_dispatch: # Allow manual triggering of this workflow.

--- a/.github/workflows/verify-guides-small.yml
+++ b/.github/workflows/verify-guides-small.yml
@@ -1,4 +1,4 @@
-name: Verify Giudes (Small)
+name: Verify Guides (Small)
 
 on:
   workflow_dispatch: # Allow manual triggering of this workflow.

--- a/.github/workflows/verify-guides.yml
+++ b/.github/workflows/verify-guides.yml
@@ -1,4 +1,4 @@
-name: Verify Giudes
+name: Verify Guides
 
 on:
   workflow_call:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

![image](https://github.com/user-attachments/assets/003d9a4b-5b9c-445d-81ac-558e5e4e34aa)

CI action says giudes, not guides.