### PR TITLE
fix: swap cluster controller metric descriptions

### DIFF
--- a/en/reference/clustercontroller-metrics-reference.html
+++ b/en/reference/clustercontroller-metrics-reference.html
@@ -100,12 +100,12 @@ title: "ClusterController Metrics"
     </tr>
     <tr>
       <td><p id="cluster-controller_resource_usage_memory_limit">cluster-controller.resource_usage.memory_limit</p></td>
-      <td>Disk space limit as a fraction of available disk space</td>
+      <td>Memory space limit as a fraction of available memory</td>
       <td>fraction</td>
     </tr>
     <tr>
       <td><p id="cluster-controller_resource_usage_disk_limit">cluster-controller.resource_usage.disk_limit</p></td>
-      <td>Memory space limit as a fraction of available memory</td>
+      <td>Disk space limit as a fraction of available disk space</td>
       <td>fraction</td>
     </tr>
     <tr>


### PR DESCRIPTION
`cluster-controller.resource_usage.memory_limit` and `cluster-controller.resource_usage.disk_limit` descriptions were mixed, let's put them in place.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
