### PR TITLE
Use <code>, not <pre>

### DIFF
--- a/en/documents.html
+++ b/en/documents.html
@@ -213,7 +213,7 @@ music:title,artist
     <document type="music" selection="music.timestamp &gt; now() - 86400" />
 </documents>
 {% endhighlight %}</pre>
-<p>Note: The <pre>selection</pre> expression says which documents to <em>keep</em>, not which ones to delete.
+<p>Note: The <code>selection</code> expression says which documents to <em>keep</em>, not which ones to delete.
   The <em>timestamp</em> field must have a value in seconds since EPOCH:</p>
 <pre>
 field timestamp type long {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
