### PR TITLE
Add use of maintenance mode to admin procedure documentation

### DIFF
--- a/en/operations-selfhosted/admin-procedures.html
+++ b/en/operations-selfhosted/admin-procedures.html
@@ -49,8 +49,32 @@ and is the recommended way to stop Vespa on a node." %}
   See <a href="multinode-systems.html#aws-ec2">multinode</a> for <em>systemd</em> /<em>systemctl</em> examples.
   <a href="/en/operations-selfhosted/docker-containers.html">Docker containers</a> has relevant start/stop information, too.
 </p>
-
-
+<h3>Content node maintenance mode</h3>
+<p>
+  When stopping a content node <em>temporarily</em> (e.g. for a software upgrade), consider manually setting the node into
+  <a href="../reference/cluster-v2.html#maintenance">maintenance mode</a> <em>before</em> stopping the node to prevent
+  automatic redistribution of data while the node is down. Maintenance mode must be manually removed once the node has
+  come back online. See also: <a href="#cluster-state">cluster state</a>.
+</p>
+<p>
+  Example of setting a node with <a href="../reference/services-content.html#node">distribution key</a> 42 into
+  <code>maintenance</code> mode using <a href="vespa-cmdline-tools.html#vespa-set-node-state">vespa-set-node-state</a>,
+  additionally supplying a reason that will be recorded by the cluster controller:
+</p>
+<pre>
+  $ vespa-set-node-state --type storage --index 42 maintenance "rebooting for software upgrade"
+</pre>
+<p>
+  After the node has come back online, clear maintenance mode by marking the node as <code>up</code>:
+</p>
+<pre>
+  $ vespa-set-node-state --type storage --index 42 up
+</pre>
+<p>
+  Note that if the above commands are executed <em>locally</em> on the host running the services for node 42,
+  <code>--index 42</code> can be omitted; <code>vespa-set-node-state</code> will use the distribution key of
+  the local node if no <code>--index</code> has been explicitly specified.
+</p>
 
 <h2 id="system-status">System status</h2>
 <ul>

--- a/en/operations-selfhosted/admin-procedures.html
+++ b/en/operations-selfhosted/admin-procedures.html
@@ -49,7 +49,7 @@ and is the recommended way to stop Vespa on a node." %}
   See <a href="multinode-systems.html#aws-ec2">multinode</a> for <em>systemd</em> /<em>systemctl</em> examples.
   <a href="/en/operations-selfhosted/docker-containers.html">Docker containers</a> has relevant start/stop information, too.
 </p>
-<h3>Content node maintenance mode</h3>
+<h3 id="content-node-maintenance-mode">Content node maintenance mode</h3>
 <p>
   When stopping a content node <em>temporarily</em> (e.g. for a software upgrade), consider manually setting the node into
   <a href="../reference/cluster-v2.html#maintenance">maintenance mode</a> <em>before</em> stopping the node to prevent


### PR DESCRIPTION
@kkraune please review

Not knowing the subtle and fine art of using `maintenance` mode when temporarily taking content nodes down is a frequent occurrence amongst users, which isn't too strange since you really have to know where to look in order to learn about it. To make things a bit better, mention the use of `vespa-set-node-state` explicitly under the ops procedures for stopping and starting a Vespa node.

