### PR TITLE
add doc prepend and update commit sha for voyage-4-nano

### DIFF
--- a/en/rag/model-hub.html
+++ b/en/rag/model-hub.html
@@ -381,7 +381,7 @@ for details on quality impact.</p>
     <tr><td>Matryoshka dimensions</td><td><code>x[2048]</code>, <code>x[1024]</code>, <code>x[512]</code>, <code>x[256]</code></td></tr>
     <tr><td><a href="../reference/schemas/schemas.html#distance-metric">distance-metric</a></td><td><code>angular</code></td></tr>
     <tr><td>License</td><td><a href="https://www.apache.org/licenses/LICENSE-2.0">apache-2.0</a></td></tr>
-    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ 736c0d0</td></tr>
+    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ fcf290</td></tr>
     <tr><td>Language</td><td>English</td></tr>
     <tr><td>Component declaration</td><td>
     <div class="pre-parent">
@@ -394,6 +394,7 @@ for details on quality impact.</p>
         <normalize>true</normalize>
         <prepend>
             <query>Represent the query for retrieving supporting documents: </query>
+            <document>Represent the document for retrieval: </document>
         </prepend>
     </component>
 {% endhighlight %}</pre>
@@ -409,7 +410,7 @@ for details on quality impact.</p>
     <tr><td>Matryoshka dimensions</td><td><code>x[2048]</code>, <code>x[1024]</code>, <code>x[512]</code>, <code>x[256]</code></td></tr>
     <tr><td><a href="../reference/schemas/schemas.html#distance-metric">distance-metric</a></td><td><code>angular</code></td></tr>
     <tr><td>License</td><td><a href="https://www.apache.org/licenses/LICENSE-2.0">apache-2.0</a></td></tr>
-    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ 736c0d0</td></tr>
+    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ fcf290 </td></tr>
     <tr><td>Language</td><td>English</td></tr>
     <tr><td>Component declaration</td><td>
     <div class="pre-parent">
@@ -422,6 +423,7 @@ for details on quality impact.</p>
         <normalize>true</normalize>
         <prepend>
             <query>Represent the query for retrieving supporting documents: </query>
+            <document>Represent the document for retrieval: </document>
         </prepend>
     </component>
 {% endhighlight %}</pre>

--- a/en/rag/model-hub.html
+++ b/en/rag/model-hub.html
@@ -381,7 +381,7 @@ for details on quality impact.</p>
     <tr><td>Matryoshka dimensions</td><td><code>x[2048]</code>, <code>x[1024]</code>, <code>x[512]</code>, <code>x[256]</code></td></tr>
     <tr><td><a href="../reference/schemas/schemas.html#distance-metric">distance-metric</a></td><td><code>angular</code></td></tr>
     <tr><td>License</td><td><a href="https://www.apache.org/licenses/LICENSE-2.0">apache-2.0</a></td></tr>
-    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ fcf290</td></tr>
+    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ fcf290d</td></tr>
     <tr><td>Language</td><td>English</td></tr>
     <tr><td>Component declaration</td><td>
     <div class="pre-parent">
@@ -410,7 +410,7 @@ for details on quality impact.</p>
     <tr><td>Matryoshka dimensions</td><td><code>x[2048]</code>, <code>x[1024]</code>, <code>x[512]</code>, <code>x[256]</code></td></tr>
     <tr><td><a href="../reference/schemas/schemas.html#distance-metric">distance-metric</a></td><td><code>angular</code></td></tr>
     <tr><td>License</td><td><a href="https://www.apache.org/licenses/LICENSE-2.0">apache-2.0</a></td></tr>
-    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ fcf290 </td></tr>
+    <tr><td>Source</td><td><a href="https://huggingface.co/thomasht86/voyage-4-nano-ONNX">https://huggingface.co/thomasht86/voyage-4-nano-ONNX</a> @ fcf290d </td></tr>
     <tr><td>Language</td><td>English</td></tr>
     <tr><td>Component declaration</td><td>
     <div class="pre-parent">


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Uses official tokenizer after transformers base model changed (no longer needs to add `endoftext` token) and add document prepend string to snippets.  
