### PR TITLE
Headings from commented sections in TOC fix

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,7 +1,13 @@
 <!-- Copyright Vespa.ai. All rights reserved. -->
 {% assign h2_count = content | split: '<h' | size | minus: 1 %}
     {% if h2_count > 4 %}
-  
+ 
+<!-- script to exclude comments from the content before headings parsing -->
+<script>
+  const content = '{{ content | escape }}'; // Your Liquid content
+  const cleanContent = content.replace(/<!--[\s\S]*?-->/g, ''); // Regex to remove comments
+  document.getElementById('content').innerHTML = cleanContent;
+</script>
 
 <nav class="toc {% if page.title == 'FAQ - frequently asked questions'%} faq-toc {% endif %}" aria-labelledby="on-this-page-heading" style="position: fixed; align-self: flex-start;">
     <h3 id="on-this-page-heading"  style="pointer-events: none;">On this page:</h3>


### PR DESCRIPTION
Solution is regex which excludes `<!--`,` -->` and anything between them from content to parse
