### PR TITLE
Remove small gap from the navbar on mobile

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -6,8 +6,8 @@
         <span class="nav-item hide-small-desktop-up" onclick="toggleMenu()">
             <i class="d-icon d-menu-hamburger"></i>
         </span>
-        <a href="https://docs.vespa.ai/">
-            <img class="nav-brand" src="{{ site.baseurl }}/assets/logos/{{include.logo}}" alt="Vespa logo"/>
+        <a class="nav-item nav-brand" href="https://docs.vespa.ai/">
+            <img src="{{ site.baseurl }}/assets/logos/{{include.logo}}" alt="Vespa logo"/>
         </a>
         <div  id="navMenu" class="nav-responsive">
             <div class="section-searchbar" style="margin: 0 5%">


### PR DESCRIPTION
### Description: 
During testing freshly added navbar extension a new problem was noticed:
> <img width="543" height="166" alt="image" src="https://github.com/user-attachments/assets/254b8371-5dad-4d6e-9630-a9e4991c2a1a" />
>
> you can see the content at the very top between the menu and top bar.
### The problem: 
<img width="428" height="147" alt="image" src="https://github.com/user-attachments/assets/8e490cb7-28f4-4682-a848-7747f4b8efd3" />

 container had its own styles as well as logo did, so both were breaking the grid.

### Solution: 
All the styling was moved to the container.

### Result:

<img width="420" height="147" alt="image" src="https://github.com/user-attachments/assets/0a8bd8d7-0109-4996-981d-4500a6590462" />
