### PR TITLE
Correct github url links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 url: "https://docs.vespa.ai" # the base hostname & protocol for your site, e.g. http://example.com
 # Remove this before publishing on github.com
 repository: vespa/documentation
+repository_url: "https://github.com/vespa-engine/documentation"
 
 # Build settings
 sass:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,7 @@
           </a>
           {%- endif -%}
           
-          <a href="{{site.github.repository_url}}/blob/master/{{page.path}}"
+          <a href="{{site.repository_url}}/blob/master/{{page.path}}"
              class="d-icon is-small d-pencil"
              data-proofer-ignore></a> <!-- https://denali.design/icons alternative d-file-edit ToDo: color-->
         </div>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The issue was the links with pencil icons, that _should_ link to github url. 
So, should not remove /blob/master, but rather use the github link instead of the docs page. 
This variable was no longer available when deploying from GHA. 
Should work with this. 