### PR TITLE
Ruby 3.2

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.2
         bundler-cache: true
 
     - uses: actions/setup-java@v4


### PR DESCRIPTION
- required by `activesupport-8.0.0 requires ruby version >= 3.2.0, which is incompatible with`
