### PR TITLE
Add h2 with id document-selection-exact-type-matching

### DIFF
--- a/en/vespa9-release-notes.html
+++ b/en/vespa9-release-notes.html
@@ -332,6 +332,7 @@ The following metrics are removed:
 
 <h2 id="security">Security</h2>
 
+<h2 id="document-selection-exact-type-matching">Changes to the document selection language</h2>
 
 <h2 id="operating-system">Operating system support for Vespa artifacts</h2>
 

--- a/en/vespa9-release-notes.html
+++ b/en/vespa9-release-notes.html
@@ -37,7 +37,6 @@ title: "Vespa 9 Release Notes"
   <li><a href="#removed-http-api-parameters">HTTP API changes</a></li>
   <li><a href="#removed-command-line-tools">Removed command line tools</a></li>
   <li><a href="#removed-or-renamed-metrics">Removed or renamed metrics</a></li>
-  <li><a href="#document-selection-exact-type-matching">Changes to the document selection language</a></li>
   <li><a href="#security">Security related changes</a></li>
   <li><a href="#operating-system">Operating system support</a></li>
   <li><a href="#other-changes">Other changes</a>, not covered by any of the above categories.</li>
@@ -331,8 +330,6 @@ The following metrics are removed:
 
 
 <h2 id="security">Security</h2>
-
-<h2 id="document-selection-exact-type-matching">Changes to the document selection language</h2>
 
 <h2 id="operating-system">Operating system support for Vespa artifacts</h2>
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

https://github.com/vespa-engine/documentation/actions/runs/16159866709/job/45609429300
```
internally linking to #document-selection-exact-type-matching; the file exists, but the hash 'document-selection-exact-type-matching' does not
