### PR TITLE
docs: document <prepend> config for OpenAI embedder

### DIFF
--- a/en/rag/embedding.html
+++ b/en/rag/embedding.html
@@ -733,6 +733,11 @@ emit the same predefined metrics, although emitting custom metrics is perfectly 
   sample application.
 </p>
 <p>
+  The <code>&lt;prepend&gt;</code> element is also supported by the
+  <a href="../reference/rag/embedding.html#openai-embedder-reference-config">OpenAI embedder</a>,
+  which is useful for OpenAI-compatible instruction-tuned models that expect a task-specific prefix.
+</p>
+<p>
   An alternative approach is using query profiles to prepend query data.
   If you need to add a standard wrapper or a prefix instruction around the input text you want to embed
   use parameter substitution to supply the text, as in <code>embed(myEmbedderId, @text)</code>,

--- a/en/reference/rag/embedding.html
+++ b/en/reference/rag/embedding.html
@@ -661,6 +661,24 @@ Add the secret to the container <code>&lt;secrets&gt;</code> and refer to it in 
       <td>element</td>
       <td>disabled</td>
     </tr>
+    <tr>
+      <td>prepend</td>
+      <td>Optional</td>
+      <td>Strings prepended to the text input before sending the embedding request. Useful for
+        OpenAI-compatible instruction-tuned models that expect a task-specific prefix.
+        <ul>
+          <li>Element &lt;query&gt; - Optional query prepend instruction.</li>
+          <li>Element &lt;document&gt; - Optional document prepend instruction.</li>
+        </ul>
+    <pre>{% highlight xml %}
+    <prepend>
+      <query>query: </query>
+      <document>passage: </document>
+    </prepend>{% endhighlight %}</pre>
+      </td>
+      <td>Optional &lt;query&gt; &lt;document&gt; elements.</td>
+      <td></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary

- Documents the new `<prepend>` element for the OpenAI embedder in `en/reference/rag/embedding.html` (reference table row with example).
- Adds a cross-reference from the "Adding a fixed string to a query text" section in `en/rag/embedding.html` so users searching for prepend find that it also works for the OpenAI embedder.
- Pairs with the implementation PR: vespa-engine/vespa#36580.