### PR TITLE
Document new, timing-related ANN parameters and metrics

### DIFF
--- a/en/performance/graceful-degradation.html
+++ b/en/performance/graceful-degradation.html
@@ -40,6 +40,12 @@ redirect_from:
     Soft timeout might also be considered as an <em>early termination</em> technique, and is enabled by default.
     Refer to <a href="../reference/api/query.html#ranking.softtimeout.enable">ranking.softtimeout.enable</a>.
   </li>
+  <li>
+    <strong>ANN Timeout</strong>: The ANN timeout allows approximate nearest neighbor searches
+    to terminate early in order to leave enough time for the actual matching process.
+    See <a href="#early-termination-of-approximate-nearest-neighbor-search">Early termination of approximate nearest neighbor search</a>
+    for more details.
+  </li>
 </ul>
 
 
@@ -47,8 +53,7 @@ redirect_from:
 <h2 id="detection">Detection</h2>
 <p>
 The default JSON renderer template will always render a <em>coverage</em> element below the root element,
-which has a <em>degraded</em> element if the query execution was degraded in some way
-and the <em>coverage</em> field will be less than 100.
+which has a <em>degraded</em> element if the query execution was degraded in some way.
 Example request with a query timeout of 200 ms and <em>ranking.softtimeout.enable=true</em>:
 </p>
 <pre>
@@ -63,7 +68,8 @@ Example request with a query timeout of 200 ms and <em>ranking.softtimeout.enabl
                 "adaptive-timeout": false,
                 "match-phase": false,
                 "non-ideal-state": false,
-                "timeout": true
+                "timeout": true,
+                "anntimeout": false
             },
             "documents": 167006201,
             "full": false,
@@ -94,12 +100,14 @@ The <em>degraded</em> field contains the following fields which explains why the
     </li>
   <li><em>non-ideal-state</em> is true in cases where the system is not in
     <a href="../content/idealstate.html">ideal state</a>. This case is extremely rare.</li>
-  <li><em>timeout</em> is true if softtimeout was enabled, and not all documents could be matched and ranked
+  <li><em>timeout</em> is true if the soft timeout was enabled, and not all documents could be matched and ranked
       within the query timeout.</li>
+  <li><em>anntimeout</em> is true if the ANN timeout was enabled and an ANN search terminated early
+      due to reaching the timeout, cf. <a href="#early-termination-of-approximate-nearest-neighbor-search">Early termination of approximate nearest neighbor search</a></li>
 </ul>
 <p>
 Note that the degraded reasons are not mutually exclusive.
-In the example, the softtimeout was triggered
+In the example, the soft timeout was triggered
 and only 99% of the documents where queried before the time budget ran out.
 
 One could imagine scenarios where 10 out of 11 nodes involved in the query execution were healthy
@@ -167,6 +175,70 @@ get the coverage information programmatically:
 
 
 
