### PR TITLE
Fix typo in text() documentation

### DIFF
--- a/en/reference/querying/yql.html
+++ b/en/reference/querying/yql.html
@@ -587,7 +587,7 @@ where attribute_field matches "mado[n]+a"
 
       <p>The text argument can be given as a reference using "@parameterName":</p>
       <pre>
-      yql=select * from sources * where text_field contains (@text)&amp;text=some text
+      yql=select * from sources * where text_field contains text(@text)&amp;text=some text
       </pre>
   </tr>
 


### PR DESCRIPTION
Not really a typo, but we missed the actual operator.