### PR TITLE
add .md extension to llms.txt links

### DIFF
--- a/_plugins/html_to_markdown_generator.rb
+++ b/_plugins/html_to_markdown_generator.rb
@@ -144,7 +144,7 @@ def generate_llms_txt(site_dest, pages_to_process, site)
       
       valid_pages.each do |page_info|
         # Use the base URL from site configuration + original page URL
-        web_url = "#{base_url}#{page_info[:url]}"
+        web_url = "#{base_url}#{page_info[:md_path]}"
         file.puts "- [#{page_info[:title]}](#{web_url})" + (page_info[:description] ? ": #{page_info[:description]}" : "")
       end
       file.puts "\n"


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Links in https://docs.vespa.ai/llms.txt should point to the markdown-version of each page, as the consumer is an llm.