### PR TITLE
trigger on content files only

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -2,6 +2,12 @@ name: Vespa Documentation Search Feed
 on:
   push:
     branches: [ master ]
+    paths:
+      - '*.md'
+      - '*.html'
+      - '**/*.md'
+      - '**/*.html'
+      - '.github/workflows/feed.yml'
 
 env:
   DATA_PLANE_PUBLIC_KEY     : ${{ secrets.VESPA_TEAM_DATA_PLANE_PUBLIC_CERT }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -5,9 +5,21 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '*.md'
+      - '*.html'
+      - '**/*.md'
+      - '**/*.html'
+      - '.github/workflows/link-checker.yml'
   pull_request:
     branches:
       - master
+    paths:
+      - '*.md'
+      - '*.html'
+      - '**/*.md'
+      - '**/*.html'
+      - '.github/workflows/link-checker.yml'
   schedule:
     - cron: "00 3 * * 1-5"
 


### PR DESCRIPTION
I think it will suffice to run the link check once a day, and the scheduled run does that I believe - but it seems to run on regular commits, too, a mystery to me. With this PR, exclude the non-content files to begin with ...
