### PR TITLE
fix: services content min-node-ratio-per-group

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -1365,7 +1365,7 @@ Setting this tuning parameter allows the system to instead automatically take do
 allowing feed and query traffic to fail completely over to the remaining groups.
 </p><p>
 Valid parameter is a decimal value in the range [0, 1].
-Default is 0, which means that the automatic group out-of-service functionality will <em>not</em> automatically take effect.
+Default is 1, which means that the automatic group out-of-service functionality will automatically <em>take</em> effect.
 </p><p>
 Example: assume a cluster has been configured with <em>n</em> groups of 4 nodes each
 and the following tuning config:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

There is a bug in `min-node-ratio-per-group` docs https://docs.vespa.ai/en/reference/services-content.html#min-node-ratio-per-group

> Default is 0, which means that the automatic group out-of-service functionality will <em>not</em> automatically take effect.

This is not correct with at least Vespa version 8.363.17. The default is 1 because the group was taken out of action when 1 node out of 20 was put in maintenance. 