### PR TITLE
Mention that there can be only a single level of leaf groups under the top group

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -500,6 +500,7 @@ Contained in <a href="#content">content</a> or
 Defines the <a href="../elasticity.html#grouped-distribution">hierarchical structure</a> of the cluster.
 Can not be used in conjunction with the <a href="#nodes">nodes</a> element.
 Groups can contain other groups or nodes, but not both.
+There can only be a single level of leaf groups under the top group.
 </p><p>
 When using groups in <a href="https://vespa.ai/">Open Source Vespa</a>,
 <a href="#searchable-copies">searchable-copies</a> and


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

When trying to make a two-level grouping hierarchy for content nodes there was an error:
```
Invalid application:
Expected all groups under root group 'null' to be leaf groups only containing nodes, but sub group 'group1' contains 1 sub groups
```

It should clarify the allowed configurations of the content nodes.

This fact is mentioned in another documentation [page](https://docs.vespa.ai/en/performance/sizing-examples.html#grouped-distribution) which was discovered only after receiving the error.