### PR TITLE
docs: add request-content logging to accesslog configuration

### DIFF
--- a/en/access-logging.html
+++ b/en/access-logging.html
@@ -113,6 +113,32 @@ For details on the access logging configuration see <a href="reference/services-
 accesslog in the container</a> element in <em>services.xml</em>.
 </p>
 
+<h3 id="logging-request-content">Logging Request Content</h3>
+<p>
+  Vespa supports logging of request content for specific URI paths. This is useful for inspecting query content of search POST requests 
+  or document operations of Document v1 POST/PUT requests. The request content is logged as a base64-encoded string in the JSON access log.
+</p>
+<p>
+  To configure request content logging, use the <a href="reference/services-container.html#request-content">request-content</a> element 
+  in the accesslog configuration in <em>services.xml</em>.
+</p>
+<p>
+  Here is an example of how the request content appears in the JSON access log:
+</p>
+<pre>
+{
+  ...
+  "method": "POST",
+  "uri": "/search",
+  ...,
+  "request-content": {
+    "type": "application/json; charset=utf-8",
+    "length": 12345,
+    "body": "&lt;raw bytes encoded with base64&gt;"
+  }
+}
+</pre>
+
 <h3 id="file-name-pattern">File name pattern</h3>
 <p>
 The file name pattern is expanded using the time when the file is created.

--- a/en/reference/services-container.html
+++ b/en/reference/services-container.html
@@ -56,6 +56,7 @@ container [version, id]
         <a href="../stateless-model-evaluation.html#onnx-inference-options">onnx</a>
     <a href="#document">document [type, class, bundle]</a>
     <a href="#accesslog">accesslog [type, fileNamePattern, symlinkName, rotationInterval, rotationScheme]</a>
+        <a href="#request-content">request-content [samples-per-second, path-prefix, max-bytes]</a>
     <a href="config-files.html#generic-configuration-in-services-xml">config</a>
     <a href="#nodes">nodes [allocated-memory, jvm-gc-options, jvm-options]</a>
         <a href="#environment-variables">environment-variables</a>
@@ -606,12 +607,46 @@ Access logging can be disabled by setting the type to <code>disabled</code>.
       <td><p id="accesslog.rotationScheme">Valid values are <em>date</em> or <em>sequence</em></p></td></tr>
   </tbody>
 </table>
+
+<h3 id="request-content">request-content</h3>
+<p>
+  The <code>request-content</code> element is a child of <code>accesslog</code> and configures logging of request content.
+  Multiple <code>request-content</code> elements can be specified to log different request paths with different configurations.
+</p>
+<table class="table">
+  <thead>
+    <tr><th>Element</th><th>Required</th><th>Value</th><th>Default</th><th>Description</th></tr>
+  </thead><tbody>
+    <tr><th>samples-per-second</th>
+      <td>required</td>
+      <td>double</td>
+      <td></td>
+      <td><p id="request-content.samples-per-second">Probabilistic sample rate per second</p></td></tr>
+    <tr><th>path-prefix</th>
+      <td>required</td>
+      <td>string</td>
+      <td></td>
+      <td><p id="request-content.path-prefix">URI path prefix to match for logging</p></td></tr>
+    <tr><th>max-bytes</th>
+      <td>required</td>
+      <td>integer</td>
+      <td></td>
+      <td><p id="request-content.max-bytes">Maximum size in bytes to log, only prefix will be kept for larger requests</p></td></tr>
+  </tbody>
+</table>
+
 <p>Example:</p>
 <pre>
-&lt;accesslog fileNamePattern="$VESPA_HOME/logs/vespa/access/JsonAccessLog.&lt;container id&gt;.%Y%m%d%H%M%S"
-           symlinkName="JsonAccessLog.&lt;container id&gt;"
-           rotationInterval="0 1 ..."
-           type="vespa" /&gt;
+  &lt;accesslog fileNamePattern="$VESPA_HOME/logs/vespa/access/JsonAccessLog.&lt;container id&gt;.%Y%m%d%H%M%S"
+             symlinkName="JsonAccessLog.&lt;container id&gt;"
+             rotationInterval="0 1 ..."
+             type="json" &gt;
+    &lt;request-content&gt;
+        &lt;samples-per-second&gt;0.2&lt;/samples-per-second&gt;
+        &lt;path-prefix&gt;/search&lt;/path-prefix&gt;
+        &lt;max-bytes&gt;65536&lt;/max-bytes&gt;
+    &lt;/request-content&gt;
+  &lt;/accesslog&gt;
 </pre>
 
 


### PR DESCRIPTION
Document the new <request-content> element in services.xml,
including its configuration options: samples-per-second, path-prefix,
and max-bytes. Provide example JSON output showing base64-encoded request
content and update related documentation to explain usage and benefits.

This enables users to inspect query content of POST requests and document
operations, improving observability and debugging capabilities.