### PR TITLE
To configure OpenNlpLinguistics, it must be declared as a component

### DIFF
--- a/en/linguistics.html
+++ b/en/linguistics.html
@@ -91,9 +91,11 @@ width="810px" height="auto" />
 <pre>
   &lt;container id="..." version="1.0"&gt;
     ...
-    &lt;config name="ai.vespa.opennlp.open-nlp"&gt;
-      &lt;snowballStemmingForEnglish&gt;true&lt;/snowballStemmingForEnglish&gt;
-    &lt;/config&gt;
+    &lt;component id="com.yahoo.language.opennlp.OpenNlpLinguistics"&gt;
+      &lt;config name="ai.vespa.opennlp.open-nlp"&gt;
+        &lt;snowballStemmingForEnglish&gt;true&lt;/snowballStemmingForEnglish&gt;
+      &lt;/config&gt;
+    &lt;/component&gt;
 </pre>
 
   <p>See <em>Tokens</em> <a href="https://opennlp.apache.org/models.html">OpenNLP models</a> and <a href="text-matching.html">text matching</a>
@@ -110,10 +112,12 @@ width="810px" height="auto" />
 <pre>
   &lt;container id="..." version="1.0"&gt;
     ...
-    &lt;config name="ai.vespa.opennlp.open-nlp"&gt;
-      &lt;cjk&gt;true&lt;/cjk&gt;
-      &lt;createCjkGrams&gt;true&lt;/createCjkGrams&gt;
-    &lt;/config&gt;
+    &lt;component id="com.yahoo.language.opennlp.OpenNlpLinguistics"&gt;
+      &lt;config name="ai.vespa.opennlp.open-nlp"&gt;
+        &lt;cjk&gt;true&lt;/cjk&gt;
+        &lt;createCjkGrams&gt;true&lt;/createCjkGrams&gt;
+      &lt;/config&gt;
+    &lt;/component&gt;
 </pre>
 
 <p>The createCjkGrams adds substrings of segments longer than 2 characters, which may increase recall.</p>
@@ -279,18 +283,18 @@ $ vespa query "select * from music where userInput(@text)" \
 
 
 <h3 id="multiple-languages">Multiple languages</h3>
-<p>Vespa supports having documents in multiple languages in the same schema, but does not out-of-the-box 
-  support cross-lingual retrieval (e.g., search using English and retrieve relevant documents written in German). 
-  
-  This is because the language of a query is determined 
-  by the language of the query string and only one transformation can take place. 
+<p>Vespa supports having documents in multiple languages in the same schema, but does not out-of-the-box
+  support cross-lingual retrieval (e.g., search using English and retrieve relevant documents written in German).
+
+  This is because the language of a query is determined
+  by the language of the query string and only one transformation can take place.
 </p>
 <p>
 Approaches to overcome this limitation include:
 </p>
 <ol>
     <li>
-        Use semantic retrieval using a multilingual text embedding model (see <a href="https://blog.vespa.ai/simplify-search-with-multilingual-embeddings/">blog post</a>) 
+        Use semantic retrieval using a multilingual text embedding model (see <a href="https://blog.vespa.ai/simplify-search-with-multilingual-embeddings/">blog post</a>)
         which has been trained on multilingual corpus and can be used to retrieve documents in multiple languages.
     </li><li>
         Stem and tokenize the query using the relevant languages,


### PR DESCRIPTION
The documented way to configure createCjkGrams had no effect. Looking at the systemtest it seems it's necessary do declare a component in services.xml - not sure if this is supposed to be necessary.
This PR follows the recommended way to configure components from https://docs.vespa.ai/en/configuring-components.html and I've tested that it actually takes effect.

@bratseth please review
@kkraune @bjormel FYI