### PR TITLE
Be more explicit about documentid setting requiring restart

### DIFF
--- a/en/reference/schemas/schemas.html
+++ b/en/reference/schemas/schemas.html
@@ -2739,6 +2739,8 @@ Contained in <a href="#schema">schema</a>.
 Sets whether document IDs are stored on disk only or made an attribute
 by also storing them in memory.
 Changing this setting will only take effect on the next restart of the <code>searchnode</code> service.
+Unlike other <a href="#changes-that-require-restart-but-not-re-feed">Changes that require restart but not re-feed</a>,
+changing this setting is currently not being reported as needing a restart and the restart is currently not automated on Vespa Cloud.
 <p>
 Making the document IDs an attribute allows to return <a href="../../schemas/documents.html#docid-in-results">Document IDs in search results</a>
 and to visit Document IDs without disk access, cf.


### PR DESCRIPTION
Makes it clear that the `documentid` setting will not trigger a restart automatically on Vespa Cloud.