### PR TITLE
Write to correct dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,10 @@ plugins:
 kramdown:
   smart_quotes: ["apos", "apos", "quot", "quot"]
 
+# Include markdown files generated from HTML
+include:
+  - "*.html.md"
+
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/_config.yml
+++ b/_config.yml
@@ -33,8 +33,8 @@ plugins:
 kramdown:
   smart_quotes: ["apos", "apos", "quot", "quot"]
 
-# Include markdown files generated from HTML
-include:
+# Keep markdown files in output
+keep_files:
   - "*.html.md"
 
 # Exclude from processing.

--- a/_plugins/html_to_markdown_generator.rb
+++ b/_plugins/html_to_markdown_generator.rb
@@ -26,7 +26,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
   # Calculate all unique destination directories before the parallel block.
   # This avoids using a slow Mutex for synchronization inside the loop.
   required_dirs = pages_to_process.map do |page_data|
-    File.dirname(construct_markdown_path(site.source, page_data[:url]))
+    File.dirname(construct_markdown_path(site.dest, page_data[:url]))
   end.uniq.reject { |dir| dir == '.' }
   
   FileUtils.mkdir_p(required_dirs) unless required_dirs.empty?
@@ -34,9 +34,9 @@ Jekyll::Hooks.register :site, :post_write do |site|
 
   # For CPU-bound tasks like HTML parsing, processes are much faster than threads
   # in Ruby due to the Global Interpreter Lock (GIL).
-  # We pass site.source as an argument to make it available in each process.
+  # We pass site.dest as an argument to make it available in each process.
   Parallel.each(pages_to_process, in_processes: Parallel.processor_count, progress: "Generating Markdown") do |page_data|
-    md_path = construct_markdown_path(site.source, page_data[:url])
+    md_path = construct_markdown_path(site.dest, page_data[:url])
     
     # Skip if the markdown file is newer than the HTML file
     next if File.exist?(md_path) && File.mtime(md_path) >= page_data[:html_mtime]
@@ -70,10 +70,10 @@ def process_markdown_content(markdown_content)
 end
 
 # Combined the logic for URLs ending in "/" and other paths.
-def construct_markdown_path(site_source, page_url)
+def construct_markdown_path(site_dest, page_url)
   # Handle the root index page specifically
   if page_url == "/"
-    return File.join(site_source, "index.html.md")
+    return File.join(site_dest, "index.html.md")
   end
 
   # Remove the leading slash
@@ -81,10 +81,10 @@ def construct_markdown_path(site_source, page_url)
   
   # If the URL ends with "/", it's a directory index page
   if page_url.end_with?("/")
-    # Convert "/en/tutorials/" to "en/tutorials/index.html.md"
-    File.join(site_source, path_without_slash + "index.html.md")
+    # Convert "/en/tutorials/" to "_site/en/tutorials/index.html.md"
+    File.join(site_dest, path_without_slash + "index.html.md")
   else
-    # For regular pages like "/page.html", convert to "page.html.md"
-    File.join(site_source, path_without_slash + ".md")
+    # For regular pages like "/page.html", convert to "_site/page.html.md"
+    File.join(site_dest, path_without_slash + ".md")
   end
 end


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The files generated by #4027 was not included in pages deployment, so we get 404 for the markdown links.
Think this should fix it. 