+<h2 id="early-termination-of-approximate-nearest-neighbor-search">Early termination of approximate nearest neighbor search</h2>
+<p>
+  <a href="../querying/approximate-nn-hnsw.html">Approximate nearest neighbor search</a>
+  in Vespa using <a href="../reference/schemas/schemas.html#index-hnsw">HNSW</a>
+  happens before the actual matching process.
+  This means that a soft timeout
+  during an ANN search leaves no time for the actual matching process
+  and results in no hits being returned at all.
+  However, the way HNSW works makes it possible to terminate the search early:
+  It maintains a queue of the best results found so far,
+  which it returns once it stops finding better results.
+  Instead of waiting for the algorithm to terminate,
+  the search can also be terminated early by returning the queue
+  in its current state.
+</p>
+<p>
+  Early termination of HNSW in Vespa can be triggered by
+  an explicitly specified time budget or by the ANN timeout.
+  These two concepts work independently, and the former is intended to be used for tweaking purposes,
+  while the latter is intended as a rescue mechanism in case a query is in danger of timing out.
+  <ul>
+    <li>
+      An ANN time budget can be configured with the
+      <a href="../reference/api/query.html#ranking.matching.anntimebudget">ranking.matching.anntimebudget</a>
+      parameter.
+      It is intended to be used for performance tweaking: For example, instead of fine-tuning
+      ANN parameters like
+      <a href="../reference/querying/yql.html#targethits">targetHits</a>
+      or
+      <a href="../reference/api/query.html#ranking.matching.filterFirstExploration">ranking.matching.filterFirstExploration</a>
+      to obtain the optimal balance of latency and recall,
+      you increase these parameters and then specify an ANN time budget
+      to limit the time of ANN searches to the time budget you have in mind.
+      This way, you ideally would get the best recall possible within your specified time budget.
+    </li>
+    <li>
+      The ANN timeout can be configured with the
+      <a href="../reference/api/query.html#ranking.matching.anntimeout.enable">ranking.matching.anntimeout.enable</a>
+      and
+      <a href="../reference/api/query.html#ranking.matching.anntimeout.factor">ranking.matching.anntimeout.factor</a>
+      parameters.
+      Enabling the ANN timeout makes ANN searches terminate early if they
+      reach a configured point in time before the soft timeout.
+      This avoids the situation described above, where a soft timeout during an ANN search
+      results in no hits at all being returned:
+      it makes it possible to still have enough time left for the actual matching process,
+      possibly even without hitting the soft timeout there.
+      To this end, the factor might need tweaking for the specific use case:
+      A large factor is well suited for
+      <a href="../querying/nearest-neighbor-search-guide#combining-approximate-nearest-neighbor-search-with-query-filters">approximate nearest neighbor search with filtering</a>,
+      where only the hits found by ANN have to be considered in matching, which usually
+      only takes very little time.
+      For
+      <a href="../learn/tutorials/hybrid-search.html">hybrid search</a>,
+      a lower value might be required to leave enough time
+      for the text search.
+    </li>
+  </ul>
+  Note that only early termination by hitting the ANN timeout is considered a failure and, thus,
+  reported via the
+  <a href="../reference/querying/default-result-format.html#anntimeout">anntimeout</a>
+  element in the query response.
+</p>
+
 <h2 id="match-phase-degradation">Match phase degradation</h2>
 <p>
   Refer to the <a href="../reference/schemas/schemas.html#match-phase">match-phase reference</a>.
@@ -198,7 +270,7 @@ and total-hit-count since it actually limits, so the query gets fewer hits.
 Also note that it doesn't really make sense to use this
 feature together with a <a href="../ranking/wand.html">WAND operator</a> that also limit hits,
 since they both operate in the same manner,
-and you would get interference between them that could cause unpredictable results.
+
 The graph shows possible hits versus actual hits in a corpus with 100 000 documents,
 where <code>total-max-hits</code> is configured to 10 000 per node.
 The corpus is a synthetic (slightly randomized) data set,

--- a/en/reference/api/query.html
+++ b/en/reference/api/query.html
@@ -745,7 +745,7 @@ These parameters are defined in the <code>native</code> query profile type.
         To return no hits at timeout instead, set <code>ranking.softtimeout.enable=false</code>.
       </p>
       <p>
-        Softtimeout uses <code>ranking.softtimeout.factor</code> of the <a href="#timeout">timeout</a>, default 70%.
+        The soft timeout uses <code>ranking.softtimeout.factor</code> of the <a href="#timeout">timeout</a>, default 70%.
         The rest of the time budget is spent on later ranking phases.
       </p>
       <p>
@@ -1166,6 +1166,126 @@ These parameters are defined in the <code>native</code> query profile type.
         <a href="../querying/yql.html#totaltargethits">totalTargetHits</a> used when evaluating an approximate
         <a href="../querying/yql.html#nearestneighbor">nearestNeighbor</a>
         operator with post-filtering.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>ranking.matching<br/>.anntimebudget</th>
