### PR TITLE
Run link-checker.yml scheduled only

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -2,24 +2,6 @@ name: Link checker
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-    paths:
-      - '*.md'
-      - '*.html'
-      - '**/*.md'
-      - '**/*.html'
-      - '.github/workflows/link-checker.yml'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - '*.md'
-      - '*.html'
-      - '**/*.md'
-      - '**/*.html'
-      - '.github/workflows/link-checker.yml'
   schedule:
     - cron: "00 3 * * 1-5"
 


### PR DESCRIPTION
We definitely do not need this for PRs. I claim we don't need for master push, too, as we normally just look at this every morning, at this is low criticality