### PR TITLE
metrics related clarification: 1 minute sliding window

### DIFF
--- a/en/operations/metrics.html
+++ b/en/operations/metrics.html
@@ -10,6 +10,7 @@ redirect_from:
   Metrics for all nodes is aggregated using
   <em><a href="../reference/metrics-v2.html#metrics-v2-values">/metrics/v2/values</a></em> or
   <em><a href="../reference/prometheus-v1.html#prometheus-v1-values">/prometheus/v1/values</a></em>.
+  Values from these endpoints reflect the 1 minute activity immediately before the request.
 </p>
 <p>Example getting a metric value from using the prometheus endpoint:</p>
 


### PR DESCRIPTION
Currently the metrics documentation doesn't provide the information regarding the `to` and `from` timestamps the metrics reflect on. As discussed with @radu-gheorghe the metrics are a snapshot on a 1 min sliding window. Added the same information to the metrics documentation page. 

I think this detail will be the most relevant [here](https://docs.vespa.ai/en/operations/metrics.html?mode=selfhosted)

[Reference Slack thread](https://vespatalk.slack.com/archives/C01QNBPPNT1/p1746677788535259?thread_ts=1743491495.323379&cid=C01QNBPPNT1)