### PR TITLE
Update sidebar: remove glitching after clicking the tab, fixing togle the parent tab, add word-break on the tabs

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,56 +6,118 @@
 	  <li class="collapse-all tabs__section-header" onclick="expandAllItems();" id="collapse-all"><span class="d-icon d-add-circle" style="font-size: 16px; max-width: 20px; padding-left: 0"></span>expand all</li>
 	  <li class="collapse-all tabs__section-header hide" onclick="collapseAllItems();" id="expand-all"><span class="d-icon d-minus-circle" style="font-size: 16px; max-width: 20px; padding-left: 0"></span>collapse all</li>
 	</ul>
-    {% if site.data.sidebar.docs[0] %}
-        {% for section in site.data.sidebar.docs %}
-            <ul class="p-b-0{% if section.mode %} mode-{{ section.mode }} {% endif %}">
-                {% if page.url == section.url %}
-                    <li class="collapse-parent tabs__section-header active" onclick="toggleCollapse(this);"><b><a class="tab-link" href="{{ section.url }}">{{ section.title }}</a></b></li>
-                {% else %}
-                    <li class="collapse-parent tabs__section-header" onclick="toggleCollapse(this);"><a class="tab-link" {% if section.url %} href="{{ section.url }}" {% endif %}>{{ section.title }}</a></li>
-                {% endif %}
-                {% if section.documents[0] %}
-                    {% for entry in section.documents %}
-						{% if entry.sub%}
-							<ul class="m-l-10 inner-ul collapsable collapsed">
-								{% if page.url == entry.url %}
-                    				<li class="collapse-parent tabs__section-sub collapsable inner-ul-child active" onclick="toggleCollapse(this);"><b><a class="tab-link" href="{{ entry.url }}">{{ entry.page }}</a></b></li>
-                				{% else %}
-                    				<li class="collapse-parent tabs__section-sub collapsable inner-ul-child" onclick="toggleCollapse(this);"><a class="tab-link" {% if entry.url %} href="{{ entry.url }}" {% endif %}>{{ entry.page }}</a></li>
-                				{% endif %}
-								{% for item in entry.sub %}
-									{% if page.url == item.url %}
-										<li class="m-l-10 collapsable active inner-ul-child"><b><a class="tab-link" {% if item.url %} href="{{ item.url }}" {% endif %}>{{ item.page }}</b></a></li>
-									{% else %}
-										<li class="m-l-10 collapsable inner-ul-child"><a class="tab-link" {% if item.url %} href="{{ item.url }}" {% endif %}>{{ item.page }}</a></li>
-									{%endif%}
-								{%endfor%}
-							</ul>
-						{%else%}
-                    		{% if entry.sidebar_exclude != true %}
-                        		{% if entry.sidebar_exclude != true %}
-                            		{% if entry.url == page.url %}
-                                		<li class="m-l-10 collapsable active{% if section.mode %} mode-{{ section.mode }} {% endif %}"><b><a class="tab-link"  href="{{ entry.url }}">{{ entry.page }}</a></b></li>
-                            		{% else %}
-                                		<li class="m-l-10 collapsable{% if section.mode %} mode-{{ section.mode }} {% endif %}"><a class="tab-link" href="{{ entry.url }}">{{ entry.page }}</a></li>
-                            		{% endif %}
-                        		{%endif%}	
-                    		{%endif%}
-						{% endif %}
-            		{%endfor%}
-                {%endif%}
-            </ul>
-        {% endfor %}
-    {% endif %}
+	{% assign is_first_level_expanded = false %}
+
+	{%- for section in site.data.sidebar.docs -%}
+	  {%- assign current_section_expanded = false -%}
+	
+	  {%- if page.url == section.url -%}
+		{%- assign current_section_expanded = true -%}
+	  {%- endif -%}
+	
+	  {%- if section.documents -%}
+		{%- for entry in section.documents -%}
+		  {%- if page.url == entry.url -%}
+			{%- assign current_section_expanded = true -%}
+		  {%- endif -%}
+		  {%- if entry.sub -%}
+			{%- for item in entry.sub -%}
+			  {%- if page.url == item.url -%}
+				{%- assign current_section_expanded = true -%}
+			  {%- endif -%}
+			{%- endfor -%}
+		  {%- endif -%}
+		{%- endfor -%}
+	  {%- endif -%}
+	
+	  {%- if current_section_expanded -%}
+		{% assign is_first_level_expanded = true %}
+	  {%- endif -%}
+	{% endfor %}
+	
+	
+	{%- for section in site.data.sidebar.docs -%}
+	  {% assign current_section_expanded = false %}
+	
+	  {%- if page.url == section.url -%}
+		{% assign current_section_expanded = true %}
+	  {%- endif -%}
+	
+	  {%- if section.documents -%}
+		{%- for entry in section.documents -%}
+		  {%- if page.url == entry.url -%}
+			{% assign current_section_expanded = true %}
+		  {%- endif -%}
+		  {%- if entry.sub -%}
+			{%- for item in entry.sub -%}
+			  {%- if page.url == item.url -%}
+				{% assign current_section_expanded = true %}
+			  {%- endif -%}
+			{%- endfor -%}
+		  {%- endif -%}
+		{%- endfor -%}
+	  {%- endif -%}
+	
+	  <ul class="p-b-0{% if section.mode %} mode-{{ section.mode }}{% endif %}{% if current_section_expanded %} show{% endif %}">
+		<li class="collapse-parent tabs__section-header{% if current_section_expanded %} active{% endif %}" onclick="toggleCollapse(this);">
+		  <a class="tab-link"{% if section.url  and  page.url != section.url %} href="{{ section.url }}"{% endif %}><b>{{ section.title }}</b></a>
+		</li>
+	
+		{% if section.documents %}
+		  {% for entry in section.documents %}
+			{% assign is_second_level_expanded = false %}
+			{% assign is_third_level_expanded = false %}
+	
+			{% if page.url == entry.url %}
+			  {% assign is_second_level_expanded = true %}
+			{% endif %}
+	
+			{% if entry.sub %}
+			  {% for item in entry.sub %}
+				{% if page.url == item.url %}
+				  {% assign is_third_level_expanded = true %}
+				  {% assign is_second_level_expanded = true %}
+				{% endif %}
+			  {% endfor %}
+			{% endif %}
+	
+			{% if entry.sub %}
+			  <ul class="m-l-10 inner-ul collapsable{% if is_second_level_expanded %} show{% endif %}">
+				<li class="collapse-parent tabs__section-sub collapsable inner-ul-child{% if is_second_level_expanded %} active{% endif %} {% unless is_first_level_expanded and current_section_expanded %} collapsed{% endunless %}" onclick="toggleCollapse(this);">
+				  <a class="tab-link"{% if entry.url and  page.url != entry.url %} href="{{ entry.url }}"{% endif %}>
+					{% if is_second_level_expanded %}<b>{{ entry.page }}</b>{% else %}{{ entry.page }}{% endif %}
+				  </a>
+				</li>
+				{% for item in entry.sub %}
+				  <li class="m-l-10 collapsable inner-ul-child{% if is_third_level_expanded and page.url == item.url %} active{% endif %}{% unless is_second_level_expanded %} collapsed{% endunless %}">
+					<a class="tab-link"{% if item.url and  page.url != item.url %} href="{{ item.url }}"{% endif %}>
+					  {% if page.url == item.url %}<b>{{ item.page }}</b>{% else %}{{ item.page }}{% endif %}
+					</a>
+				  </li>
+				{% endfor %}
+			  </ul>
+			{% else %}
+			  {% if entry.sidebar_exclude != true %}
+				<li class="m-l-10 collapsable{% if page.url == entry.url %} active{% endif %}{% unless current_section_expanded %} collapsed{% endunless %}{% if section.mode %} mode-{{ section.mode }}{% endif %}">
+				  <a class="tab-link" href="{{ entry.url }}">
+					{% if page.url == entry.url %}<b>{{ entry.page }}</b>{% else %}{{ entry.page }}{% endif %}
+				  </a>
+				</li>
+			  {% endif %}
+			{% endif %}
+		  {% endfor %}
+		{% endif %}
+	  </ul>
+	{% endfor %}
+	
+
 
   </div>
   
