### PR TITLE
fix: wrong parameter name: not `container` but `jdisc`

### DIFF
--- a/en/components/bundles.html
+++ b/en/components/bundles.html
@@ -185,10 +185,10 @@ Import-Package: org.osgi.framework;version="1.3.0"
 <pre>{% highlight xml %}
 <services version="1.0">
     <config name="search.config.qr-start">
-        <container>
+        <jdisc>
             <classpath_extra>/lib/jars/foo.jar:/path/bar.jar</classpath_extra>
             <export_packages>com.foo,com.bar</export_packages>
-        </container>
+        </jdisc>
     </config>
     ...
 </services>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The param seems to be called `jdisc` and not `container`. The source of the config class is [here](https://github.com/vespa-engine/vespa/blob/f6acdd12bb24f65c4b3a036dea79cddfd1f13dd4/container-search/src/main/resources/configdefinitions/search.config.qr-start.def#L44).
