### PR TITLE
fix: only commit if there are changes on auto-update-documentation workflow

### DIFF
--- a/.github/workflows/auto-update-documentation.yml
+++ b/.github/workflows/auto-update-documentation.yml
@@ -154,9 +154,10 @@ jobs:
         run: |
           curl -SsLo metrics.jar "https://repo1.maven.org/maven2/com/yahoo/vespa/metrics/${VESPA_VERSION}/metrics-${VESPA_VERSION}.jar"
           java -cp metrics.jar ai.vespa.metrics.docs.DocumentationGenerator en/reference
-
-          git diff
-          echo "has-changes=$(git status --short | wc -l)" >> "${GITHUB_OUTPUT}"
+          rm metrics.jar
+          
+          git diff -- en/reference
+          echo "has-changes=$(git status --short -- en/reference | wc -l)" >> "${GITHUB_OUTPUT}"
 
       - name: Commit changes
         if: ${{ steps.update-docs.outputs.has-changes != '0' }}


### PR DESCRIPTION
## What

Changes to the `auto-update-documentation.yml/update-metric-reference` workflow:

- Only check for a diff in the documentation directory

## Why

Only changes where are expected will be tracked, this prevents false positive in git diff.