### PR TITLE
clarify, take out from the HTTP section

### DIFF
--- a/en/querying/query-api.html
+++ b/en/querying/query-api.html
@@ -27,7 +27,13 @@ $ vespa query "select * from music where year > 2001" \
   refer to the <a href="../reference/api/query.html">Query API reference</a> for details.
   See <a href="#query-execution">query execution</a> below for data flow.
 </p>
-
+<p>
+  Best practice for lexical queries is submitting the user-generated query as-is,
+  then use <a href="../applications/searchers.html">Searcher components</a> to implement additional logic.
+</p>
+<p>
+  See the <a href="https://github.com/vespa-engine/vespa/tree/master/client">client library</a> for options.
+</p>
 
 
 <h2 id="input">Input</h2>
@@ -430,9 +436,6 @@ use this to write code to manipulate results.
 
 
 <h2 id="http">HTTP</h2>
-{% include note.html content='Vespa does not provide a java client library for the query API.
-Best practice for queries is submitting the user-generated query as-is,
-then use <a href="../applications/searchers.html">Searcher components</a> to implement additional logic.' %}
 <p>
   The Vespa Team does not recommend any specific HTTP client, since we haven't done any systematic evaluation.
   We have most experience with the Apache HTTP client.


### PR DESCRIPTION
Added best practices for lexical queries and client library options.
