### PR TITLE
document-api on feed container nodes

### DIFF
--- a/en/indexing.html
+++ b/en/indexing.html
@@ -6,7 +6,26 @@ title: "Indexing"
 <p>
   Refer to the <a href="overview.html">overview</a>.
   The primary index configuration is the <a href="schemas.html">schema</a>.
-  <a href="reference/services.html">services.xml</a> configures how indexing is distributed to the nodes.
+</p>
+<p>
+  <a href="reference/services.html">services.xml</a> configures how indexing is distributed to the nodes,
+  see <a href="https://github.com/vespa-engine/sample-apps/blob/master/examples/operations/multinode-HA/services.xml">multinode-HA</a>
+  for a full example:
+</p>
+<pre>{% highlight xml %}
+<container id="feed" version="1.0">
+    <document-api />
+    <document-processing />
+    <nodes count="2" />
+</container>
+{% endhighlight %}</pre>
+<p>
+  It is important to configure both <code>document-api</code> and <code>document-processing</code>
+  to run the document processing on the same nodes as the document API endpoint,
+  to avoid network hops to other nodes (for better throughput).
+  Normally, one will run the indexing preprocessing on these nodes, too,
+  see the <a href="/en/reference/services-content.html#document-processing">document-processing reference</a>
+  for a full example.
 </p>
 
 

--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -347,6 +347,7 @@ referred to by the content cluster:
 </p>
 <pre>{% highlight xml %}
 <container id="my-indexing-cluster" version="1.0">
+    <document-api/>
     <document-processing/>
 </container>
 <content id="music" version="1.0">
@@ -364,6 +365,7 @@ referred to by the content cluster:
 </p>
 <pre>{% highlight xml %}
 <container id="my-indexing-cluster" version="1.0">
+    <document-api/>
     <document-processing>
         <chain id="my-document-processors"
                inherits="indexing">
@@ -383,12 +385,10 @@ referred to by the content cluster:
     </documents>
 </content>
 {% endhighlight %}</pre>
-<p>
-Also note the <a href="services-container.html#document-api">document-api</a> configuration,
-applications can set up this API on the same nodes as <em>document-processing</em> -
-find details in <a href="../indexing.html">indexing</a>.
-</p>
-
+{% include important.html content='
+Note the <a href="services-container.html#document-api">document-api</a> configuration.
+Set up this API on the same nodes as <code>document-processing</code> -
+find details in <a href="../indexing.html">indexing</a>.' %}
 
 
 <h2 id="min-redundancy">min-redundancy</h2>


### PR DESCRIPTION
- it is always the case that the docproc nodes should have document-api, make this clearer