### PR TITLE
Select syntax: doc type selection example

### DIFF
--- a/en/reference/querying/json-query-language.md
+++ b/en/reference/querying/json-query-language.md
@@ -172,10 +172,24 @@ equivalent JSON `grouping`-argument:
 ]
 ```
 
+### Other query parameters
+
+[Query parameters](../api/query.html) not specific to the Select or YQL syntax will work as well. For example, to search for everything (`"where": true`) in the `music` document type:
+
+```json
+{
+  "select": {
+    "where": true
+  },
+  "model": {
+    "restrict": "judgment"
+  }
+}
+```
 
 ### Complete examples
 
-Query everything (`"where": true`), create one bucket for all documents (`"group": "\"all\""`) and output overall price statistics (`"avg(price)"` and `"sum(price)"`):
+Create one bucket for all documents (`"group": "\"all\""`) and output overall price statistics (`"avg(price)"` and `"sum(price)"`):
 
 ```json
 {


### PR DESCRIPTION
And, in general, that you could use other parameters.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
