### PR TITLE
Document cluster-scoped template variables for resource tags

### DIFF
--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -400,15 +400,15 @@ Variables can be combined, e.g. <code>value="${environment}-${clustertype}"</cod
   <tbody>
   <tr>
     <td><code>${tenant}</code></td>
-    <td>The tenant name.</td>
+    <td>The tenant name, e.g. <code>mytenant</code>.</td>
   </tr>
   <tr>
     <td><code>${application}</code></td>
-    <td>The application name.</td>
+    <td>The application name, e.g. <code>myapp</code>.</td>
   </tr>
   <tr>
     <td><code>${instance}</code></td>
-    <td>The instance name.</td>
+    <td>The instance name, e.g. <code>default</code>, <code>beta</code>.</td>
   </tr>
   <tr>
     <td><code>${environment}</code></td>

--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -386,18 +386,49 @@ instance-level value wins.
 </p>
 
 <p id="resource-tags-template-variables"><strong>Template variables.</strong>
-Tag values may reference the following template variables, which are resolved at deployment time:</p>
-<ul>
-  <li><code>${tenant}</code></li>
-  <li><code>${application}</code></li>
-  <li><code>${instance}</code></li>
-  <li><code>${environment}</code></li>
-  <li><code>${region}</code></li>
-</ul>
-<p>
-  Resolved values are lowercased to match the label constraints above. Referencing an unknown
-  variable causes the deployment to fail.
-</p>
+Tag values may reference the following template variables.
+Resolved values are lowercased to match the label constraints above.
+Referencing an unknown variable causes the deployment to fail.
+Variables can be combined, e.g. <code>value="${environment}-${clustertype}"</code>.</p>
+<table class="table">
+  <thead>
+  <tr>
+    <th style="width:200px">Variable</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><code>${tenant}</code></td>
+    <td>The tenant name.</td>
+  </tr>
+  <tr>
+    <td><code>${application}</code></td>
+    <td>The application name.</td>
+  </tr>
+  <tr>
+    <td><code>${instance}</code></td>
+    <td>The instance name.</td>
+  </tr>
+  <tr>
+    <td><code>${environment}</code></td>
+    <td>The deployment environment, e.g. <code>prod</code>, <code>dev</code>.</td>
+  </tr>
+  <tr>
+    <td><code>${region}</code></td>
+    <td>The deployment region, e.g. <code>aws-us-east-1c</code>.</td>
+  </tr>
+  <tr>
+    <td><code>${clustername}</code></td>
+    <td>The cluster ID from <a href="services/services.html">services.xml</a>,
+      e.g. <code>default</code>, <code>music</code>.</td>
+  </tr>
+  <tr>
+    <td><code>${clustertype}</code></td>
+    <td>The Vespa cluster type: <code>container</code>, <code>content</code>, or <code>admin</code>.</td>
+  </tr>
+  </tbody>
+</table>
 
 <p><strong>Reconciliation.</strong>
 Tags are applied to virtual machines and attached disks. When tags are changed, added, or removed


### PR DESCRIPTION
Adds `${clustername}` and `${clustertype}` to the template variables section of the `<resource-tags>` reference.

Reformats the variable list as a table with consistent descriptions for all seven variables.

Companion PRs: vespaai/cloud#2588, vespa-engine/vespa#36597