-  <script type="application/javascript">
-	  function initSidebar() {
-		  collapseAllItems();
-		  expandActiveSection();
-		  scrollSidebar(); 
-	  }
+<script type="application/javascript">
+	function initSidebar() {	  
+		scrollSidebar(); 
+	}
   
 	  function collapseAllItems() {
 		  document.getElementById('collapse-all').classList.remove('hide');
@@ -78,28 +140,6 @@
 			  item.parentElement.classList.add("show");
 		  }
 	  }
-
-	  function expandSection(section) {
-			for (const elem of getNextSiblings(section.parentNode.firstChild)) {
-				  elem.classList.remove("collapsed")
-				  if (elem.classList.contains("inner-ul")) {
-					elem.querySelector('li').classList.remove("collapsed");
-                }
-			}
-			section.parentElement.classList.add("show");
-		}
-
-	  function expandActiveSection() {
-		  let activeSections = document.getElementsByClassName("active");
-		  for (const section of activeSections) {
-			  expandSection(section);
-
-			  if(section.parentElement.classList.contains("inner-ul")) {
-				let activeParentSection = section.parentElement;
-				expandSection(activeParentSection)
-			  }
-			}
-		}
   
 	  function toggleCollapse(item) {
 		  item.parentElement.classList.toggle("show");

--- a/css/style.scss
+++ b/css/style.scss
@@ -380,9 +380,6 @@ pre > code {
 
 
 /* Sidebar */
-#sidebar {
-    scroll-behavior: smooth;
-}
 
 .collapse-parent {
     cursor: pointer;

--- a/css/style.scss
+++ b/css/style.scss
@@ -380,6 +380,10 @@ pre > code {
 
 
 /* Sidebar */
+#sidebar {
+    scroll-behavior: smooth;
+}
+
 .collapse-parent {
     cursor: pointer;
 }
@@ -478,6 +482,12 @@ pre > code {
     bottom: 0;
     left: 0;
     z-index: 3;
+}
+
+a.tab-link {
+    word-wrap: break-word;
+    white-space: normal;
+    font-weight: normal;
 }
 
 dt {


### PR DESCRIPTION
This PR addresses several issues with the sidebar:

- resolved tab glitching that occurred after clicking on a tab.

- fixed parent tab toggle behavior to ensure consistent expansion/collapse.

- added word-break styling to prevent tab titles from overflowing or breaking the layout.

These changes improve the sidebar's usability and visual consistency, especially in edge cases with longer tab names or frequent interactions.
