### PR TITLE
Use same rate.idDimension for the three different clients

### DIFF
--- a/en/performance/rate-limiting-searcher.html
+++ b/en/performance/rate-limiting-searcher.html
@@ -118,20 +118,20 @@ title: "Rate Limiting Search Requests"
     <!-- default rate limiting; add specific query profile for clientId with other settings -->
     <field name="rate.quota">100</field>
     <field name="rate.id">default</field>
-    <field name="rate.idDimension">default</field>
+    <field name="rate.idDimension">clientID</field>
 
     <!-- rate limiting for requests with &amp;clientId=clientA -->
     <query-profile for="clientA">
         <field name="rate.quota">200</field>
         <field name="rate.id">clientA</field>
-        <field name="rate.idDimension">clientA</field>
+        <field name="rate.idDimension">clientID</field>
     </query-profile>
 
     <!-- rate limiting for requests with &amp;clientId=clientB -->
     <query-profile for="clientB">
         <field name="rate.quota">400</field>
         <field name="rate.id">clientB</field>
-        <field name="rate.idDimension">clientB</field>
+        <field name="rate.idDimension">clientID</field>
     </query-profile>
 </query-profile>
 {% endhighlight %}</pre>


### PR DESCRIPTION
@bratseth : Please review and merge. My understanding is that rate.idDimension is the dimension name used for the metrics emitted. Makes little sense to have this be different for each client?