### PR TITLE
Remove stale/invalid info about process pid files

### DIFF
--- a/en/operations-selfhosted/admin-procedures.html
+++ b/en/operations-selfhosted/admin-procedures.html
@@ -72,7 +72,7 @@ and is the recommended way to stop Vespa on a node." %}
 
 <h2 id="status-pages">Status pages</h2>
 <p>
-  All Vespa services have status pages, for showing healt, Vespa version, config and metrics.
+  All Vespa services have status pages, for showing health, Vespa version, config, and metrics.
   Status pages are subject to change at any time - take care when automating. Procedure:
 </p>
 <ol>

--- a/en/operations-selfhosted/admin-procedures.html
+++ b/en/operations-selfhosted/admin-procedures.html
@@ -21,7 +21,6 @@ redirect_from:
 
 <h2 id="vespa-start-stop-restart">Vespa start / stop / restart</h2>
 <p>
-  There is no restart command, do a stop then start for a restart.
   Start and stop <span style="text-decoration: underline">all</span> services on a node:
 </p>
 <pre>
@@ -34,6 +33,7 @@ $ $VESPA_HOME/bin/<a href="/en/operations-selfhosted/vespa-cmdline-tools.html#ve
 $ $VESPA_HOME/bin/<a href="/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-stop-configserver">vespa-stop-configserver</a>
 </pre>
 <p>
+  There is no <em>restart</em> command, do a <em>stop</em> then <em>start</em> for a restart.
   Learn more about which processes / services are started at <a href="/en/operations-selfhosted/config-sentinel.html">Vespa startup</a>,
   read the <a href="/en/operations-selfhosted/configuration-server.html#start-sequence">start sequence</a>
   and find training videos in the vespaengine <a href="https://www.youtube.com/@vespaai">YouTube channel</a>.
@@ -46,7 +46,7 @@ $ $VESPA_HOME/bin/<a href="/en/operations-selfhosted/vespa-cmdline-tools.html#ve
 <a href='/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-proton-cmd'>prepareRestart</a> to optimize restart time,
 and is the recommended way to stop Vespa on a node." %}
 <p>
-  See <a href="multinode-systems.html#aws-ec2">multinode</a> for <em>systemd</em>/<em>systemctl</em> examples.
+  See <a href="multinode-systems.html#aws-ec2">multinode</a> for <em>systemd</em> /<em>systemctl</em> examples.
   <a href="/en/operations-selfhosted/docker-containers.html">Docker containers</a> has relevant start/stop information, too.
 </p>
 
@@ -55,7 +55,7 @@ and is the recommended way to stop Vespa on a node." %}
 <h2 id="system-status">System status</h2>
 <ul>
   <li>Use <a href="/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-config-status">vespa-config-status</a>
-    on all nodes in <a href="../reference/hosts.html">hosts.xml</a> to verify all services run with updated config</li>
+    on a node in <a href="../reference/hosts.html">hosts.xml</a> to verify all services run with updated config</li>
   <li>Make sure <a href="/en/operations-selfhosted/files-processes-and-ports.html#environment-variables">
     VESPA_CONFIGSERVERS</a> is set and identical on all nodes in hosts.xml</li>
   <li>Use the <em>cluster controller</em> status page (below)
@@ -70,23 +70,9 @@ and is the recommended way to stop Vespa on a node." %}
 <!-- ToDo: https://github.com/vespa-engine/vespa/issues/18555
  Tool to check a cluster's status like Vespa Cloud's deploy output -->
 
-
-
-<h2 id="process-pid-files">Process PID files</h2>
-<p>
-  All Vespa processes have a PID file <em>$VESPA_HOME/var/run/{service name}.pid</em>,
-  where <em>{service name}</em> is the Vespa service name, e.g. <em>container</em> or <em>distributor</em>.
-  It is the same name which is used in the administration interface
-  in the <a href="/en/operations-selfhosted/config-sentinel.html">config sentinel</a>.
-</p><p>
-  Learn how to <a href="#vespa-start-stop-restart">start / stop</a> nodes.
-</p>
-
-
-
 <h2 id="status-pages">Status pages</h2>
 <p>
-  Vespa service instances have status pages for debugging and testing.
+  All Vespa services have status pages, for showing healt, Vespa version, config and metrics.
   Status pages are subject to change at any time - take care when automating. Procedure:
 </p>
 <ol>
@@ -171,7 +157,7 @@ $ <a href="/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-model-inspec
 <p>
   Also see the cluster controller <a href="#status-pages">status page</a>.
 </p><p>
-  State is persisted in a ZooKeeper cluster, restarting/changing a cluster controller preserves this:
+  State is persisted in a ZooKeeper cluster, restarting/changing a cluster controller preserves:
 </p>
 <ul>
   <li>Last cluster state version number, for new cluster controller handover at restarts</li>
@@ -186,7 +172,7 @@ $ <a href="/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-model-inspec
 
 <h2 id="cluster-controller-configuration">Cluster controller configuration</h2>
 <p>
-  It is recommended to run the cluster controller on the same hosts as
+  It is recommended to run cluster controllers on the same hosts as
   <a href="/en/operations-selfhosted/configuration-server.html">config servers</a>,
   as they share a zookeeper cluster for state and deploying three nodes is best practise for both.
   See the <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA">multinode-HA</a>


### PR DESCRIPTION
Some other minor improvements

There are pid files only for sentinel, config proxy and config server, so doc was wrong. I think it's enough to know how to start and stop services and config server.