### PR TITLE
Wire up SEO infrastructure: meta description, canonical, OG, sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,10 +15,12 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: Vespa. Big data. Real time. Open source.
+tagline: Vespa Documentation
 description: >- # this means to ignore newlines until "baseurl:"
   Vespa - the open big data serving platform
 # baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://docs.vespa.ai" # the base hostname & protocol for your site, e.g. http://example.com
+logo: /assets/logos/vespa-logo-green-rgb.svg
 # Remove this before publishing on github.com
 repository: vespa/documentation
 repository_url: "https://github.com/vespa-engine/documentation"
@@ -31,6 +33,8 @@ markdown: kramdown
 plugins:
   - jekyll-feed
   - jekyll-redirect-from
+  - jekyll-sitemap
+  - jekyll-seo-tag
 
 kramdown:
   smart_quotes: ["apos", "apos", "quot", "quot"]

--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -7,7 +7,7 @@
     <!-- "meta_robots_noindex" front matter flag - prevents external search engines from indexing this page.
          Separate from the "index" flag which controls the Vespa site search index. -->
     {% if page.meta_robots_noindex %}<meta name="robots" content="noindex" />
-    {% endif %}<title>{{ page.title | default: "Vespa Documentation" }}</title>
+    {% endif %}{% seo %}
 
     {% if jekyll.environment == 'production' %}
     <script>

--- a/robots.txt
+++ b/robots.txt
@@ -4,3 +4,8 @@ Disallow: /css/
 Disallow: /js/
 Disallow: /playground/
 Disallow: /icons/
+
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.vespa.ai/sitemap.xml


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

  - _config.yml: jekyll-sitemap and jekyll-seo-tag (already in Gemfile.lock via github-pages), added tagline so titles read "Page Title | Vespa Documentation" instead of the verbose site title, and pointed logo at the existing brand SVG for JSON-LD.
  - _includes/htmlhead.html: replaced the manual <title> with {% seo %}, which now emits title, meta description (falls back to first paragraph), canonical, Open Graph, Twitter Card, and JSON-LD. Existing meta_robots_noindex logic preserved.
  - robots.txt: added User-agent: * block and Sitemap: https://docs.vespa.ai/sitemap.xml.
