### PR TITLE
added example endpoint comment

### DIFF
--- a/en/llms-external.md
+++ b/en/llms-external.md
@@ -36,6 +36,7 @@ define a component in your application's
             <!-- Optional configuration: -->
             <config name="ai.vespa.llm.clients.llm-client">
                 <apiKeySecretName> ... </apiKeySecretName>
+                <!-- endpoint example: https://openai-compatible-api.com/v1/ -->
                 <endpoint> ... </endpoint>
             </config>
 


### PR DESCRIPTION
I should have probably proposed this on slack first but I took the liberty of adding a comment on the external LLMs config page to indicate expected url needs the `v1` path. This is something I myself got confused with while referring to this page configuring ollama and vllm services as a client.

Not sure if this might be confusing for other usecases so pleases feel free to reject the request.  

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
