### PR TITLE
Remove sidebar from printed version

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -196,6 +196,12 @@ button.section-searchbar {
         height: 473px;
     }
 }
+/* Printed version styling */
+@media print {
+    #sidebar {
+        display: none;
+    }
+}
 
 /* Guides */
 .section-guide--item {
@@ -466,7 +472,10 @@ pre > code {
     margin: 2px 16px;
     
 }
-
+a.tab-link {
+    word-break: break-word;
+    white-space: normal;
+  }
 .denali-theme-vespa-light .tabs.is-primary.is-vertical ul li.tabs__section-header {
     height: auto;
     padding: 0;


### PR DESCRIPTION
So that's how printed version of the first page looks like now:

<img width="561" alt="image" src="https://github.com/user-attachments/assets/b4c30b85-c6ae-49c4-9051-5a7b42fbacf7" />

Is there any edits wanted, please, let me know.

