### PR TITLE
Set customer resource tag limit to 20 in reference docs

### DIFF
--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -383,8 +383,9 @@ instance-level value wins.
   </tbody>
 </table>
 <p>
-  The maximum number of tags per instance (after merging deployment-level and instance-level tags)
-  depends on the cloud; see <a href="#resource-tags-per-cloud-rules">per-cloud rules</a> below.
+  A maximum of 20 tags may be defined per instance (after merging deployment-level and
+  instance-level tags). This limit is the same for all clouds; the remaining tag capacity at
+  each provider is reserved for platform-owned tags.
 </p>
 
 <p id="resource-tags-per-cloud-rules"><strong>Per-cloud rules.</strong>
@@ -426,12 +427,6 @@ instance-level value wins.
     <td>256</td>
     <td>256</td>
     <td>63</td>
-  </tr>
-  <tr>
-    <td>Max tags</td>
-    <td>35</td>
-    <td>35</td>
-    <td>49</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Update the `<resource-tags>` reference to reflect a uniform customer tag limit of 20 across all clouds.

- State a flat maximum of 20 tags per instance (previously documented as per-cloud: AWS 35, Azure 35, GCP 49).
- This is in line with the original design, which was modified when switching to per-cloud validation of tags.

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*