### PR TITLE
Correct default feeding.concurrency

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -905,7 +905,7 @@ Tune <a href="../proton.html">proton</a> settings for feed operations. Optional 
 </p>
 <ul>
   <li id="feeding-concurrency"><code>concurrency</code>:
-    A number between 0.0 and 1.0 that specifies the concurrency when handling feed operations, default 0.5.
+    A number between 0.0 and 1.0 that specifies the concurrency when handling feed operations, default 0.2.
     When set to 1.0, all cores on the cpu can be used for feeding. Changing this value requires restart of
     node to take effect.
   </li>


### PR DESCRIPTION
correct default feeding.concurrency.

#### proton.def
```
feeding.concurrency double default = 0.2 restart
```
https://github.com/vespa-engine/vespa/blob/v8.461.16/configdefinitions/src/vespa/proton.def#L473