+    <td></td>
+    <td>String</td>
+    <td></td>
+    <td>
+      <p id="ranking.matching.anntimebudget">
+        This parameter limits the time spent on a single ANN search.
+        That is, if an ANN search did not terminate within the specified
+        time, it terminates early and returns the best results found so far.
+        This parameter is specified as a positive floating point number with an optional unit, cf.
+        <a href="#timeout">timeout</a>.
+      </p>
+      <p>
+        When a single query contains multiple nearestNeighbor operators,
+        every operator gets the specified time budget, i.e., the total time that
+        can be spent on ANN searches for that query is bounded by
+        the number of nearestNeighbor operators times the specified time budget.
+      </p>
+      <p>
+        An early termination caused
+        by this parameter is not considered a failure and not reported
+        as a degraded search result.
+      </p>
+      <p>
+        Example: To specify a time budget of 25 milliseconds per ANN search, use
+        <code>&amp;ranking.matching.anntimebudget=25ms</code>.
+      </p>
+      <p>
+        Read more about the ANN time budget in <a href="../../performance/graceful-degradation.html#early-termination-of-approximate-nearest-neighbor-search">Early termination of approximate nearest neighbor search</a>.
+      </p>
+      <p>
+        Available since {% include version.html version="8.684.9" %}.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>ranking.matching.anntimeout<br/>.enable</th>
+    <td></td>
+    <td>Boolean</td>
+    <td>false</td>
+    <td>
+      <p id="ranking.matching.anntimeout.enable">
+        This parameter enables an additional ANN timeout,
+        which makes ANN searches terminate early if a specified point in time
+        before the soft timeout is reached.
+        The goal of this is to leave enough time for the actual matching process
+        without hitting the soft timeout, cf.
+        <a href="#ranking.softtimeout.enable">ranking.softtimeout.enable</a>.
+      </p>
+      <p>
+        The point in time at which ANN searches have to be finished is specified
+        as a factor of the actual soft timeout used by the search node via
+        <a href="#ranking.matching.anntimeout.factor">ranking.matching.anntimeout.factor</a>.
+        The default for this is 0.9, i.e., the ANN search of a query with a single nearestNeighbor operator
+        will terminate early if 90% of the time until the soft timeout is used up.
+        If a query uses multiple ANN searches, the available time until the specified
+        timeout is split evenly between all ANN searches.
+      </p>
+      <p>
+        The ANN timeout functions similarly to the ANN time budget specified by
+        <a href="#ranking.matching.anntimebudget">ranking.matching.anntimebudget</a>
+        with the following two differences:
+        <br/>1. The timeout is specified as a factor
+        of the actual soft timeout being used, which means that it automatically adapts
+        to the soft timeout and, hence, also the <a href="#timeout">timeout</a>.
+        <br/>2. An ANN search hitting the ANN timeout is considered a failure and results in
+        the query being reported as degraded:
+        an <a href="../querying/default-result-format.html#anntimeout">anntimeout</a>
+        element is returned in the query response at timeout.
+      </p>
+      </p>
+      <p>
+        For this parameter to have an effect, the soft timeout has to be enabled, cf.
+        <a href="#ranking.softtimeout.enable">ranking.softtimeout.enable</a>.
+      </p>
+      <p>
+        The number of such timeouts can be observed using the
+        <a href="../operations/metrics/searchnode.html#content_proton_documentdb_matching_approximate_nns_timed_out_queries">approximate_nns_timed_out_queries</a>
+        metric.
+      </p>
+      <p>
+        Read more about the ANN timeout in <a href="../../performance/graceful-degradation.html#early-termination-of-approximate-nearest-neighbor-search">Early termination of approximate nearest neighbor search</a>.
+      </p>
+      <p>
+        Available since {% include version.html version="8.696.20" %}.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>ranking.matching.anntimeout<br/>.factor</th>
+    <td></td>
+    <td>Number</td>
+    <td>0.9</td>
+    <td>
+      <p id="ranking.matching.anntimeout.factor">
+        Sets the point in time at which ANN searches have to be finished.
+        Specified as a factor of the actual soft timeout used by the search node.
+        See <a href="#ranking.matching.anntimeout.enable">ranking.matching.anntimeout.enable</a>
+        for more information on the ANN timeout.
+      </p>
+      <p>
+        Available since {% include version.html version="8.696.20" %}.
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <th>ranking.sorting</th>
+    <td>sorting</td>
+    <td>String</td>
+    <td></td>
+    <td>
+      <p id="ranking.sorting">
+        A valid <a href="../querying/sorting-language.html">sort specification</a>.
+        Fields you want to sort on must be stored as document attributes in the index structure
+        by adding <a href="../schemas/schemas.html#attribute">attribute</a> to the indexing statement.
+        <!-- ToDo: Add example / link to example. Move the sortspec here instead-->
       </p>
     </td>
   </tr>

