### PR TITLE
Exclude search.maven.org from link check

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -27,3 +27,4 @@ jobs:
         /hub.docker.com/r/
         /platform.openai.com/
         /www.ietf.org/
+        /search.maven.org/


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
