### PR TITLE
Remove internal config doc from contributing section

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -603,11 +603,3 @@ docs:
         url: /en/build-install-vespa.html
       - page: Documentation Conventions
         url: /en/introduction-to-documentation.html
-      - page: Config API
-        url: /en/contributing/configapi-dev.html
-      - page: Developing Config Model Plugins
-        url: /en/contributing/cloudconfig-model-plugins.html
-      - page: Developing with the Java Cloud Config API
-        url: /en/contributing/configapi-dev-java.html
-      - page: Using the C++ Cloud config API
-        url: /en/contributing/configapi-dev-cpp.html


### PR DESCRIPTION
This is internal/developer doc (and probably stale in some regards), it should not be in contributing section at least, not sure where the right place for it is, I'll follow up