### PR TITLE
Improve and extend dispatch policy documentation

### DIFF
--- a/en/reference/applications/services/content.html
+++ b/en/reference/applications/services/content.html
@@ -1679,22 +1679,26 @@ Tune the query dispatch behavior - child elements:
         See <em>top-k-probability</em> below for improving performance with fewer hits.</p></td></tr>
     <tr><th>dispatch-policy</th>
       <td>optional</td>
-      <td>best-of-random-2 / adaptive</td>
+      <td>adaptive / best-of-random-2 / round-robin</td>
       <td>adaptive</td>
       <td>
         <p id="dispatch-policy">
+        With <a href="../../../performance/sizing-search.html#data-distribution">grouped distribution</a>:
         Configure policy for choosing which group shall receive the next query request.
-        However, multiphase requests that either requires or benefits from hitting the same group
+        Coverage requirements is considered when choosing a group.
+        Note that multiphase requests that requires or benefits from hitting the same group
         in all phases are always hashed.
-        Relevant only for <a href="../../../performance/sizing-search.html#data-distribution">grouped distribution</a>:
         </p>
         <table class="table">
+          <tr>
+            <th>adaptive</th>
+            <td>Measures latency, preferring lower latency groups, selecting group <code>i</code> has a probability proportional to 1 / (latency for group <code>i</code>).</td>
           <tr>
             <th style="white-space: nowrap">best-of-random-2</th>
             <td>Selects 2 random groups and selects the one with the lowest latency.</td>
           </tr><tr>
-            <th>adaptive</th>
-            <td>measures latency, preferring lower latency groups, selecting group with probability latency/(sum latency over all groups)</td>
+            <th>round-robin</th>
+            <td>Selects groups in a round-robin manner, giving fair distribution of queries to each group.</td>
           </tr>
         </table>
     <tr><th style="white-space: nowrap">prioritize-availability</th>


### PR DESCRIPTION
* Document 'round-robin' policy
* Fix description of 'adaptive' policy to be correct (groups with lower latency get more queries, not the other way around)
