### PR TITLE
ignore link check for aclanthology.org

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,3 +22,4 @@ jobs:
         /platform.openai.com/
         /www.ietf.org/
         /search.maven.org/
+        /aclanthology.org/


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

>   External link https://aclanthology.org/D19-1671/ failed with something very wrong.
It's possible libcurl couldn't connect to the server, or perhaps the request timed out.
Sometimes, making too many requests at once also breaks things. (status code 0)