### PR TITLE
fix: update deploy commands to specify application path

### DIFF
--- a/en/cloud/getting-started-java.html
+++ b/en/cloud/getting-started-java.html
@@ -136,7 +136,7 @@ $ mvn -U package
     <div class="pre-parent">
       <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 600
+$ vespa deploy --wait 600 ./app
 </pre>
     </div>
     <p>

--- a/en/cloud/getting-started.html
+++ b/en/cloud/getting-started.html
@@ -119,7 +119,7 @@ $ vespa auth cert
     <div class="pre-parent">
       <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 600
+$ vespa deploy --wait 600 ./app
 </pre>
     </div>
     <p>

--- a/en/vespa-quick-start-java.html
+++ b/en/vespa-quick-start-java.html
@@ -101,7 +101,7 @@ $ mvn install
     <div class="pre-parent">
       <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300
+$ vespa deploy --wait 300 ./app
 </pre>
     </div>
   </li>

--- a/en/vespa-quick-start.html
+++ b/en/vespa-quick-start.html
@@ -94,7 +94,7 @@ $ vespa clone album-recommendation myapp &amp;&amp; cd myapp
   <div class="pre-parent">
     <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300
+$ vespa deploy --wait 300 ./app
 </pre>
   </div>
 </li>


### PR DESCRIPTION
## What

* update deploy commands to specify application path

## Why

* Fixes tests ran during build.
* The sample-apps repo is going through a standardization process and this involves moving all the Vespa application package files inside the `./app` directory. 
    * Ref: https://github.com/vespa-engine/sample-apps/pull/1670

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
