### PR TITLE
Document reserved tag keys and per-cloud tag limits

### DIFF
--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -429,9 +429,9 @@ instance-level value wins.
   </tr>
   <tr>
     <td>Max tags</td>
-    <td>50</td>
-    <td>50</td>
-    <td>64</td>
+    <td>35</td>
+    <td>35</td>
+    <td>49</td>
   </tr>
   </tbody>
 </table>

--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -367,7 +367,7 @@ instance-level value wins.
     <td>
       The tag key. Must be non-empty. Allowed characters and maximum length depend on the
       target cloud; see <a href="#resource-tags-per-cloud-rules">per-cloud rules</a> below.
-      The <code>vai_</code> prefix is reserved for internal use.
+      Certain keys are <a href="#resource-tags-reserved-keys">reserved</a> by the platform.
     </td>
   </tr>
   <tr>
@@ -432,6 +432,53 @@ instance-level value wins.
     <td>35</td>
     <td>35</td>
     <td>49</td>
+  </tr>
+  </tbody>
+</table>
+
+<p id="resource-tags-reserved-keys"><strong>Reserved keys.</strong>
+The following tag keys are reserved by the platform and cannot be used.
+All comparisons are case-insensitive.</p>
+<table class="table">
+  <thead>
+  <tr>
+    <th style="width:150px">Type</th>
+    <th>Reserved keys</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Exact names</td>
+    <td>
+      <code>app</code>,
+      <code>application</code>,
+      <code>applicationid</code>,
+      <code>athenz</code>,
+      <code>athenz-domain</code>,
+      <code>athenzservice</code>,
+      <code>auth-method</code>,
+      <code>cluster</code>,
+      <code>clusterid</code>,
+      <code>fqdn</code>,
+      <code>generation</code>,
+      <code>name</code>,
+      <code>owner</code>,
+      <code>preprovisioned</code>,
+      <code>system</code>,
+      <code>tenant</code>,
+      <code>tenantName</code>,
+      <code>zone</code>
+    </td>
+  </tr>
+  <tr>
+    <td>Key prefixes</td>
+    <td>
+      <code>vai_</code>,
+      <code>corp_</code>,
+      <code>corp:</code>,
+      <code>bastion_</code>,
+      <code>bastion:</code>
+    </td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Documents the full set of reserved tag keys and key prefixes for the `<resource-tags>` element, and reduces the per-cloud max tag counts to reflect customer-available limits after reserving headroom for system tags.

Goes with vespa-engine/vespa#37005.

- Fix max tags in per-cloud table: 50/50/64 -> 35/35/49 (cloud hard limit minus 15 reserved system tags)
- Add reserved keys section: 18 exact names and 3 key prefixes (`vai_`, `corp_`, `bastion_`), all case-insensitive
- Update key attribute description to link to the new reserved keys section

### Important notes
- I have reserved 15 tags per cloud for our own use. Our current count could double if we phase in the `vai_` prefix for all at once. We're currently using 4 per cloud for instance/disk but 7 for e.g. NLB (which we don't currently apply custom tags for).
- Please check the list of reserved tags for leaking internals. 