### PR TITLE
Avoid eye pain caused by links inside pre-tags

### DIFF
--- a/css/denali-theme-vespa-light.scss
+++ b/css/denali-theme-vespa-light.scss
@@ -491,6 +491,16 @@ $line-height-expanded: 1.75;
         font-family: $font-family-sans-serif;
     }
 
+    // Custom styling for links inside pre elements
+    pre a {
+        color: $color-brand-300; // Override the default link color for pre elements
+        text-decoration: underline;
+        
+        &:hover {
+            color: darken($color-brand-300, 10%); // Darker on hover
+        }
+    }
+
     // COMPONENTS
     @include alerts-theme;
     @include box-theme;

--- a/css/denali-theme-vespa.scss
+++ b/css/denali-theme-vespa.scss
@@ -491,6 +491,17 @@ $line-height-expanded: 1.75;
         color: $body-text-color;
         font-family: $font-family-sans-serif;
     }
+
+    // Custom styling for links inside pre elements
+    pre a {
+        color: $color-brand-300; // Override the default link color for pre elements
+        text-decoration: underline;
+        
+        &:hover {
+            color: darken($color-brand-300, 10%); // Darker on hover
+        }
+    }
+
     // COMPONENTS
     @include alerts-theme;
     @include box-theme;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Because this hurt my eyes:
 
<img width="1181" height="893" alt="Screenshot 2025-08-01 at 10 50 44" src="https://github.com/user-attachments/assets/3fe99642-6f85-4996-b644-d07020499ad8" />

After:
<img width="1181" height="893" alt="Screenshot 2025-08-01 at 11 05 22" src="https://github.com/user-attachments/assets/0fb012e8-cc9c-4423-b039-936e87822ef4" />
