### PR TITLE
Add documentation for private model hub embedders

### DIFF
--- a/en/embedding.html
+++ b/en/embedding.html
@@ -171,7 +171,7 @@ to produce tokens which are then input to a supplied transformer model in <a hre
 <code>url</code> to supply them from a remote server, or
 <code>model-id</code> to use a
 <a href="https://cloud.vespa.ai/en/model-hub#hugging-face-embedder">model supplied by Vespa Cloud</a>.
-You can also use a model hosted in private Huggingface Model Hub by configuring adding your Huggingface API token
+You can also use a model hosted in private Huggingface Model Hub by adding your Huggingface API token
 to the <a href="/en/cloud/security/secret-store.html">secret store</a> and referring to the secret
 using <code>secret-ref</code> in the model tag.
 See <a href="reference/embedding-reference.html#model-config-reference">model config reference</a> for more details.

--- a/en/embedding.html
+++ b/en/embedding.html
@@ -171,10 +171,10 @@ to produce tokens which are then input to a supplied transformer model in <a hre
 <code>url</code> to supply them from a remote server, or
 <code>model-id</code> to use a
 <a href="https://cloud.vespa.ai/en/model-hub#hugging-face-embedder">model supplied by Vespa Cloud</a>.
-You can also use a model hosted in private Huggingface Model Hub by configuring a secret
-in the <a href="/en/cloud/security/secret-store.html">secret store</a> and <code>&lt;secrets&gt;</code> container configuration, and referring to it
+You can also use a model hosted in private Huggingface Model Hub by configuring adding your Huggingface API token
+to the <a href="/en/cloud/security/secret-store.html">secret store</a> and referring to the secret
 using <code>secret-ref</code> in the model tag.
-See <a href="reference/embedding-reference.html#model-config-reference">model config reference</a>.
+See <a href="reference/embedding-reference.html#model-config-reference">model config reference</a> for more details.
 </p>
 <pre>{% highlight xml %}
 <container id="default" version="1.0">

--- a/en/embedding.html
+++ b/en/embedding.html
@@ -170,8 +170,11 @@ to produce tokens which are then input to a supplied transformer model in <a hre
 <p>Use <code>path</code> to supply the model files from the application package,
 <code>url</code> to supply them from a remote server, or
 <code>model-id</code> to use a
-<a href="https://cloud.vespa.ai/en/model-hub#hugging-face-embedder">model supplied by Vespa Cloud</a>,
-see <a href="reference/embedding-reference.html#model-config-reference">model config reference</a>.
+<a href="https://cloud.vespa.ai/en/model-hub#hugging-face-embedder">model supplied by Vespa Cloud</a>.
+You can also use a model hosted in private Huggingface Model Hub by configuring a secret
+in the <a href="/en/cloud/security/secret-store.html">secret store</a> and <code>&lt;secrets&gt;</code> container configuration, and referring to it
+using <code>secret-ref</code> in the model tag.
+See <a href="reference/embedding-reference.html#model-config-reference">model config reference</a>.
 </p>
 <pre>{% highlight xml %}
 <container id="default" version="1.0">

--- a/en/reference/config-files.html
+++ b/en/reference/config-files.html
@@ -122,6 +122,10 @@ parameterName type [default=value] [range=[min,max]]
         <li>Otherwise, if a URL is specified, it is used.
         <li>Otherwise, path is used.</li>
       </ul>
+      <p>
+        You may also use remote URLs protected by bearer-token authentication by supplying the optional <code>secret-ref</code> attribute.
+        See <a href="../reference/embedding-reference#private-model-hub">using private Huggingface models</a>.
+      </p>
       On the receiving side, this config value is simply represented as a file path regardless of how it is resolved.
       This makes it easy to refer to models in multiple ways such that the appropriate one is used depending on the context.
       The special syntax for setting these config values is documented in

--- a/en/reference/embedding-reference.html
+++ b/en/reference/embedding-reference.html
@@ -7,9 +7,9 @@ title: "Embedding Reference"
 
 <h2 id="model-config-reference">Model config reference</h2>
 <p>
-  Embedder models uses the <a href="config-files.html#model">model</a> type configuration.
-  The <em>model</em> type configuration accepts attributes <code>model-id</code>, <code>url</code> or <code>path</code>,
-  and multiple of these can be specified as a single config value, where one is used depending on the deployment environment:
+  Embedder models use the <a href="config-files.html#model">model</a> type configuration which accepts the attributes
+  <code>model-id</code>, <code>url</code> or <code>path</code>.
+  Multiple of these can be specified as a single config value, where one is used depending on the deployment environment:
 </p>
   <ul>
     <li>If a <code>model-id</code> is specified and the application is deployed on Vespa Cloud, the <code>model-id</code> is used.</li>
@@ -44,6 +44,27 @@ title: "Embedding Reference"
     ...
 </container>
 {% endhighlight %}</pre>
+
+<h3 id="private-model-hub">Private Model Hub</h3>
+<p>
+You may also use models hosted in a
+<a href="https://huggingface.co/docs/hub/en/repositories-settings#private-repositories">private Huggingface model hub</a>.
+<p/>
+<p>
+Retrieve an API key from Huggingface with the appropriate permissions, and add it to the <a href="/en/cloud/security/secret-store">vespa secret store.</a>
+Add the secret to the container <code>&lt;secrets&gt;</code> and refer to it in your Huggingface model configuration:
+</p>
+
+<pre>{% highlight xml %}
+<container id="default" version="1.0">
+  <secrets>
+    <myPrivateHubApiKey vault="my-vault" name="my-secret-name" />
+  </secrets>
+  <component id="hf-embedder" type="hugging-face-embedder">
+      <transformer-model url="my-url" secret-ref="myPrivateHubApiKey"/>
+      <tokenizer-model url="my-url" secret-ref="myPrivateHubApiKey"/>
+  </component>
+</container>{% endhighlight %}</pre>
 
 <h3 id="huggingface-embedder-reference-config">Huggingface embedder reference config</h3>
 <p>In addition to <a href="#embedder-onnx-reference-config">embedder ONNX parameters</a>:</p>


### PR DESCRIPTION
Documents the usage of `secret-ref` for `model` type configurations (i.e support for private models in Huggingface). 