### PR TITLE
Fix typo which breaks executable grouping cells

### DIFF
--- a/en/grouping.html
+++ b/en/grouping.html
@@ -137,7 +137,7 @@ function executeGrouping(yql, outputContainer) {
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       return response.json();
     })
-    .then(jsonDate => {
+    .then(jsonData => {
       const groupingResponses = jsonData.root.children?.[0]?.children ?? [];
       console.log(groupingResponses);
       outputContainer.innerHTML = '';


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
