### PR TITLE
remove the important css classes overriding column widths by setting …

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -894,11 +894,6 @@ table:not(table table) {
     min-width: fit-content;
     word-break: normal;
 }
-  
-/*Temporary solution of the grid conflict */
-  .lg-col-3-12 {
-    width: 25% !important;
-}
-.lg-col-6-12 {
-    width: 50% !important;
+.col{
+    min-width: 0;
 }


### PR DESCRIPTION
…a min-width 0 on the column

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
