### PR TITLE
remove reference to 64kb summary limit

### DIFF
--- a/en/reference/indexing-language-reference.html
+++ b/en/reference/indexing-language-reference.html
@@ -689,9 +689,7 @@ The following are the unclassified expressions available:
     <td><code>summary &lt;fieldName&gt;</code></td>
     <td>
       <p id="summary">
-      Writes the execution value to the named summary field.
-      Summary fields of type string are limited to 64 kB. <!-- ToDo: check -->
-      If a larger string is stored, the indexer will issue a warning and truncate the value to 64 kB.
+      Writes the execution value to the named summary field. During deployment, this indicates that the field should be included in the document summary.
       </p>
     </td>
   </tr>


### PR DESCRIPTION
I don't think there's any such limit any more (for how long)?

Is it even possible to use the second argument "summary my_field"? When trying I can only get 
```
Error: invalid application package (status 400)
Invalid application:
For schema 'music', field 'album':
Indexing expression 'summary my_field' attempts to write to a field other than 'album'.
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
