### PR TITLE
Escaping for schema snippet in grouping

### DIFF
--- a/en/grouping.html
+++ b/en/grouping.html
@@ -2048,7 +2048,7 @@ document-summary name_only {
 {% endhighlight %}</pre>
 <p>The map field <a href="/en/reference/schema-reference.html#map">schema definition</a> is:</p>
 <pre>
-field attributes type map<string, string> {
+field attributes type map&lt;string, string&gt; {
     indexing: summary
     struct-field key   { indexing: attribute }
     struct-field value { indexing: attribute }


### PR DESCRIPTION
Now the `<string, string>` shows.