### PR TITLE
Easier navigation to the variants

### DIFF
--- a/en/reference/applications/services/services.html
+++ b/en/reference/applications/services/services.html
@@ -286,6 +286,24 @@ Any value set as a range will be <a href="../../../operations/autoscaling.html">
 {% endhighlight %}</pre>
 
 
+
+<h2 id="zone-specific-configuration">Zone-specific configuration</h2>
+<p>
+  Use <em>deployment variants</em> to express configuration like:
+</p>
+<pre>{% highlight xml %}
+<nodes deploy:environment="prod"
+       deploy:region="aws-use1-az4"
+       count="20">
+    <resources vcpu="4" memory="16Gb" disk="125Gb"/>
+</nodes>
+{% endhighlight %}</pre>
+<p>
+  Refer to <a href="../../../operations/deployment-variants.html">deployment variants</a> for details and more options.
+</p>
+
+
+
 <h2 id="generic-config">Generic configuration using &lt;config&gt;</h2>
 
 <p>Most elements in <em>services.xml</em> accept a sub-element named <em>config</em>.


### PR DESCRIPTION
... i always go to the services.xml reference for this, not to find it ...

I consider moving this from deployment-variants.html into the services.xml reference, and the rest into some query profile reference - it feels odd to have it as a separate doc, with two different things in it - what do you think @hmusum  ?