### PR TITLE
Add dev.gcp-us-central1-a zone

### DIFF
--- a/en/operations/zones.html
+++ b/en/operations/zones.html
@@ -26,6 +26,7 @@ redirect_from:
   <tr><td><a href="environments.html#dev">dev</a></td><td>Yes</td><td>aws-us-east-1c</td><td>use1-az6</td></tr>
   <tr><td><a href="environments.html#dev">dev</a></td><td>No</td><td>aws-euw1-az1</td><td>euw1-az1</td></tr>
   <tr><td><a href="environments.html#dev">dev</a></td><td>No</td><td>azure-eastus-az1</td><td></td></tr>
+  <tr><td><a href="environments.html#dev">dev</a></td><td>No</td><td>gcp-us-central1-a</td><td></td></tr>
   <tr><td><a href="environments.html#dev">dev</a></td><td>No</td><td>gcp-us-central1-f</td><td></td></tr>
   </tbody>
 </table>


### PR DESCRIPTION
## What

- Add `gcp-us-central1-a` to the dev zones table.

## Why

- A new dev zone in GCP `us-central1` is now available in Vespa Cloud.