### PR TITLE
Fix Playground icon overlap

### DIFF
--- a/playground/css/playground.css
+++ b/playground/css/playground.css
@@ -239,12 +239,12 @@ a {
 }
 
 a > svg {
-    position: relative;
+    position: static;
     top: 6px;
 }
 
 a.header > svg {
-    position: relative;
+    position: static;
     top: 0px;
 }
 


### PR DESCRIPTION
You can see [playground](https://docs.vespa.ai/playground/) and notice that the SVG icons in the frame’s header are overlapping with the main page header:
![image](https://github.com/user-attachments/assets/41fdb3e9-7767-4065-928f-a42f1137b51d)
This small fix solves the problem and makes the layout look like this (no overlap):
![image](https://github.com/user-attachments/assets/ad42a402-8d54-46ee-a1bc-439e63d7616c)
