### PR TITLE
changed norwegian language abreviation

### DIFF
--- a/en/linguistics.html
+++ b/en/linguistics.html
@@ -75,7 +75,7 @@ width="810px" height="auto" />
     <li>Indonesian (id)</li>
     <li>Irish (ga)</li>
     <li>Italian (it)</li>
-    <li>Norwegian (nb)</li>
+    <li>Norwegian (no)</li>
     <li>Portuguese (pt)</li>
     <li>Romanian (ro)</li>
     <li>Russian (ru)</li>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


@sebastiannberg and @johansolbakken found that Norwegian language is specified in Vespa as "no" and not by "nb" as was written in the docs. fixed.
