### PR TITLE
Add information on state/v1/initialization endpoint

### DIFF
--- a/en/proton.html
+++ b/en/proton.html
@@ -839,13 +839,12 @@ Metrics are available at the <a href="operations/metrics.html">Metrics API</a>.
 </table>
 
 
-
-<h2 id="custom-component-state-api">Custom Component State API</h2>
+<h2 id="state-v1-api">/state/v1 API</h2>
 <p>
-  This section describes the custom extensions of the proton custom component state API.
-  Component status can be found by HTTP GET at <code>http://host:stateport/state/v1/custom/component</code>.
-  This gives an overview of the relevant search node components and their internal state.
-  Note that this is <strong>not</strong> a stable API, and it will expand and change between releases.
+  Besides the common endpoints documented in the
+  <a href="reference/state-v1.html">/state/v1 API reference</a>, Proton has additional endpoints
+  as part of the /state/v1 API that expose information about the internal state of a search node.
+  This API is available at <code>http://host:stateport/state/v1/</code>.
 </p>
 <p>
   Run <a href="/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-model-inspect">vespa-model-inspect</a>
@@ -854,6 +853,69 @@ Metrics are available at the <a href="operations/metrics.html">Metrics API</a>.
 <pre>
 vespa-model-inspect service searchnode
 </pre>
+
+<h3 id="initialization-progress-api">Initialization Progress API</h3>
+<p>
+  The initialization progress can be found by HTTP GET at <code>http://host:stateport/state/v1/initialization</code>.
+  This endpoint becomes available early during initialization of Proton when other endpoints are not yet available.
+  It gives a human-readable overview of the document databases and their attributes being loaded.
+  Note that this is <strong>not</strong> a stable API, and it will expand and change between releases.
+</p>
+<p>
+  Example <code>state/v1/initialization</code>:
+</p>
+<pre>{% highlight json %}
+{
+  "state": "initializing",
+  "current_time": "1758873251.933488",
+  "start_time": "1758873249.715624",
+  "load": 1,
+  "replay_transaction_log": 0,
+  "online": 0,
+  "dbs": [
+    {
+      "state": "load",
+      "start_time": "1758873249.936939",
+      "name": "dbname",
+      "ready_subdb": {
+        "loaded_attributes": [
+          {
+            "state": "loaded",
+            "start_time": "1758873249.941415",
+            "name": "int_field",
+            "end_time": "1758873249.942051"
+          },
+          {
+            "state": "loaded",
+            "start_time": "1758873249.941498",
+            "name": "string_field",
+            "end_time": "1758873249.944647"
+          }
+        ],
+        "loading_attributes": [
+          {
+            "state": "reprocessing",
+            "start_time": "1758873249.941555",
+            "name": "tensor_field",
+            "reprocess_progress": "6.061879",
+            "reprocess_start_time": "1758873249.993847"
+          }
+        ],
+        "queued_attributes": [
+
+        ]
+      }
+    }
+  ]
+}
+{% endhighlight %}</pre>
+
+<h3 id="custom-component-state-api">Custom Component State API</h3>
+<p>
+  The custom componet status can be found by HTTP GET at <code>http://host:stateport/state/v1/custom/component</code>.
+  It gives an overview of the relevant search node components and their internal state.
+  Note that this is <strong>not</strong> a stable API, and it will expand and change between releases.
+</p>
 <p>
   Example <code>state/v1/custom/component</code>:
 </p>

--- a/en/reference/state-v1.html
+++ b/en/reference/state-v1.html
@@ -10,6 +10,8 @@ redirect_from:
   vespa-model-inspect</a> to find ports,
   see the <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA">multinode-HA</a>
   sample application for practical examples.
+  Besides the endpoints listed below, a service might have additional endpoints specific to that service -
+  this is the case for <a href="/en/proton.html#state-v1-api">Proton</a>.
 </p>
 
 <h2 id="http-requests">HTTP requests</h2>


### PR DESCRIPTION
This adds information on the state/v1/initialization endpoint to the Proton page and a small remark on this to the state/v1 page.