### PR TITLE
Revert "Update dependency github-pages to v232"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.1)
-    activesupport (8.0.2)
+    activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -14,7 +14,6 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)


### PR DESCRIPTION
Reverts vespa-engine/documentation#4035

failed on

activesupport-8.0.2 requires ruby version >= 3.2.0, which is incompatible with
the current version, 3.1.0
Error: The process '/opt/hostedtoolcache/Ruby/3.1.0/x64/bin/bundle' failed with exit code 5

lets try ruby 3.2 first