### PR TITLE
Update rank feature doc with featureName(fieldName) parameter syntax

### DIFF
--- a/en/reference/ranking/nativerank.html
+++ b/en/reference/ranking/nativerank.html
@@ -925,7 +925,7 @@ This is a comprehensive list of all the configuration properties to all native r
 <tr><th>Feature</th><th>Parameter</th><th>Default</th><th>Description</th></tr>
 </thead><tbody>
 <tr>
-  <td><code>nativeFieldMatch</code></td>
+  <td><code>nativeFieldMatch(<em>fieldName</em>)</code></td>
   <td><code>averageFieldLength</code></td>
   <td>The actual length of the field in the given document.</td>
   <td>When set this replaces the true field length in the nativeFieldMatch formula for all documents.</td>
@@ -936,8 +936,8 @@ This is a comprehensive list of all the configuration properties to all native r
     <td>expdecay(8000,12.50)</td>
     <td>The default table used when calculating boost for the first occurrence in a field.</td>
 </tr><tr>
-    <td><code>nativeFieldMatch</code></td>
-    <td><code>firstOccurrenceTable.<em>fieldName</em></code></td>
+    <td><code>nativeFieldMatch(<em>fieldName</em>)</code></td>
+    <td><code>firstOccurrenceTable</code></td>
     <td>The value of <code>firstOccurrenceTable</code></td>
     <td>The table used when calculating boost for the first occurrence in the given field.</td>
 </tr><tr>
@@ -946,8 +946,8 @@ This is a comprehensive list of all the configuration properties to all native r
     <td>loggrowth(1500,4000,19)</td>
     <td>The default table used when calculating boost for the number of occurrences in a field.</td>
 </tr><tr>
-    <td><code>nativeFieldMatch</code></td>
-    <td><code>occurrenceCountTable.<em>fieldName</em></code></td>
+    <td><code>nativeFieldMatch(<em>fieldName</em>)</code></td>
+    <td><code>occurrenceCountTable</code></td>
     <td>The value of <code>occurrenceCountTable</code></td>
     <td>The table used when calculating boost for the number of occurrences in the given field.</td>
 </tr><tr>
@@ -956,8 +956,8 @@ This is a comprehensive list of all the configuration properties to all native r
     <td>0.5</td>
     <td>The default importance value used for weighting the boosts for first occurrence and number of occurrences in a field. This value should be in the interval [0, 1].</td>
 </tr><tr>
-    <td><code>nativeFieldMatch</code></td>
-    <td><code>firstOccurrenceImportance.<em>fieldName</em></code></td>
+    <td><code>nativeFieldMatch(<em>fieldName</em>)</code></td>
+    <td><code>firstOccurrenceImportance</code></td>
     <td>The value of <code>firstOccurrenceImportance</code></td>
     <td>The importance value used for the given field.</td>
 </tr><tr>
@@ -966,8 +966,8 @@ This is a comprehensive list of all the configuration properties to all native r
     <td>expdecay(500,3)</td>
     <td>The default table used when calculating forward proximity boost in a field.</td>
 </tr><tr>
-    <td><code>nativeProximity</code></td>
-    <td><code>proximityTable.<em>fieldName</em></code></td>
+    <td><code>nativeProximity(<em>fieldName</em>)</code></td>
+    <td><code>proximityTable</code></td>
     <td>The value of <code>proximityTable</code></td>
     <td>The table used when calculating forward proximity boost in the given field.</td>
 </tr><tr>
@@ -976,8 +976,8 @@ This is a comprehensive list of all the configuration properties to all native r
     <td>expdecay(400,3)</td>
     <td>The default table used when calculating reverse proximity boost in a field.</td>
 </tr><tr>
-    <td><code>nativeProximity</code></td>
-    <td><code>reverseProximityTable.<em>fieldName</em></code></td>
+    <td><code>nativeProximity(<em>fieldName</em>)</code></td>
+    <td><code>reverseProximityTable</code></td>
     <td>The value of <code>reverseProximityTable</code></td>
     <td>The table used when calculating reverse proximity boost in the given field.</td>
 </tr><tr>
@@ -987,8 +987,8 @@ This is a comprehensive list of all the configuration properties to all native r
     <td>The default importance value used for weighting the boosts for forward and reverse proximity in a field.
         This value should be in the interval [0, 1].</td>
 </tr><tr>
