### PR TITLE
Mark saved search notifications as experimental

### DIFF
--- a/en/modules/e-commerce/saved-search.html
+++ b/en/modules/e-commerce/saved-search.html
@@ -4,6 +4,14 @@ title: Saved Search Notifications
 applies_to: enterprise
 ---
 
+{% include important.html content="
+<strong>Experimental feature under active development.</strong>
+Saved Search Notifications is in early access and is being actively developed.
+Schemas, configuration, the webhook payload format, and other public APIs may change in
+backwards-incompatible ways without notice. Do not rely on this feature for
+production-critical workloads, and expect to migrate as the feature evolves.
+Feedback is welcome &mdash; please reach out to <a href='https://vespa.ai/support/'>Vespa Support</a>." %}
+
 <p>
   Vespa for e-commerce includes a module for storing queries in Vespa ("searches") and issuing notifications
   when a new or updated document matches any saved searches.

--- a/en/modules/e-commerce/using-features-together.html
+++ b/en/modules/e-commerce/using-features-together.html
@@ -4,6 +4,11 @@ title: Using Features Together
 applies_to: enterprise
 ---
 
+{% include important.html content="
+Some features described on this page (notably <a href='saved-search.html'>Saved Search Notifications</a>)
+are experimental and under active development. APIs and configuration may change in
+backwards-incompatible ways &mdash; see the individual feature pages for details." %}
+
 <p>
   The e-commerce features are designed as standalone components that can be composed together.
   This page covers the configuration needed


### PR DESCRIPTION
- Adds a prominent "Important" notice at the top of the Saved Search Notifications page flagging the feature as experimental, under active development, and subject to backwards-incompatible API changes.
- Adds a shorter notice on the Using Features Together page pointing to the experimental status of saved search.

🤖 AI declaration: _[Claude Code](https://claude.com/claude-code) wrote this PR title and description. The code is partly written with Claude; I have reviewed all code and commits myself._