### PR TITLE
Note that `ranking.matchPhase.maxHits=0` disables match-phase

### DIFF
--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -1147,6 +1147,7 @@ These parameters are defined in the <code>native</code> query profile type.
         Rank profile equivalent: <a href="schema-reference.html#match-phase-max-hits">match-phase: max-hits</a>
       </p>
       <p>The max number of hits that should be generated on each content node during the match phase.</p>
+      <p>Setting the value to `0` disables the match phase early termination.</p>
     </td>
   </tr>
   <tr>

--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -834,6 +834,7 @@ These parameters are defined in the <code>native</code> query profile type.
       <p id="ranking.rerankcount">
         Specifies the number of hits that should be ranked in the second ranking phase.
         Overrides the <a href="schema-reference.html#secondphase-rerank-count">rerank-count</a> set in the rank profile.
+        Setting to 0 disables the second phase reranking.
       </p>
     </td>
   </tr>
@@ -882,6 +883,7 @@ These parameters are defined in the <code>native</code> query profile type.
       <p id="ranking.globalphase.rerankcount">
         Specifies the number of hits that should be re-ranked in the global ranking phase.
         Overrides the <a href="schema-reference.html#globalphase-rerank-count">rerank-count</a> set in the rank profile.
+        Setting to 0 disables the global phase reranking.
       </p>
     </td>
   </tr>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

If the value in the content node is 0 then match-phase early termination is disabled.

Previously, I've been creating separate ranking profiles without the `match-phase` to compare whether the optimisation is improves performance.