### PR TITLE
Kkraune/grouping maps

### DIFF
--- a/en/grouping.html
+++ b/en/grouping.html
@@ -2028,7 +2028,51 @@ document-summary name_only {
 
 
 
-<h2 id="grouping-over-map-field">Grouping over Map field</h2>
+<h2 id="grouping-over-a-map-field">Grouping over a Map field</h2>
+<p>In the example data, a record looks like:</p>
+<pre>{% highlight json %}
+{
+  "fields": {
+    "attributes": {
+      "delivery_method": "Curbside Pickup",
+      "sales_rep": "Bonnie",
+      "coupon": "SAVE10"
+    },
+    "customer": "Smith",
+    "date": 1157526000,
+    "item": "Intake valve",
+    "price": "1000",
+    "tax": "0.24"
+  }
+}
+{% endhighlight %}</pre>
+<p>The map field <a href="/en/reference/schema-reference.html#map">schema definition</a> is:</p>
+<pre>
+field attributes type map<string, string> {
+    indexing: summary
+    struct-field key   { indexing: attribute }
+    struct-field value { indexing: attribute }
+}
+</pre>
 <p>
-
+  With this, one can group on both key (<code>delivery_method</code>, <code>sales_rep</code>, and <code>coupon</code>)
+  and values (here counting each value).
+  Try the link to see the output:
+</p>
+<p>
+  <a class="yql-x">select * from purchase where true limit 0 |
+    all(
+      group(attributes.key)
+      each( group(attributes.value) each(output(count())))
+    )</a>
+</p>
+<p>
+  A more interesting example is to see the sum per sales rep:
+</p>
+<p>
+  <a class="yql-x">select * from purchase where true limit 0 |
+    all(
+      group(attributes.key)
+      each( group(attributes.value) each(output(sum(price))))
+    )</a>
 </p>

--- a/en/grouping.html
+++ b/en/grouping.html
@@ -2025,3 +2025,10 @@ document-summary name_only {
     Use the <a href="#pagination">continuation token</a> to iterate over the result set.
   </li>
 </ul>
+
+
+
+<h2 id="grouping-over-map-field">Grouping over Map field</h2>
+<p>
+
+</p>

--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -440,6 +440,7 @@ struct person {
 
 field people type array&lt;person&gt; {
     indexing: summary
+    summary:  matched-elements-only
     struct-field first_name {
         indexing: attribute
         attribute: fast-search
@@ -645,67 +646,72 @@ field bignumber type long {
       <p id="map">
         Use to create a map where each unique key is mapped to a single value.
         Any primitive type can be used as <em>key-type</em> and any primitive type or Vespa struct type as <em>value-type</em>.
-        A map entry is handled as a struct with a <em>key</em> and <em>value</em> field
-        with <em>key-type</em> and <em>value-type</em> as types. Example:
-<pre>
-struct person {
-    field first_name type string {}
-    field last_name type string {}
-}
-field identities type map&lt;string, person&gt; {
-    indexing: summary
-    struct-field key {
-        indexing: attribute
-        attribute: fast-search
-    }
-    struct-field value.first_name {
-        indexing: attribute
-        attribute: fast-search
-    }
-}
-</pre>
-      <p>
-        The entire <em>identities</em> field is part of document summary,
-        and the <a href="#struct-field">struct fields</a>
-        <em>key</em> and <em>value.first_name</em> are defined as attributes, available for searching using the
-        <a href="query-language-reference.html#sameelement">sameElement</a> operator, and
-        <a href="grouping-syntax.html#multivalue-attributes">grouping</a>. The
-        attributes also have <code>fast-search</code>. See
-        <a href="../performance/feature-tuning.html#when-to-use-fast-search-for-attribute-fields">when to use fast-search</a>.
+        Example of a map of primitive types,
+        where the <em>key</em> and <em>value</em> fields are specified as <em>attributes</em>:
       </p>
-      <p>
-        Note that you can define only a subset of the struct fields as attributes.
-      </p>
-      <p>
-        Use <a href="#matched-elements-only">matched-elements-only</a>
-        to reduce the amount of data that is returned in document summary.
-      </p><p>
-      The next example shows a map of primitive types,
-      where the <em>key</em> and <em>value</em> struct fields are specified as attributes:
 <pre>
 field my_map type map&lt;string, int&gt; {
     indexing: summary
-    struct-field key { indexing: attribute }
+    struct-field key   { indexing: attribute }
     struct-field value { indexing: attribute }
 }
 </pre>
-      The following array of struct example is similar to the above,
-      the difference being that an array can contain the same element multiple times and maintains order.
+      <p>
+        Note that a Vespa map entry is handled as a <em>struct</em>
+        with a <em>key</em> and <em>value</em> field
+        with <em>key-type</em> and <em>value-type</em> as types.
+        This explains the <em>struct-field</em> syntax above.
+        The full <em>my_map</em> field is configured into the document summary.
+      </p>
+      <p>A more complex example is a map of struct:</p>
 <pre>
-struct mystruct {
-    field key type string { }
-    field value type int { }
+struct person {
+    field first_name type string {}
+    field last_name  type string {}
+    field age        type int {}
 }
-field my_array type array&lt;mystruct&gt; {
+
+field identities type map&lt;string, person&gt; {
     indexing: summary
+    summary:  matched-elements-only
     struct-field key {
-        indexing: attribute
+        indexing:  attribute
         attribute: fast-search
-        rank: filter
+    }
+    struct-field value.first_name {
+        indexing:  attribute
+        attribute: fast-search
+    }
+    struct-field value.last_name {
+        indexing:  attribute
+        attribute: fast-search
     }
 }
 </pre>
-      Restrictions:
+      <p>
+        This example illustrates that the struct elements are configured individually -
+        there is no field configuration for <em>age</em> -
+        one can define a subset of the struct fields as attributes.
+      </p>
+      <p>
+        Here, <em>key</em>, <em>value.first_name</em> and <em>value.last_name</em> are defined as attributes.
+        This makes them available for searching and <a href="/en/grouping.html#grouping-over-map-field">grouping</a>.
+        A common use case is requiring matches in the same map entry
+        (e.g. match both first and last name for the same person),
+        see the <a href="/en/reference/query-language-reference.html#sameelement">sameElement</a> operator
+        for how to implement this.
+        Use <a href="#matched-elements-only">matched-elements-only</a>
+        to reduce the amount of data in the document summary.
+        </p>
+      <p>
+        <a href="/en/performance/feature-tuning.html#when-to-use-fast-search-for-attribute-fields">fast-search</a>
+        is used to make query access faster by creating an index structure for lookups.
+      </p>
+      <p>
+        As a map alternative,
+        an <a href="#array">array&lt;struct&gt;</a> can contain the same element multiple times and maintains order.
+      </p>
+      <p>Restrictions:</p>
       <ul>
         <li>Map of struct or primitive types do not support <a href="../ranking.html">ranking features</a>
           and can only be used for matching and filtering.</li>
@@ -4166,8 +4172,8 @@ to: [document-summary-name], [document-summary-name], &hellip;
     but it can also be used when searching directly on a sub struct field.
     Is also supported when the field is <a href=#import-field>imported</a>.
     Is not supported for <a href="#index">index</a> fields in indexed search.
-    Example .sd files from system tests:
   </p>
+  <p>See <a href="#map">example use</a> and example schemas:</p>
   <ul>
     <li><a href="https://github.com/vespa-engine/system-test/blob/master/tests/search/matched_elements_only/indexed/test.sd">
       matched elements only</a></li>

--- a/en/reference/schema-reference.html
+++ b/en/reference/schema-reference.html
@@ -695,7 +695,7 @@ field identities type map&lt;string, person&gt; {
       </p>
       <p>
         Here, <em>key</em>, <em>value.first_name</em> and <em>value.last_name</em> are defined as attributes.
-        This makes them available for searching and <a href="/en/grouping.html#grouping-over-map-field">grouping</a>.
+        This makes them available for searching and <a href="/en/grouping.html#grouping-over-a-map-field">grouping</a>.
         A common use case is requiring matches in the same map entry
         (e.g. match both first and last name for the same person),
         see the <a href="/en/reference/query-language-reference.html#sameelement">sameElement</a> operator


### PR DESCRIPTION
- the ref doc for maps / array of struct was unclear, cleaned up
- added and example for grouping over a map field
- FYI @bjorncs  and @radu-gheorghe 

this is part of a larger sweep. I will redo some of the `matched-elements-only` pieces, too, for now I stuffed an example in there so we have it. This will be separated to a better example and relate to the "how to reduce data size in results" by @andreer 

Related commits:
- https://github.com/vespa-cloud/vespa-documentation-search/pull/183
- https://github.com/vespa-engine/sample-apps/pull/1649 and https://github.com/vespa-engine/sample-apps/pull/1652