### PR TITLE
Grouping: Add 'Direct Response' link to executable cells

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1017,6 +1017,7 @@ table:not(table table) {
     resize: vertical;
   }
 
+  /* yql-cells(grouppung) */
   .yql-cell {
     margin: 1em 0;
     padding: 1em;
@@ -1042,5 +1043,18 @@ table:not(table table) {
   .yql-cell-button:hover {
     background-color:$color-brand-300;
     color: $color-brand-100;
+  }
+
+  #query-link-container {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+    a {
+        font-size: 14px;
+        color: $color-brand-400;
+        &:hover {
+            color: $color-brand-300;
+        }
+    }
   }
   

--- a/en/grouping.html
+++ b/en/grouping.html
@@ -90,6 +90,20 @@ function getQueryParam(name) {
     return urlParams.get(name);
 }
 
+function addQueryLink(yql, container) {
+  const existingLinkDiv = container.querySelector('#query-link-container');
+  const linkDiv = document.createElement('div');
+  linkDiv.id = 'query-link-container';
+  const rawYql = 'select * from purchase where true limit 0 |' + yql;
+  linkDiv.innerHTML = `<a href="${getSearchUrl(rawYql)}" target="_blank">Direct Response</a>`;
+
+  if (existingLinkDiv) {
+    existingLinkDiv.replaceWith(linkDiv);
+  } else {
+    container.appendChild(linkDiv);
+  }
+}
+
 function executeGrouping(yql, outputContainer) {
   outputContainer.classList.add('loading');
   outputContainer.innerHTML = '<div class="loader"></div>';
@@ -127,6 +141,8 @@ function executeGrouping(yql, outputContainer) {
           anyDataShown = true;
         }
       }
+
+      addQueryLink(yql, outputContainer.parentNode);
 
       if (!anyDataShown) {
         if (jsonData.root.errors) {
@@ -181,12 +197,16 @@ function transformPreToExecutableCells() {
     container.appendChild(textarea);
     container.appendChild(runButton);
     container.appendChild(resultDiv);
+    
   });
 }
 
 
 document.addEventListener('DOMContentLoaded', function() {
     transformPreToExecutableCells();
+    const yql = document.querySelector('#grouping-query-input').value;
+    const linkContainer = document.querySelector('#query-link-container');
+    addQueryLink(yql, linkContainer);
     // Get the value of the 'grouping' query parameter
     const groupingValue = getQueryParam('grouping');
     // If the 'grouping-query-input' element exists, set its value to the query parameter


### PR DESCRIPTION
### Changes Included
_This PR adds a "Direct Response" link to the grouping interface, allowing users to directly access the raw JSON response for any submitted YQL query._

**SCSS (style.scss):**

- Added styles for #query-link-container with right-aligned layout.

- Styled the link with hover behavior and brand colors.

**HTML/JS (grouping.html):**

- **Introduced a new addQueryLink(yql, container) function:**

> - Injects or replaces the #query-link-container element.

> - Generates a raw YQL query and wraps it in a link to the Vespa query endpoint.

- **Called addQueryLink() inside:**

> - executeGrouping() to show updated link after query execution.

> - DOMContentLoaded event to generate the link on initial page load.