### PR TITLE
fix(search): use the latest version of vespa-cli in the feed workflow

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -35,11 +35,8 @@ jobs:
       run: |
         pip3 install PyYAML mmh3 requests html5lib beautifulsoup4 markdownify tiktoken
 
-    - name: Get Vespa CLI - update to later versions as needed
-      run: |
-        apt update && apt -y install curl
-        curl -SsLo vespa-cli.tar.gz https://github.com/vespa-engine/vespa/releases/download/v8.209.11/vespa-cli_8.209.11_linux_amd64.tar.gz
-        tar -xvf vespa-cli.tar.gz && ln -fs vespa-cli_8.209.11_linux_amd64/bin/vespa
+    - name: Install Vespa CLI
+      uses: vespa-engine/setup-vespa-cli@v1
 
     - name: Feed docs site
       run: |


### PR DESCRIPTION
## What

use the latest version of vespa-cli in the feed workflow

## Why

There is no reason why we should use a specific version

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
