### PR TITLE
Add note on Jekyll force-polling to ensure docs are rebuilt on local changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ or RHEL 8
     $ podman run -it --rm --name doc -p 4000:4000 -e JEKYLL_ROOTLESS=true \
       -v "$PWD":/srv/jekyll:Z docker.io/jekyll/jekyll jekyll serve
 
+The Jekyll server should normally rebuild HTML files automatically
+when a source files changes. If this does not happen, you can use
+`jekyll serve --force-polling` as a workaround.
+
 The layout is written in [denali.design](https://denali.design/),
 see [_layouts/default.html](_layouts/default.html) for usage.
 Please do not add custom style sheets, as it is harder to maintain.


### PR DESCRIPTION
@kkraune please review
@geirst FYI

Although this _shouldn't_ be required, it seems this currently needs to be specified for automatic rebuilds to work, at least when running under macOS+Podman with a mapped directory.
