### PR TITLE
Add documentation about timezone

### DIFF
--- a/en/grouping.html
+++ b/en/grouping.html
@@ -1735,6 +1735,23 @@ Simple grouping to count the number of documents in each group and return the be
   )
 </pre>
 
+<h3 id="timezone-grouping">Timezones in grouping</h3>
+
+The <code>timezone</code> query parameter can be used to rewrite each time-function with a timezone offset.
+See the <a href="reference/query-api-reference.html#timezone">reference</a>. Example:
+
+<pre class="no-transform">
+$ vespa query "select * from purchase where true | \
+               all( group(time.hourofday(date)) each(output(count()))" \
+              "timezone=America/Los_Angeles"
+</pre>
+
+<p>
+  This query selects all documents from <code>purchase</code>, groups them by the
+  hour they were made (adjusted to the local time
+  in <code>America/Los_Angeles</code>), and counts how many purchases fall into
+  each hour.
+</p>
 
 
 <h2 id="counting-unique-groups">Counting unique groups</h2>

--- a/en/reference/grouping-syntax.html
+++ b/en/reference/grouping-syntax.html
@@ -422,6 +422,7 @@ for more examples.
     The field must be a <a href="schema-reference.html#long">long</a>,
     with second resolution (unix timestamp/epoch) -
     <a href="../grouping.html#time-and-date">examples</a>.
+    Each of the time-functions will respect the <a href="query-api-reference.html#timezone">timezone</a> query parameter.
   </td></tr>
   <tr class="trx"><th class="thx">Name</th><th class="thx">Description</th><th class="thx">Arguments</th><th class="thx">Result</th></tr>
   <tr><td>time.dayofmonth</td><td>Returns the day of month (1-31) for the given timestamp</td><td>Long</td><td>Long</td></tr>

--- a/en/reference/query-api-reference.html
+++ b/en/reference/query-api-reference.html
@@ -114,6 +114,7 @@ get methods as Java objects from the Query to Searcher components.
     <li><a href="#grouping.defaultmaxhits">grouping.defaultMaxHits</a></li>
     <li><a href="#grouping.globalmaxgroups">grouping.globalMaxGroups</a></li>
     <li><a href="#grouping.defaultprecisionfactor">grouping.defaultPrecisionFactor</a></li>
+    <li><a href="#timezone">timezone</a></li>
   </ul>
 </dd>
 
@@ -1573,6 +1574,22 @@ These parameters are defined in the <code>native</code> query profile type.
         <a href="../grouping.html#ordering-and-limiting-groups">precision</a> is not specified.
         The final precision value is calculated by multiplying the effective <code>max</code> value
         with the scale factor.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>timezone</th>
+    <td></td>
+    <td>String</td>
+    <td><code>utc</code></td>
+    <td>
+      <p id="timezone">
+        Specifies a timezone that will be used to offset all <code>time</code> related expressions in
+        grouping. See <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/TimeZone.html#getTimeZone(java.lang.String)">Java's definition</a>
+        for valid timezones.
+      </p>
+      <p>
+        See the <a href="../grouping.html#timezone-grouping">grouping guide</a> for examples.
       </p>
     </td>
   </tr>


### PR DESCRIPTION
1. Adds `timezone` to overview of query parameters
2. Mentions that time functions will respect the timezone query parameter in grouping reference.
3. In Grouping Guide, add subheading "Timezones in grouping" with example on how to use vespacli to use timezones.