### PR TITLE
update no uppercase restriction for tags to only apply to GCP

### DIFF
--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -376,15 +376,17 @@ instance-level value wins.
     <td>
       The tag value. May contain <a href="#resource-tags-template-variables">template variables</a>.
       After template resolution, must be non-empty and contain only the characters
-      <code>[a-z0-9_-]</code>. At most 63 characters.
+      <code>[A-Za-z0-9_-]</code>. At most 63 characters.
+      Uppercase letters are <strong>not</strong> allowed when the deployment targets a GCP zone,
+      since GCP labels are lowercase-only.
     </td>
   </tr>
   </tbody>
 </table>
 <p>
   Up to 20 tags are allowed per instance (after merging deployment-level and instance-level tags).
-  The key and value constraints apply to AWS tags, Azure tags, and GCP labels; the lowercase and
-  length restrictions are the strictest of the three and apply uniformly.
+  Keys must be lowercase to satisfy the strictest cloud (GCP). Values may use uppercase on AWS and
+  Azure, but must remain lowercase on GCP.
 </p>
 
 <p id="resource-tags-template-variables"><strong>Template variables.</strong>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
