### PR TITLE
Updates news-1-getting-started tutorial so User has their Vespa CLI targeting localhost

### DIFF
--- a/en/tutorials/news-1-getting-started.md
+++ b/en/tutorials/news-1-getting-started.md
@@ -56,6 +56,17 @@ $ brew install vespa-cli
 </pre>
 </div>
 
+For the rest of this tutorial you will be using localhost, so you need to configure your Vespa CLI to connect to localhost
+Run the following to use endpoints on localhost:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre>
+$ vespa config set target local
+</pre>
+</div>
+
+
 
 ## A minimal Vespa application
 


### PR DESCRIPTION
Adds an explicit instruction to ensure the user's Vespa CLI is targeting localhost for all subsequent commands in the rest of this tutorial. This will prevent inexperienced users from being unable to get the `vespa status deploy --wait 300` step to pass due to their Vespa CLI being configured for cloud access.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
