### PR TITLE
Document document-IDs-as-attribute feature

### DIFF
--- a/en/operations/data-management.html
+++ b/en/operations/data-management.html
@@ -79,9 +79,11 @@ $ vespa visit --zone prod.aws-us-east-1c --cluster default --selection doc | hea
 <pre>
 $ vespa visit --zone prod.aws-us-east-1c --cluster default --selection doc --field-set '[id]' | head
 </pre>
+{% include note.html content='Configuring the <a href="../reference/schemas/schemas.html#documentid"><code>documentid</code></a> field to be an attribute in the schema avoids that this requires disk access and, hence, speeds up the exporting process.' %}
 <p>
   As the name implies, fieldsets are useful to select a subset of fields to export.
-  Note that this normally does not speed up the exporting process, as the same amount of data is read from the index.
+  Note that, if disk access is required to fetch a field from the fieldset, selecting fewer
+  fields does not speed up the exporting process as the same amount of data is read from the index.
   The data transfer out of the Vespa application is smaller with fewer fields.
 </p>
 <p>

--- a/en/querying/document-summaries.html
+++ b/en/querying/document-summaries.html
@@ -57,9 +57,10 @@ $ vespa query "select <span class="pre-hilite">*</span> from music where album c
 </pre>
 
 <p>A common reason to define a document summary class is <a href="#performance">performance</a>:
-By configuring a document summary which only contains attributes the result can be generated
-without disk accesses. Note that this is needed to ensure only memory is accessed even if all fields are
-attributes because the <a href="../schemas/documents.html#document-ids">document ID</a> is not stored as an attribute.</p>
+By configuring a document summary that only contains attributes the result can be generated
+without disk accesses. Note that this may be needed to ensure only memory is accessed even if all fields are
+attributes because the <a href="../schemas/documents.html#document-ids">Document IDs</a>
+are not an attribute unless explicitly configured otherwise.</p>
 
 <p>Document summaries may also contain <a href="#dynamic-snippets">dynamic snippets and highlighted terms</a>.</p>
 
@@ -222,13 +223,16 @@ in services.xml inside the &lt;content&gt; cluster tag for the content cluster i
   <a href="../content/proton.html#document-store">document store</a>.
   Requesting these fields may therefore require a disk access, increasing latency.
 </p>
