### PR TITLE
Remove reference to tfrank.py, as it does not exist

### DIFF
--- a/en/tutorials/text-search-ml.md
+++ b/en/tutorials/text-search-ml.md
@@ -437,15 +437,6 @@ which takes the entire ranked list into consideration when updating the model pa
 To illustrate this, we trained linear models using the [TF-Ranking framework](https://github.com/tensorflow/ranking).
 The framework is built on top of TensorFlow and allow us to specify pointwise, pairwise and listwise loss functions,
 among other things.
-The following script was used to generate the results below
-(just remember to increase the number of training steps when using the script).
-
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre>
-$ ./src/python/tfrank.py
-</pre>
-</div>
 
 The two _rank-profile_'s below are obtained by training the linear model with a pointwise (sigmoid cross-entropy)
 and listwise (softmax cross-entropy) loss functions, respectively:


### PR DESCRIPTION
The tutorial [text-search-ml](https://docs.vespa.ai/en/tutorials/text-search-ml.html) mentions a python script `tfrank.py`:

> To illustrate this, we trained linear models using the [TF-Ranking framework](https://github.com/tensorflow/ranking). The framework is built on top of TensorFlow and allow us to specify pointwise, pairwise and listwise loss functions, among other things. The following script was used to generate the results below (just remember to increase the number of training steps when using the script).

> `./src/python/tfrank.py`

However, that file is not found anywhere in [text-search/python](https://github.com/vespa-engine/sample-apps/tree/master/text-search/python) or even in the parent repo [vespa-engine/sample-apps](https://github.com/vespa-engine/sample-apps/).
