### PR TITLE
fix(ci): exclude www.ietf.org from the link-checker workflow

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -26,3 +26,4 @@ jobs:
         /arxiv.org/
         /hub.docker.com/r/
         /platform.openai.com/
+        /www.ietf.org/


### PR DESCRIPTION
## What

- Excludes links to www.ietf.org to be checked

## Why

- It seems that they blocked access from CI systems, as the link [www.ietf.org/rfc/rfc2396.txt](https://www.ietf.org/rfc/rfc2396.txt) exists and is valid, but when checked via GH actions it returns 404.