### PR TITLE
expand on sync-transactionlog=false

### DIFF
--- a/en/reference/services-content.html
+++ b/en/reference/services-content.html
@@ -1135,7 +1135,34 @@ Refer to <a href="../proton.html#proton-maintenance-jobs">Proton maintenance job
   However, if using NAS (Network Attached Storage) like EBS on AWS one can see significant
   feed performance impact. For one particular case, turning off sync-transactionlog for EBS gave a 60x improvement.
 </p>
-
+<p>
+    With sync-transactionlog turned off, the risk of losing data depends on the kernel's
+    <a href="https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html#dirty-background-bytes">sysctl settings.</a>
+    For example, this is a common default:
+</p>
+<pre>
+# sysctl -a
+...
+vm.dirty_expire_centisecs = 3000
+vm.dirty_ratio = 20
+vm.dirty_writeback_centisecs = 500
+...
+</pre>
+<p>
+    With this configuration, the worse case scenario is to lose 35 seconds worth of transactionlog, but no more than 1/20
+    of the free memory. Because kernel flusher threads wake up every 5s (dirty_writeback_centisecs) and write data
+    older than 30s (dirty_expire_centisecs) from memory to disk. But if un-synced data exceeds 1/20 of the free memory,
+    the Vespa process will sync it (dirty_ratio).
+</p>
+<p>
+    The above also assumes that all copies of the data are lost at the same time <b>and</b> that kernels on all these nodes
+    flush at the same time: realistic scenario only with one copy.
+</p>
+<p>
+    Adjust these <a href="https://www.kernel.org/doc/html/latest/admin-guide/sysctl/vm.html#dirty-background-bytes">sysctl settings</a>
+    to manage the trade-off between data loss and performance. You'll see more in those kernel docs: for example,
+    thresholds can be expressed in bytes.
+</p>
 
 
 <h2 id="resource-limits-proton">resource-limits (in proton)</h2>


### PR DESCRIPTION
Expands a bit on the implications and on the tunables.

This might be needed for people considering sync-transactionlog=false. This was something I was doing quite often with Elasticsearch, when disk IO was problematic under heavy writes. Elasticsearch/OpenSearch allow you to configure the async flush behavior, but I don't think this is needed with Vespa, because the kernel exposes even more knobs.