### PR TITLE
Update parameters that have no effect in streaming search

### DIFF
--- a/en/streaming-search.html
+++ b/en/streaming-search.html
@@ -79,6 +79,9 @@ The following differences however apply:</p>
         <ul>
             <li><a href="reference/schema-reference.html#post-filter-threshold">post-filter-threshold</a></li>
             <li><a href="reference/schema-reference.html#approximate-threshold">approximate-threshold</a></li>
+            <li><a href="reference/schema-reference.html#filter-first-threshold">filter-first-threshold</a></li>
+            <li><a href="reference/schema-reference.html#filter-first-exploration">filter-first-exploration</a></li>
+            <li><a href="reference/schema-reference.html#exploration-slack">exploration-slack</a></li>
             <li><a href="reference/schema-reference.html#target-hits-max-adjustment-factor">target-hits-max-adjustment-factor</a></li>
         </ul>
     </li>


### PR DESCRIPTION
Adds the parameters from https://github.com/vespa-engine/documentation/pull/4010 to the list of parameters that have no effect in streaming search.