### PR TITLE
Update saved-search docs for config rename

### DIFF
--- a/en/modules/e-commerce/saved-search.html
+++ b/en/modules/e-commerce/saved-search.html
@@ -115,7 +115,7 @@ schema saved_search {
                         </webhook>
                     </notification>
 
-                    <itemDocumentType>product</itemDocumentType>
+                    <productDocumentType>product</productDocumentType>
                     <savedSearchDocumentType>saved_search</savedSearchDocumentType>
                     <predicateFieldName>filters</predicateFieldName>
                     <savedSearchNumHits>100</savedSearchNumHits>
@@ -296,6 +296,9 @@ Authorization: Bearer TOKEN
 </container>
 {% endhighlight %}</pre>
 
+<p>Webhook notifications are sent once without automatic retry.
+Delivery failures are recorded in the Vespa log.</p>
+
 <h3 id="notification-kind-vespa">Vespa Schema</h3>
 
 <p>
@@ -456,7 +459,7 @@ This section describes the possible <a href="../../applications/configuring-comp
       <td>timestamp</td>
     </tr>
     <tr>
-      <td><code>itemDocumentType</code></td>
+      <td><code>productDocumentType</code></td>
       <td>The name of the document type that can trigger notifications, e.g. <code>product</code>.</td>
       <td><code>string</code></td>
       <td>product</td>
@@ -475,7 +478,9 @@ This section describes the possible <a href="../../applications/configuring-comp
     </tr>
     <tr>
       <td><code>savedSearchNumHits</code></td>
-      <td>Maximum number of saved searches to issue a notification for one product.</td>
+      <td>Maximum number of saved searches that can match per product update.
+        Matches beyond this limit are silently dropped. Higher values increase work per update.
+      </td>
       <td><code>int</code></td>
       <td>100</td>
     </tr>
@@ -487,7 +492,7 @@ This section describes the possible <a href="../../applications/configuring-comp
     </tr>
     <tr>
       <td><code>regularAttributes[].fieldPath</code></td>
-      <td>The field in the <code>itemDocumentType</code> to be matched with this attribute. This field should be of type <code>string</code>.</td>
+      <td>The field in the <code>productDocumentType</code> to be matched with this attribute. This field should be of type <code>string</code>.</td>
       <td><code>string</code></td>
       <td></td>
     </tr>
@@ -505,7 +510,7 @@ This section describes the possible <a href="../../applications/configuring-comp
     </tr>
     <tr>
       <td><code>rangeAttributes[].fieldPath</code></td>
-      <td>The field in the <code>itemDocumentType</code> to be matched with this attribute. This field should be of a numeric type, e.g. <code>int</code>.</td>
+      <td>The field in the <code>productDocumentType</code> to be matched with this attribute. This field should be of a numeric type, e.g. <code>int</code>.</td>
       <td><code>string</code></td>
       <td></td>
     </tr>

--- a/en/modules/e-commerce/using-features-together.html
+++ b/en/modules/e-commerce/using-features-together.html
@@ -201,7 +201,7 @@ schema saved_search {
                         <priceStructField>price</priceStructField>
                     </productFields>
 
-                    <itemDocumentType>product</itemDocumentType>
+                    <productDocumentType>product</productDocumentType>
                     <savedSearchDocumentType>saved_search</savedSearchDocumentType>
                     <predicateFieldName>filters</predicateFieldName>
 


### PR DESCRIPTION
Rename `itemDocumentType` to `productDocumentType` in examples and config reference. Clarify `savedSearchNumHits` behavior and add note on webhook delivery



I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
