### PR TITLE
Remove hamburger-icon from the printed version

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -198,7 +198,7 @@ button.section-searchbar {
 }
 /* Printed version styling */
 @media print {
-    #sidebar, .chip.chip-cloud, .chip.chip-oss {
+    #sidebar, .chip.chip-cloud, .chip.chip-oss, .d-menu-hamburger {
         display: none;
     }
 }


### PR DESCRIPTION
It's a change to a printed version which removes an icon close to vespa-logo from it:
![image](https://github.com/user-attachments/assets/9d9e430c-ec38-4be2-a312-e2b8fd63532d)
After:
![image](https://github.com/user-attachments/assets/cc1616f9-3af7-45fe-a92c-0e364695d576)