--- a/en/reference/operations/metrics/searchnode.html
+++ b/en/reference/operations/metrics/searchnode.html
@@ -1061,6 +1061,11 @@ redirect_from:
       <td>Number of queries executed</td>
     </tr>
     <tr>
+      <td><p id="content_proton_documentdb_matching_approximate_nns_timed_out_queries">content.proton.documentdb.matching.approximate_nns_timed_out_queries</p></td>
+      <td>query</td>
+      <td>Number of queries hitting the approximate nearest-neighbor search timeout</td>
+    </tr>
+    <tr>
       <td><p id="content_proton_documentdb_matching_soft_doomed_queries">content.proton.documentdb.matching.soft_doomed_queries</p></td>
       <td>query</td>
       <td>Number of queries hitting the soft timeout</td>
@@ -1074,6 +1079,11 @@ redirect_from:
       <td><p id="content_proton_documentdb_matching_query_setup_time">content.proton.documentdb.matching.query_setup_time</p></td>
       <td>second</td>
       <td>Average time (sec) spent setting up and tearing down queries</td>
+    </tr>
+    <tr>
+      <td><p id="content_proton_documentdb_matching_query_approximate_nns_time">content.proton.documentdb.matching.query_approximate_nns_time</p></td>
+      <td>second</td>
+      <td>Average time (sec) spent on approximate nearest-neighbor search in queries that perform such searches</td>
     </tr>
     <tr>
       <td><p id="content_proton_documentdb_matching_docs_matched">content.proton.documentdb.matching.docs_matched</p></td>

--- a/en/reference/operations/metrics/searchnode.html
+++ b/en/reference/operations/metrics/searchnode.html
@@ -1121,6 +1121,11 @@ redirect_from:
       <td>Number of queries executed</td>
     </tr>
     <tr>
+      <td><p id="content_proton_documentdb_matching_rank_profile_approximate_nns_timed_out_queries">content.proton.documentdb.matching.rank_profile.approximate_nns_timed_out_queries</p></td>
+      <td>query</td>
+      <td>Number of queries hitting the approximate nearest-neighbor search timeout</td>
+    </tr>
+    <tr>
       <td><p id="content_proton_documentdb_matching_rank_profile_soft_doomed_queries">content.proton.documentdb.matching.rank_profile.soft_doomed_queries</p></td>
       <td>query</td>
       <td>Number of queries hitting the soft timeout</td>
@@ -1139,6 +1144,11 @@ redirect_from:
       <td><p id="content_proton_documentdb_matching_rank_profile_query_setup_time">content.proton.documentdb.matching.rank_profile.query_setup_time</p></td>
       <td>second</td>
       <td>Average time (sec) spent setting up and tearing down queries</td>
+    </tr>
+    <tr>
+      <td><p id="content_proton_documentdb_matching_rank_profile_query_approximate_nns_time">content.proton.documentdb.matching.rank_profile.query_approximate_nns_time</p></td>
+      <td>second</td>
+      <td>Average time (sec) spent on approximate nearest-neighbor search in queries that perform such searches</td>
     </tr>
     <tr>
       <td><p id="content_proton_documentdb_matching_rank_profile_grouping_time">content.proton.documentdb.matching.rank_profile.grouping_time</p></td>

