### PR TITLE
Add edge n-gram autocomplete recipe to Lucene Linguistics docs

### DIFF
--- a/en/linguistics/lucene-linguistics.html
+++ b/en/linguistics/lucene-linguistics.html
@@ -358,3 +358,155 @@ field title_grams type string {
 
 {% include note.html content='Queries look for all stems by default (regardless of the schema configuration). For example, a search for
 <code>dog</code> would expand to <code>do</code> and <code>og</code> as well, looking for all three terms.' %}
+
+
+<h2 id="autocomplete-with-edge-n-grams">Recipe: autocomplete with edge n-grams</h2>
+
+<p>
+  Edge n-grams turn a term into its growing prefixes &mdash; <code>deli</code> becomes
+  <code>d</code>, <code>de</code>, <code>del</code>, <code>deli</code> &mdash; which is a common way to implement
+  prefix matching and search-as-you-type. Reach for Lucene Linguistics edge n-grams when you also need
+  <em>text normalization</em> that the built-in
+  <a href="../reference/schemas/schemas.html#gram">gram match</a> does not provide, for example
+  mapping <code>&amp;</code> to <code>and</code> so that <em>"Guns &amp; Roses"</em> also matches a search for
+  <code>and</code>. If you do not need normalization, prefer the built-in
+  <a href="../reference/schemas/schemas.html#gram">gram matching</a> (see the
+  <a href="https://github.com/vespa-engine/sample-apps/tree/master/incremental-search/search-as-you-type">search-as-you-type</a>
+  sample app) &mdash; it grams the query and the document consistently and avoids the pitfalls below.
+</p>
+
+<p>
+  Getting edge n-grams right with Lucene Linguistics requires three pieces to line up. The two warnings below
+  are the mistakes that are easy to make and hard to spot.
+</p>
+<ol>
+  <li>Generate the grams with <code>edgeNGram</code> as a <strong>token filter</strong>, not a tokenizer.</li>
+  <li>Add <a href="../reference/schemas/schemas.html#stemming"><code>stemming: multiple</code></a> so that
+    <em>all</em> grams are indexed (the grams share a token position &mdash; see
+    <a href="#indexing-all-stemmed-words">Indexing all stems</a> above).</li>
+  <li>Use a separate, non-gramming profile for the <strong>query string</strong>.</li>
+</ol>
+
+<h3 id="autocomplete-indexing">Indexing: generate the grams</h3>
+
+{% include warning.html content='Do not combine a length-changing
+<a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/CharFilter.html">CharFilter</a>
+(for example a <code>patternReplace</code> that rewrites <code>&amp;</code> to <code>and</code>) with an n-gram
+<strong>tokenizer</strong> such as <code>edgeNGram</code>. The CharFilter rewrites character offsets, which makes the
+n-gram tokenizer collapse several grams onto the same token position; only the first of those is then indexed, so grams
+go silently missing. Generate n-grams with a <strong>token filter</strong> (after a regular tokenizer) instead, as shown
+below.' %}
+
+<p>
+  Put the n-gram generation last in the <code>tokenFilters</code> chain, after a normal tokenizer and the
+  normalization filters. The <code>standard</code> tokenizer splits on whitespace and punctuation so each word is
+  grammed on its own; use the <code>keyword</code> tokenizer instead if you want prefixes of the whole field value.
+</p>
+
+<pre>{% highlight xml %}
+<item key="profile=autocomplete;language=en">
+  <tokenizer>
+    <name>standard</name>
+  </tokenizer>
+  <charFilters>
+    <item>
+      <name>patternReplace</name>
+      <conf>
+        <item key="pattern">&amp;</item>
+        <item key="replacement">and</item>
+      </conf>
+    </item>
+  </charFilters>
+  <tokenFilters>
+    <item><name>asciiFolding</name></item>
+    <item><name>lowercase</name></item>
+    <item>
+      <name>edgeNGram</name>
+      <conf>
+        <item key="minGramSize">2</item>
+        <item key="maxGramSize">20</item>
+      </conf>
+    </item>
+  </tokenFilters>
+</item>
+{% endhighlight %}</pre>
+
+<p>
+  The matching field must set <code>stemming: multiple</code>, otherwise only the first (shortest) gram of each word
+  is written to the index:
+</p>
+
+<pre>
+field name type string {
+    indexing: index | summary
+    linguistics {
+        profile: autocomplete
+    }
+    stemming: multiple
+}
+</pre>
+
+{% include note.html content='Verify what gets indexed with a
+<a href="../reference/schemas/schemas.html#tokens">tokens</a> document summary. In that output a
+<em>nested</em> array represents several tokens that share one position (the grams of one word) &mdash; that is expected,
+not a bug.' %}
+
+<p>
+  Keep <code>minGramSize</code> at <code>2</code> or higher unless you really need single-character prefixes: a
+  <code>minGramSize</code> of <code>1</code> makes every term emit a one-character gram, so those posting lists grow to
+  cover a large fraction of the corpus.
+</p>
+
+<h3 id="autocomplete-querying">Querying: do not gram the query string</h3>
+
+{% include warning.html content='Do not apply the n-gram analyzer to the query string. The query term is itself
+expanded into its grams &mdash; <code>pizza</code> becomes <code>WORD_ALTERNATIVES [p, pi, piz, pizz, pizza]</code>, which
+is an <strong>OR</strong> &mdash; so the query matches any document containing <em>any</em> of those grams. With a small
+<code>minGramSize</code> this drastically over-matches: a search for <code>pizza</code> would match <em>"planet
+smoothie"</em> through the shared gram <code>p</code>. Gram at indexing time only, and analyze the query with a
+non-gramming profile.' %}
+
+<p>
+  Define a second profile that is identical to the indexing one but <em>without</em> the <code>edgeNGram</code> token
+  filter, so a query term stays a single token:
+</p>
+
+<pre>{% highlight xml %}
+<item key="profile=autocomplete_query;language=en">
+  <tokenizer>
+    <name>standard</name>
+  </tokenizer>
+  <charFilters>
+    <item>
+      <name>patternReplace</name>
+      <conf>
+        <item key="pattern">&amp;</item>
+        <item key="replacement">and</item>
+      </conf>
+    </item>
+  </charFilters>
+  <tokenFilters>
+    <item><name>asciiFolding</name></item>
+    <item><name>lowercase</name></item>
+  </tokenFilters>
+</item>
+{% endhighlight %}</pre>
+
+<p>
+  Select that profile for the query string with
+  <a href="../reference/querying/yql.html#grammar">grammar.profile</a>, using
+  <a href="../reference/querying/yql.html#grammar">grammar: 'linguistics'</a> so no extra tokenization is layered on top
+  of the profile (this works with <a href="../reference/querying/yql.html#text">text()</a> and
+  <a href="../reference/querying/yql.html#userinput">userInput()</a>):
+</p>
+
+<pre>
+where name contains ({grammar: 'linguistics', grammar.profile: 'autocomplete_query'}text(@query))
+</pre>
+
+<p>
+  Now a query for <code>pizza</code> stays the single token <code>pizza</code> and matches only terms that start with
+  <em>pizza</em>, while the document side still holds every gram. See
+  <a href="linguistics.html#overriding-profile-for-query-strings">Overriding profile for query strings</a> for more on
+  per-query profiles.
+</p>

--- a/en/linguistics/lucene-linguistics.html
+++ b/en/linguistics/lucene-linguistics.html
@@ -360,7 +360,7 @@ field title_grams type string {
 <code>dog</code> would expand to <code>do</code> and <code>og</code> as well, looking for all three terms.' %}
 
 
-<h2 id="autocomplete-with-edge-n-grams">Recipe: autocomplete with edge n-grams</h2>
+<h2 id="recipe-autocomplete-with-edge-n-grams">Recipe: autocomplete with edge n-grams</h2>
 
 <p>
   Edge n-grams turn a term into its growing prefixes &mdash; <code>coffee</code> becomes
@@ -388,7 +388,7 @@ field title_grams type string {
     <code>profile.index</code> / <code>profile.search</code>).</li>
 </ol>
 
-<h3 id="autocomplete-indexing">Indexing: generate the grams</h3>
+<h3 id="indexing-generate-the-grams">Indexing: generate the grams</h3>
 
 {% include warning.html content='Do not combine a length-changing
 <a href="https://lucene.apache.org/core/9_8_0/core/org/apache/lucene/analysis/CharFilter.html">CharFilter</a>
@@ -458,7 +458,7 @@ not a bug.' %}
   cover a large fraction of the corpus.
 </p>
 
-<h3 id="autocomplete-querying">Querying: do not gram the query string</h3>
+<h3 id="querying-do-not-gram-the-query-string">Querying: do not gram the query string</h3>
 
 {% include warning.html content='Do not apply the n-gram analyzer to the query string. The query term is itself
 expanded into its grams &mdash; <code>coffee</code> becomes <code>WORD_ALTERNATIVES [co, cof, coff, coffe, coffee]</code>,

--- a/en/linguistics/lucene-linguistics.html
+++ b/en/linguistics/lucene-linguistics.html
@@ -363,12 +363,12 @@ field title_grams type string {
 <h2 id="autocomplete-with-edge-n-grams">Recipe: autocomplete with edge n-grams</h2>
 
 <p>
-  Edge n-grams turn a term into its growing prefixes &mdash; <code>deli</code> becomes
-  <code>d</code>, <code>de</code>, <code>del</code>, <code>deli</code> &mdash; which is a common way to implement
-  prefix matching and search-as-you-type. Reach for Lucene Linguistics edge n-grams when you also need
-  <em>text normalization</em> that the built-in
+  Edge n-grams turn a term into its growing prefixes &mdash; <code>coffee</code> becomes
+  <code>c</code>, <code>co</code>, <code>cof</code>, <code>coff</code>, <code>coffe</code>, <code>coffee</code> &mdash;
+  which is a common way to implement prefix matching and search-as-you-type. Reach for Lucene Linguistics edge n-grams
+  when you also need <em>text normalization</em> that the built-in
   <a href="../reference/schemas/schemas.html#gram">gram match</a> does not provide, for example
-  mapping <code>&amp;</code> to <code>and</code> so that <em>"Guns &amp; Roses"</em> also matches a search for
+  mapping <code>&amp;</code> to <code>and</code> so that <em>"Barnes &amp; Noble"</em> also matches a search for
   <code>and</code>. If you do not need normalization, prefer the built-in
   <a href="../reference/schemas/schemas.html#gram">gram matching</a> (see the
   <a href="https://github.com/vespa-engine/sample-apps/tree/master/incremental-search/search-as-you-type">search-as-you-type</a>
@@ -461,10 +461,10 @@ not a bug.' %}
 <h3 id="autocomplete-querying">Querying: do not gram the query string</h3>
 
 {% include warning.html content='Do not apply the n-gram analyzer to the query string. The query term is itself
-expanded into its grams &mdash; <code>pizza</code> becomes <code>WORD_ALTERNATIVES [p, pi, piz, pizz, pizza]</code>, which
-is an <strong>OR</strong> &mdash; so the query matches any document containing <em>any</em> of those grams. With a small
-<code>minGramSize</code> this drastically over-matches: a search for <code>pizza</code> would match <em>"planet
-smoothie"</em> through the shared gram <code>p</code>. Gram at indexing time only, and analyze the query with a
+expanded into its grams &mdash; <code>coffee</code> becomes <code>WORD_ALTERNATIVES [co, cof, coff, coffe, coffee]</code>,
+which is an <strong>OR</strong> &mdash; so the query matches any document containing <em>any</em> of those grams. A
+search for <code>coffee</code> would then also match <em>"cottage"</em> through the shared gram <code>co</code>, and the
+smaller the <code>minGramSize</code> the worse this gets. Gram at indexing time only, and analyze the query with a
 non-gramming profile.' %}
 
 <p>
@@ -514,8 +514,8 @@ field name type string {
 </pre>
 
 <p>
-  A search for <code>pizza</code> now stays the single token <code>pizza</code> and matches only terms that start with
-  <em>pizza</em>, while the document side still holds every gram:
+  A search for <code>coffee</code> now stays the single token <code>coffee</code> and matches only terms that start with
+  <em>coffee</em>, while the document side still holds every gram:
 </p>
 
 <pre>

--- a/en/linguistics/lucene-linguistics.html
+++ b/en/linguistics/lucene-linguistics.html
@@ -384,7 +384,8 @@ field title_grams type string {
   <li>Add <a href="../reference/schemas/schemas.html#stemming"><code>stemming: multiple</code></a> so that
     <em>all</em> grams are indexed (the grams share a token position &mdash; see
     <a href="#indexing-all-stemmed-words">Indexing all stems</a> above).</li>
-  <li>Use a separate, non-gramming profile for the <strong>query string</strong>.</li>
+  <li>Use a separate, non-gramming profile for the <strong>query string</strong> (bound in the schema with
+    <code>profile.index</code> / <code>profile.search</code>).</li>
 </ol>
 
 <h3 id="autocomplete-indexing">Indexing: generate the grams</h3>
@@ -493,20 +494,42 @@ non-gramming profile.' %}
 {% endhighlight %}</pre>
 
 <p>
-  Select that profile for the query string with
-  <a href="../reference/querying/yql.html#grammar">grammar.profile</a>, using
-  <a href="../reference/querying/yql.html#grammar">grammar: 'linguistics'</a> so no extra tokenization is layered on top
-  of the profile (this works with <a href="../reference/querying/yql.html#text">text()</a> and
-  <a href="../reference/querying/yql.html#userinput">userInput()</a>):
+  Bind it as the query-side profile on the field by expanding <code>profile</code> into <code>index</code> and
+  <code>search</code> (see
+  <a href="linguistics.html#different-processing-for-query-strings">Different processing for query strings</a>). This
+  keeps the asymmetry in the schema, so ordinary queries do the right thing without any per-query annotation:
+</p>
+
+<pre>
+field name type string {
+    indexing: index | summary
+    linguistics {
+        profile {
+            index: autocomplete
+            search: autocomplete_query
+        }
+    }
+    stemming: multiple
+}
+</pre>
+
+<p>
+  A search for <code>pizza</code> now stays the single token <code>pizza</code> and matches only terms that start with
+  <em>pizza</em>, while the document side still holds every gram:
+</p>
+
+<pre>
+where name contains @query
+</pre>
+
+<p>
+  You can also override the profile per query with
+  <a href="../reference/querying/yql.html#grammar">grammar.profile</a> (with <code>grammar: 'linguistics'</code> so no
+  extra tokenization is layered on top; works with <a href="../reference/querying/yql.html#text">text()</a> and
+  <a href="../reference/querying/yql.html#userinput">userInput()</a>) &mdash; handy when you do not want to change the
+  schema. See <a href="linguistics.html#overriding-profile-for-query-strings">Overriding profile for query strings</a>:
 </p>
 
 <pre>
 where name contains ({grammar: 'linguistics', grammar.profile: 'autocomplete_query'}text(@query))
 </pre>
-
-<p>
-  Now a query for <code>pizza</code> stays the single token <code>pizza</code> and matches only terms that start with
-  <em>pizza</em>, while the document side still holds every gram. See
-  <a href="linguistics.html#overriding-profile-for-query-strings">Overriding profile for query strings</a> for more on
-  per-query profiles.
-</p>


### PR DESCRIPTION
## Why

Prompted by [SUPPORT-682](https://vespaai.atlassian.net/browse/SUPPORT-682), where a customer implementing prefix / search-as-you-type matching with Lucene Linguistics edge n-grams hit a chain of footguns that each took a support round to resolve. The required pieces are all documented, but scattered across separate sections, so nobody assembles the correct combination without hitting each wall in turn.

## What

Adds a **"Recipe: autocomplete with edge n-grams"** section to `en/linguistics/lucene-linguistics.html` that ties the three requirements together, plus two warning boxes for the easy-to-make, hard-to-spot mistakes:

- **Recipe** — edgeNGram as a **token filter** (not a tokenizer), `stemming: multiple` to index all grams, and a separate non-gramming profile for the **query string** via `grammar.profile`.
- **Warning** — a length-changing `CharFilter` (e.g. `&` → `and`) combined with an n-gram *tokenizer* corrupts offsets and silently drops grams.
- **Warning** — applying the n-gram analyzer to the query string expands the term into `WORD_ALTERNATIVES` (an OR), which over-matches badly with a small `minGramSize` (e.g. `pizza` matching *"planet smoothie"* via the shared gram `p`).
- **Notes** — how to read the `tokens` summary (a nested array = same-position grams, expected not a bug) and keeping `minGramSize >= 2`.

Also points readers at the built-in [gram matching](https://docs.vespa.ai/en/reference/schemas/schemas.html#gram) / search-as-you-type sample app as the simpler path when no normalization is needed.

All config shown was verified end-to-end against a local Vespa deployment.