### PR TITLE
Fix/html tag id must be lowercased

### DIFF
--- a/en/reference/rank-features.html
+++ b/en/reference/rank-features.html
@@ -1256,7 +1256,7 @@ tensor&lt;double&gt;(dim{}):{ {dim:v1}:1.0, {dim:v2}:1.0, {dim:v3}:1.0} }
 <tr><td>relevanceScore</td>
     <td>-</td>
     <td>
-        <p id="relevanceScore">
+        <p id="relevancescore">
             The value of the rank score calculated either in the first or (when defined) in the second phase (unavailable in first phase and second phase ranking expressions) (since 8.559.30).
         </p>
     </td></tr>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

In the `search.vespa.ai` links are all lowercased, while in actual HTM tag ID is camel-cased. Lowercase the tag so that links work in search.