### PR TITLE
Document <max-document-size> element under <document-api>

### DIFF
--- a/en/reference/applications/services/container.html
+++ b/en/reference/applications/services/container.html
@@ -54,6 +54,7 @@ container [version, id]
         <a href="#tracelevel">tracelevel</a>
         <a href="#mbusport">mbusport</a>
         <a href="#ignore-undefined-fields">ignore-undefined-fields</a>
+        <a href="#max-document-size">max-document-size</a>
     <a href="../../../ranking/stateless-model-evaluation.html">model-evaluation</a>
         <a href="../../../ranking/stateless-model-evaluation.html#onnx-inference-options">onnx</a>
     <a href="#document">document [type, class, bundle]</a>
@@ -503,6 +504,35 @@ Children elements:
         </p>
       </td>
     </tr>
+    <tr><th>max-document-size</th>
+      <td>optional</td>
+      <td>string</td>
+      <td>128MiB</td>
+      <td>
+        <p id="max-document-size">
+        Specifies the maximum size of a document operation request accepted by the container,
+        measured as the uncompressed size of the request body. The limit applies to all document types
+        in the container cluster. A request larger than this limit will be rejected by the container
+        before the operation is forwarded to the content cluster.
+        </p>
+        <p>
+        Valid values are numbers including a unit (e.g. <em>10MiB</em>) and the value must be
+        between 1MiB and 2048MiB (inclusive). Values will be rounded to the nearest MiB,
+        so using MiB as a unit is preferable.
+        </p>
+        <p>
+        The value should normally not exceed the smallest
+        <a href="content.html#max-document-size">max-document-size</a> configured in any
+        content cluster that this container feeds to; a deployment warning is emitted otherwise.
+        </p>
+        <p>Example:</p>
+<pre>{% highlight xml %}
+<document-api>
+    <max-document-size>10MiB</max-document-size>
+</document-api>
+{% endhighlight %}</pre>
+      </td>
+    </tr>
   </tbody>
 </table>
 <p>Example:</p>
@@ -519,6 +549,7 @@ Children elements:
     &lt;route&gt;default&lt;/route&gt;
     &lt;timeout&gt;250.5&lt;/timeout&gt;
     &lt;tracelevel&gt;3&lt;/tracelevel&gt;
+    &lt;max-document-size&gt;10MiB&lt;/max-document-size&gt;
 &lt;document-api&gt;
 </pre>
 

--- a/en/reference/applications/services/container.html
+++ b/en/reference/applications/services/container.html
@@ -550,7 +550,7 @@ Children elements:
     &lt;timeout&gt;250.5&lt;/timeout&gt;
     &lt;tracelevel&gt;3&lt;/tracelevel&gt;
     &lt;max-document-size&gt;10MiB&lt;/max-document-size&gt;
-&lt;document-api&gt;
+&lt;/document-api&gt;
 </pre>
 
 


### PR DESCRIPTION
## Summary
- Document the new optional `<max-document-size>` child element of `<document-api>` in `services.xml`, added in vespa-engine/vespa#36391.
- Describes the request-size limit (1–2048 MiB, default 128 MiB), MiB-preferred unit syntax, and the deploy-time warning when the value exceeds any content cluster's `max-document-size`.
- Updates the `<document-api>` TOC and combined example.
