### PR TITLE
Revert "Podman: Set memory, use crane to get latest version"

### DIFF
--- a/en/vespa-quick-start.html
+++ b/en/vespa-quick-start.html
@@ -65,7 +65,7 @@ $ vespa config set target local
 <pre data-test="exec">
 $ docker run --detach --name vespa --hostname vespa-container \
   --publish 8080:8080 --publish 19071:19071 \
-  vespaengine/vespa@$(crane digest vespaengine/vespa)
+  vespaengine/vespa
 </pre>
   </div>
 <p>


### PR DESCRIPTION
Reverts vespa-engine/documentation#3847

this breaks everyone with crane not installed - I agree with the intention but lets find a better way