--- a/en/reference/operations/metrics/vespa-metric-set.html
+++ b/en/reference/operations/metrics/vespa-metric-set.html
@@ -2540,6 +2540,12 @@ redirect_from:
       <td>Number of queries executed</td>
    </tr>
    <tr>
+      <td><p id="content_proton_documentdb_matching_approximate_nns_timed_out_queries">content.proton.documentdb.matching.approximate_nns_timed_out_queries</p></td>
+      <td>query</td>
+      <td>rate</td>
+      <td>Number of queries hitting the approximate nearest-neighbor search timeout</td>
+   </tr>
+   <tr>
       <td><p id="content_proton_documentdb_matching_soft_doomed_queries">content.proton.documentdb.matching.soft_doomed_queries</p></td>
       <td>query</td>
       <td>rate</td>
@@ -2556,6 +2562,12 @@ redirect_from:
       <td>second</td>
       <td>count, max, sum</td>
       <td>Average time (sec) spent setting up and tearing down queries</td>
+   </tr>
+   <tr>
+      <td><p id="content_proton_documentdb_matching_query_approximate_nns_time">content.proton.documentdb.matching.query_approximate_nns_time</p></td>
+      <td>second</td>
+      <td>count, max, sum</td>
+      <td>Average time (sec) spent on approximate nearest-neighbor search in queries that perform such searches</td>
    </tr>
    <tr>
       <td><p id="content_proton_documentdb_matching_docs_matched">content.proton.documentdb.matching.docs_matched</p></td>
@@ -2588,6 +2600,12 @@ redirect_from:
       <td>Number of queries executed</td>
    </tr>
    <tr>
+      <td><p id="content_proton_documentdb_matching_rank_profile_approximate_nns_timed_out_queries">content.proton.documentdb.matching.rank_profile.approximate_nns_timed_out_queries</p></td>
+      <td>query</td>
+      <td>rate</td>
+      <td>Number of queries hitting the approximate nearest-neighbor search timeout</td>
+   </tr>
+   <tr>
       <td><p id="content_proton_documentdb_matching_rank_profile_soft_doomed_queries">content.proton.documentdb.matching.rank_profile.soft_doomed_queries</p></td>
       <td>query</td>
       <td>rate</td>
@@ -2610,6 +2628,12 @@ redirect_from:
       <td>second</td>
       <td>count, max, sum</td>
       <td>Average time (sec) spent setting up and tearing down queries</td>
+   </tr>
+   <tr>
+      <td><p id="content_proton_documentdb_matching_rank_profile_query_approximate_nns_time">content.proton.documentdb.matching.rank_profile.query_approximate_nns_time</p></td>
+      <td>second</td>
+      <td>count, max, sum</td>
+      <td>Average time (sec) spent on approximate nearest-neighbor search in queries that perform such searches</td>
    </tr>
    <tr>
       <td><p id="content_proton_documentdb_matching_rank_profile_grouping_time">content.proton.documentdb.matching.rank_profile.grouping_time</p></td>

--- a/en/reference/querying/default-result-format.html
+++ b/en/reference/querying/default-result-format.html
@@ -184,6 +184,17 @@ redirect_from:
     </td>
   </tr>
   <tr>
+    <th>anntimeout</th>
+    <td>degraded</td>
+    <td>no</td>
+    <td>Boolean</td>
+    <td>
+      <p id="anntimeout">
+        Indicator whether an ANN search timed out via the <a href="../api/query.html#ranking.matching.anntimeout.enable">ANN timeout</a> before completion.
+      </p>
+    </td>
+  </tr>
+  <tr>
     <th>non-ideal-state</th>
     <td>degraded</td>
     <td>no</td>


### PR DESCRIPTION
Documents the parameters

- `ranking.matching.anntimebudget`,
- `ranking.matching.anntimeout.enable`, and
- `ranking.matching.anntimeout.factor`.

Adds the metrics

- `content.proton.documentdb.matching.approximate_nns_timed_out_queries` and
- `content.proton.documentdb.matching.query_approximate_nns_time`

to the reference.

Will update the documentation once the ANN timeout is enabled by default.