### PR TITLE
fix: Add parentheses around a annotation to fix a syntax error

### DIFF
--- a/en/reference/query-language-reference.html
+++ b/en/reference/query-language-reference.html
@@ -2047,7 +2047,7 @@ where title contains ({weight:200}"heads")
   Consider the following query:
 </p>
 <pre>
-select * from sources * where ({stem: false}(foo contains "a" and bar contains "b")) or foo contains {stem: false}"c"
+select * from sources * where ({stem: false}(foo contains "a" and bar contains "b")) or foo contains ({stem: false}"c")
 </pre>
 <p>
   The "stem" annotation controls whether a given term should be stemmed if its


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The current example doesn't parse and run. Vespa gives the following error: `Could not create query from YQL: query:L1:114 extraneous input '\"c\"' expecting {<EOF>, 'select', ';'}`