-{% include important.html content='The default summary class will access the document store
-as it includes the <a href="../reference/querying/default-result-format.html#documentid">documentid</a> field
-which is stored there.
-For maximum query throughput using memory-only access, use a dedicated summary class with attributes only.' %}
-
-<!-- ToDo: https://github.com/vespa-engine/vespa/issues/24371 - Allow documentid to be turned into an attribute
-           Update this doc when the issue is closed -->
+{% include important.html content='
+The default summary class contains the
+the <a href="../reference/querying/default-result-format.html#documentid">documentid</a> field,
+which by default is stored in the document store only. Hence, using it
+will cause accesses to the document store by default.
+For maximum query throughput using memory-only access,
+set <a href="../reference/schemas/schemas.html#documentid"><code>documentid</code></a>
+to <code>attribute</code> in the schema
+or use a custom summary class with attributes only.
+' %}
 
 <p>
   When using additional summary classes to increase performance,

--- a/en/reference/querying/default-result-format.html
+++ b/en/reference/querying/default-result-format.html
@@ -319,12 +319,16 @@ redirect_from:
     <td>String</td>
     <td>
       <p id="id">String identifying the hit, document or other data type.
-      For document hits, this is the full string document ID if the hit is filled with a
-      document summary from disk. If it is not filled or only filled with data from memory (attributes),
+      For document hits, this is the full string document ID if the hit is filled with a document summary
+      that includes the <code>documentid</code> field.
+      If it is not filled or only filled with a document summary without the <code>documentid</code> field,
       it is an internally generated unique id on the form <code>index:[source]/[node-index]/[hex-gid]</code>.</p>
-      <p>Also see the <a href="../../writing/document-v1-api-guide.html#troubleshooting">/document/v1/ guide</a>
-      and <a href="https://stackoverflow.com/questions/74033383/receiving-responses-of-different-formats-for-the-same-query-in-vespa">
-      receiving-responses-of-different-formats-for-the-same-query-in-vespa</a>.</p>
+      <p>See <a href="../../schemas/documents.html#docid-in-results">Document IDs in search results</a>
+      for how to ensure that the full string document ID (from memory) is returned.</p>
+      <p>For further information on the internally generated ids,
+      see the <a href="../../writing/document-v1-api-guide.html#troubleshooting">/document/v1/guide</a>
+      and also <a href="https://stackoverflow.com/questions/74033383/receiving-responses-of-different-formats-for-the-same-query-in-vespa">
+      receiving-responses-of-different-formats-for-the-same-query-in-vespa</a> (outdated regarding document IDs being stored on disk only).</p>
     </td>
   </tr>
   <tr>

--- a/en/reference/schemas/schemas.html
+++ b/en/reference/schemas/schemas.html
@@ -170,6 +170,7 @@ Names are <em>identifiers</em>, they must match <code>["a"-"z","A"-"Z", "_"]["a"
     <a href="#constant">constant</a>
     <a href="#onnx-model">onnx-model</a>
     <a href="#stemming">stemming</a>
+    <a href="#documentid">documentid</a>
     <a href="#document-summary">document-summary</a>
         <a href="#summary">summary</a>
     <a href="#import-field">import field</a>
@@ -241,6 +242,11 @@ The document type in this must declare that it inherits the document type of the
 <tr><td><a href="#raw-as-base64-in-summary">raw-as-base64-in-summary</a></td>
   <td>Zero or one</td>
   <td>Base64 encode raw fields in summary rather than using an escaped string. The default is true.</td>
+</tr>
+
+<tr><td><a href="#documentid">documentid</a></td>
+  <td>Zero or one</td>
+  <td>Whether document IDs are stored on disk only or made an attribute.</td>
 </tr>
 
 <tr><td style="white-space: nowrap"><a href="#document-summary">document-summary</a></td>
@@ -2725,6 +2731,31 @@ document-summary [name] inherits [document-summary1], [document-summary2], ... {
   See also <a href="../../querying/document-summaries.html">document summaries</a>.
 </p>
 
+
+<h2 id="documentid">documentid</h2>
+<p>Available since {% include version.html version="8.690.44" %}.</p>
+<p>
+Contained in <a href="#schema">schema</a>.
+Sets whether document IDs are stored on disk only or made an attribute
+by also storing them in memory.
+Changing this setting will only take effect on the next restart of the <code>searchnode</code> service.
+<p>
+Making the document IDs an attribute allows to return <a href="../../schemas/documents.html#docid-in-results">Document IDs in search results</a>
+and to visit Document IDs without disk access, cf.
+<a href="../../operations/data-management.html#export-documents">Export documents</a>.
+</p>
+<pre>
+documentid: [setting]
+</pre>
+The settings are:
+<table class="table">
+<thead>
+<tr><th>Setting</th><th>Description</th></tr>
+</thead><tbody>
+<tr><td>from-disk</td><td>Store document IDs on disk only. This is the default setting.</td></tr>
+<tr><td>attribute</td><td>Make the document IDs an attribute by also storing them in memory.</td></tr>
+</tbody>
+</table>
 
 
 <h2 id="stemming">stemming</h2>

--- a/en/reference/schemas/schemas.html
+++ b/en/reference/schemas/schemas.html
@@ -2733,7 +2733,7 @@ document-summary [name] inherits [document-summary1], [document-summary2], ... {
 
 
 <h2 id="documentid">documentid</h2>
-<p>Available since {% include version.html version="8.690.44" %}.</p>
+<p>Available since {% include version.html version="8.691.19" %}.</p>
 <p>
 Contained in <a href="#schema">schema</a>.
 Sets whether document IDs are stored on disk only or made an attribute

--- a/en/schemas/documents.html
+++ b/en/schemas/documents.html
@@ -115,7 +115,7 @@ Find examples and tools in <a href="../writing/document-v1-api-guide.html#docume
   To enable storing the document IDs in memory,
   set <a href="../reference/schemas/schemas.html#documentid"><code>documentid</code></a>
   to <code>attribute</code> in the schema.
-  This is possible since {% include version.html version="8.690.44" %}.
+  This is possible since {% include version.html version="8.691.19" %}.
   To return the document IDs from memory in the search results, configure a
   <a href="../querying/document-summaries.html">document summary</a>
   like this:

--- a/en/schemas/documents.html
+++ b/en/schemas/documents.html
@@ -106,30 +106,43 @@ Find examples and tools in <a href="../writing/document-v1-api-guide.html#docume
 <p>
   The full document ID (as a string) will often contain redundant
   information and be quite long; a typical value may look like
-  "id:mynamespace:mydoctype::user-specified-identifier" where only the
-  last part is useful outside Vespa.  The document ID is therefore not
-  stored in memory, and it <strong>not always present</strong> in
+  "id:mynamespace:mydoctype::user-specified-identifier", where only the
+  last part is useful outside Vespa. The document ID is therefore not
+  stored in memory by default and <strong>not always present</strong> in the
   <a href="../reference/querying/default-result-format.html#id">search results</a>.
-  It is therefore recommended to put your own unique identifier
-  (usually the "user-specified-identifier" above) in a document field,
-  typically named "myid" or "shortid" or similar:
+</p>
+<p>
+  To enable storing the document IDs in memory,
+  set <a href="../reference/schemas/schemas.html#documentid"><code>documentid</code></a>
+  to <code>attribute</code> in the schema.
+  This is possible since {% include version.html version="8.690.44" %}.
+  To return the document IDs from memory in the search results, configure a
+  <a href="../querying/document-summaries.html">document summary</a>
+  like this:
 </p>
 <pre>
-field shortid type string {
-    indexing: attribute | summary
-}
+schema music {
+    documentid: attribute
+    document music {
+        field ...
+    }
+    document-summary empty-summary {
+        summary documentid {
+            source: documentid
+        }
+    }
+    ...
 </pre>
 <p>
-  This enables using a
-  <a href="../querying/document-summaries.html">document-summary</a> with only
-  in-memory fields while still getting the identifier you actually
-  care about.  If the "user-specified-identifier" is just a simple
-  number you could even use "type int" for this field for minimal
-  memory overhead.
+  Then, use <code>presentation.summary=empty-summary</code> in the query API.
 </p>
 <p>
-  The document ID is stored on disk in the document summary.
-  To return this value in search results, configure the schema like this:
+  With the default <code>from-disk</code> setting for
+  <a href="../reference/schemas/schemas.html#documentid"><code>documentid</code></a>
+  in the schema, the document ID is stored on disk only.
+  To return the value in the search results anyway, configure a
+  <a href="../querying/document-summaries.html">document summary</a>
+  like this:
 </p>
 <pre>
 schema music {
@@ -145,9 +158,27 @@ schema music {
     ...
 </pre>
 <p>
-  ... and use <code>presentation.summary=empty-summary</code> in the query API.
-  The <code>from-disk</code> setting mutes a warning for document summary disk access;
-  Use a higher query timeout when requesting many IDs like this.
+  The <code>from-disk</code> setting mutes a warning for document-summary disk access;
+  use a higher query timeout when requesting many IDs like this.
+</p>
+<p>
+  A more memory-efficient, but also more complicated alternative is to
+  put your own unique identifier
+  (usually the "user-specified-identifier" above) in a document field,
+  typically named "myid" or "shortid" or similar:
+</p>
+<pre>
+field shortid type string {
+    indexing: attribute | summary
+}
+</pre>
+<p>
+  This enables using a
+  <a href="../querying/document-summaries.html">document summary</a> with only
+  in-memory fields while still getting the identifier you actually
+  care about.  If the "user-specified-identifier" is just a simple
+  number you could even use "type int" for this field for minimal
+  memory overhead.
 </p>
 
 

--- a/en/writing/document-v1-api-guide.html
+++ b/en/writing/document-v1-api-guide.html
@@ -507,10 +507,11 @@ Error: Invalid document operation: 404 Not Found
 }
 {% endhighlight %}</pre>
     <p>
-      <a href="../reference/querying/default-result-format.html#id">Query result IDs</a> are not the same as document IDs.
-      Use a separate field for the document ID, if needed.
+      The <a href="../reference/querying/default-result-format.html#id">query result IDs</a> are not necessarily document IDs.
+      See <a href="../schemas/documents.html#docid-in-results">Document IDs in search results</a>
+      for how to ensure that document IDs are returned in search results.
     </p>
-  </li><!-- ToDo: https://github.com/vespa-engine/vespa/issues/24371 Allow documentid to be turned into an attribute -->
+  </li>
   <li>
     <p id="delete-all-documents">Delete <em>all</em> documents in <em>music</em> schema, with security credentials:</p>
 <pre>


### PR DESCRIPTION
Merge only once everything is ready. Will clean up the "document id/document ID/Document ID" mess in the documentation in a separate PR.