### PR TITLE
fix(workflows): correct variable output handling and typo in script

### DIFF
--- a/.github/workflows/auto-update-documentation.yml
+++ b/.github/workflows/auto-update-documentation.yml
@@ -97,7 +97,7 @@ jobs:
             mv ${f}.new ${f};
           done
 
-          # ensure linka are to .html
+          # ensure links are to .html
           sed -i'' 's/\(vespa.*\).md)/\1.html)/' *.md
           # create links
           sed -i'' 's#\(https://[a-z.]*vespa.ai/[^[:space:]]*\)#[\1](\1)#g' *.md
@@ -144,8 +144,8 @@ jobs:
         run: |
           VESPA_VERSION=$(curl -sSL https://repo1.maven.org/maven2/com/yahoo/vespa/parent/maven-metadata.xml | \
            xq -x '/metadata/versioning/latest')
-          echo "Using version: $VESPA_VERSION"
-          echo "version=$VESPA_VERSION" >> $GITHUB_OUTPUT
+          echo "Using version: ${VESPA_VERSION}"
+          echo "version=$VESPA_VERSION" >> "${GITHUB_OUTPUT}"
 
       - name: Update Metric Reference
         id: update-docs
@@ -156,6 +156,7 @@ jobs:
           java -cp metrics.jar ai.vespa.metrics.docs.DocumentationGenerator en/reference
 
           git diff
+          echo "has-changes=$(git status --short | wc -l)" >> "${GITHUB_OUTPUT}"
 
       - name: Commit changes
         if: ${{ steps.update-docs.outputs.has-changes != '0' }}


### PR DESCRIPTION
## what

- Add missing output from a job step in auto-update-documentation.yml workflow

## why

- Fixes a bug where changes in update-metric-reference would not be committed
- Fixes VESPANG-825

## additional info

Seen in action here: https://github.com/vespa-engine/documentation/actions/runs/11950205666