-    <td><code>nativeProximity</code></td>
-    <td><code>proximityImportance.<em>fieldName</em></code></td>
+    <td><code>nativeProximity(<em>fieldName</em>)</code></td>
+    <td><code>proximityImportance</code></td>
     <td>The value of <code>proximityImportance</code></td>
     <td>The importance value used for the given field.</td>
 </tr><tr>
@@ -1045,8 +1045,8 @@ This is a comprehensive list of all the configuration properties to all native r
 </p>
 <pre>
 rank-properties {
-    nativeFieldMatch.occurrenceCountTable.content: "linear(0,0)"
-    nativeProximity.reverseProximityTable.content: "linear(0,0)"
+    nativeFieldMatch(content).occurrenceCountTable: "linear(0,0)"
+    nativeProximity(content).reverseProximityTable: "linear(0,0)"
 }
 </pre>
 <p>

--- a/en/reference/ranking/rank-feature-configuration.html
+++ b/en/reference/ranking/rank-feature-configuration.html
@@ -73,7 +73,7 @@ rank-profile my-profile inherits default {
   <td>5</td>
   <td><p id="term">The number of terms for which this is included in the rank features dump in the summary</p></td></tr>
 
-<tr><td rowspan="3"><a href="rank-features.html#bm25">bm25</a></td>
+<tr><td rowspan="3"><a href="rank-features.html#bm25">bm25(<em>fieldname</em>)</a></td>
   <td>k1</td>
   <td>1.2</td>
   <td><p id="bm25">Used to limit how much a single query term can affect the score for a document.</p></td></tr>
@@ -97,7 +97,7 @@ rank-profile my-profile inherits default {
 <tr>
   <td rowspan="3">
     <p id="elementwise-bm25">
-      <a href="rank-features.html#elementwise-bm25">elementwise bm25</a>
+      <a href="rank-features.html#elementwise-bm25">elementwise(bm25(<em>fieldname</em>,x,<em>celltype</em>))</a>
     </p>
   </td>
   <td>k1</td>
@@ -105,6 +105,7 @@ rank-profile my-profile inherits default {
   <td>
     <p>
       Used to limit how much a single query term can affect the score for a document.
+      Note that <code style="font-weight: bold;">bm25(<em>fieldname</em>).k1</code> will be used as a fallback before the default.
     </p>
   </td>
 </tr>
@@ -115,6 +116,7 @@ rank-profile my-profile inherits default {
   <td>
     <p>
       Used to control the effect of the element length compared to the average element length.
+      Note that <code style="font-weight: bold;">bm25(<em>fieldname</em>).b</code> will be used as a fallback before the default.
     </p>
   </td>
 </tr>
@@ -134,9 +136,25 @@ rank-profile my-profile inherits default {
       no index structures are generated and the average element length is not automatically calculated.
       Instead, manually set an average element length for a more precise elementwise bm25 score.
       It should also be manually set for multi-node indexed search to get consistent scoring across the nodes.
+      Note that <code style="font-weight: bold;">bm25(<em>fieldname</em>).averageFieldLength</code> will be used as a fallback before the default.
     </p>
   </td>
 </tr>
+
+<tr><td>nativeRank</td>
+  <td></td>
+  <td></td>
+  <td>See the <a href="nativerank.html#configuration-properties">nativeRank configuration</a> documentation</td></tr>
+
+<tr><td>nativeFieldMatch</td>
+  <td></td>
+  <td></td>
+  <td>See the <a href="nativerank.html#configuration-properties">nativeRank configuration</a> documentation</td></tr>
+
+<tr><td>nativeProximity</td>
+  <td></td>
+  <td></td>
+  <td>See the <a href="nativerank.html#configuration-properties">nativeRank configuration</a> documentation</td></tr>
 
 <tr><td rowspan="10">fieldMatch</td>
   <td>proximityLimit
@@ -215,11 +233,13 @@ rank-profile my-profile inherits default {
   </td></tr>
 
 <tr>
-  <td>numTerms.&lt;fieldName&gt;</td>
+  <td>numTerms.<em>fieldName</em></td>
   <td>5</td>
   <td>
     The number of terms for which this is included in the rank features dump
-    in the summary for the specified field</td></tr>
+    in the summary for the specified field.  Also configurable using
+    <code style="font-weight: bold;">fieldTermMatch(<em>fieldName</em>).numTerms</code> as the property name.
+  </td></tr>
 
 <tr><td>elementCompleteness</td>
   <td>fieldCompletenessImportance</td>
@@ -239,8 +259,8 @@ rank-profile my-profile inherits default {
     Describes how the default output should be calculated. The value must be on the
     form <code>aggregator(expression)</code>. The expression is used to
     combine the low-level similarity measures between the query and
-    individual elements in the field that matched the query. 
-    The aggregator will be used to aggregate the output of the expression across matched elements. 
+    individual elements in the field that matched the query.
+    The aggregator will be used to aggregate the output of the expression across matched elements.
     The available aggregators are <code>max</code>, <code>avg</code>
     and <code>sum</code>. The available expression operators
     are <code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>
@@ -281,7 +301,7 @@ rank-profile my-profile inherits default {
   <td>maxWeight</td>
   <td>256</td>
   <td>
-    The maximal weight when calculating <code>attributeMatch(&lt;name&gt;).normalizedWeight</code>.
+    The maximal weight when calculating <code>attributeMatch(<em>name</em>).normalizedWeight</code>.
     Weights higher than this will not have any effect on this feature.</td></tr>
 
 <tr><td rowspan="3">closeness</td>
@@ -289,7 +309,7 @@ rank-profile my-profile inherits default {
   <td>9013305.0</td>
   <td>
     <p id="closeness">
-    The maximal distance when calculating <code>closeness(&lt;name&gt;)</code>.
+    The maximal distance when calculating <code>closeness(<em>name</em>)</code>.
     Distances higher than this will not have any effect on this feature.
     The default is about 1000 km (1 km is about 9013.305 microdegrees).
     </p>
@@ -299,7 +319,7 @@ rank-profile my-profile inherits default {
   <td>scaleDistance</td>
   <td>45066.525</td>
   <td>
-    Basic scale for distances when calculating <code>closeness(&lt;name&gt;).logscale</code>.
+    Basic scale for distances when calculating <code>closeness(<em>name</em>).logscale</code>.
     The default is about 5 km.
     {% include deprecated.html content="use <code>halfResponse</code> instead"%}
   </td></tr>
@@ -309,7 +329,7 @@ rank-profile my-profile inherits default {
   <td>593861.739</td>
   <td>
     The distance that should give an output of 0.5 when calculating
-    <code>closeness(&lt;name&gt;).logscale</code>.
+    <code>closeness(<em>name</em>).logscale</code>.
     The default is about 65.89 km (must be in the range [1, maxDistance/2&gt;).
     Use this parameter to fine-tune the distance range where half of the dynamics
     of the logscale function will be used.</td></tr>
@@ -319,7 +339,7 @@ rank-profile my-profile inherits default {
   <td>3*30*24*60*60</td>
   <td>
     <p id="freshness">
-    The maximal age in seconds when calculating <code>freshness(&lt;name&gt;)</code>.
+    The maximal age in seconds when calculating <code>freshness(<em>name</em>)</code>.
     Ages older than this will not have any effect on this feature.
     The default is about 3 months.
     </p>
@@ -330,7 +350,7 @@ rank-profile my-profile inherits default {
   <td>7*24*60*60</td>
   <td>
     The age in seconds that should give an output of 0.5 when calculating
-    <code>freshness(&lt;name&gt;).logscale</code>.
+    <code>freshness(<em>name</em>).logscale</code>.
     The default is 7 days (must be in the range [1, maxAge/2&gt;).
     Use this parameter to fine-tune the age range where half of the dynamics
     of the logscale function will be used.</td></tr>


### PR DESCRIPTION
Vespa now supports an alternative naming convention for rank feature configuration parameters: instead of featureName.paramName.fieldName, you can use featureName(fieldName).paramName. This is more consistent with how rank features are referenced elsewhere (e.g. in ranking expressions).

Update the nativerank and rank-feature-configuration reference docs to use the new syntax throughout. Also add cross-reference rows for nativeRank, nativeFieldMatch, and nativeProximity in the configuration table, document elementwise bm25 fallback behavior, and modernize HTML entities to use <em> consistently.
