### PR TITLE
Make default-result-format.html more findable

### DIFF
--- a/en/reference/default-result-format.html
+++ b/en/reference/default-result-format.html
@@ -6,7 +6,7 @@ redirect_from:
 ---
 
 <p>
-  The default JSON result format is used when
+  The default Vespa query response format is used when
   <a href="../reference/query-api-reference.html#presentation.format">presentation.format</a>
   is unset or set to <code>json</code>.
   Results are rendered with one or more objects:


### PR DESCRIPTION
... I always query for "vespa query response format" and this does not show up ...

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
