### PR TITLE
Document tensorFromLabelsWithOffset rank feature

### DIFF
--- a/en/reference/ranking/rank-features.html
+++ b/en/reference/ranking/rank-features.html
@@ -204,7 +204,7 @@ tensor&lt;double&gt;(dim{}):{ {dim:key1}:0.0, {dim:key2}:1.0, {dim:key3}:2.5} }
 </pre>
     <p><em>tensorFromLabels(attribute(myField), dim)</em> produces:</p>
 <pre>
-tensor&lt;double&gt;(dim{}):{ {dim:v1}:1.0, {dim:v2}:1.0, {dim:v3}:1.0} }
+tensor&lt;double&gt;(dim{}):{ {dim:v1}:1.0, {dim:v2}:1.0, {dim:v3}:1.0 }
 </pre>
     <p>See <em>tensorFromWeightedSet</em> for performance notes.</p>
   </td></tr>
@@ -256,6 +256,33 @@ different prices of apples in different regions.
     <p>See <em>tensorFromWeightedSet</em> for performance notes.</p>
   </td>
 </tr>
+
+<tr><td>tensorFromLabelsWithOffset(<em>attribute</em>,<em>label-dimension</em>,<em>offset-dimension</em>)</td>
+  <td>empty tensor</td>
+  <td>
+    <p id="tensorFromLabelsWithOffset">
+      Creates a <code>tensor&lt;float&gt;</code> with one mapped dimension
+      with labels from the given array attribute, and another mapped dimension
+      where labels are constructed from the array index (offset) of that label.
+      The cell values of the tensor are always 1.0 (suitable for multiplication).
+      The attribute values must be integers or strings. The attribute is specified as the full feature name,
+      <code>attribute(name)</code>.
+      The <em>label-dimension</em> parameter is required, using the same as the attribute <em>name</em> is common.
+      The <em>offset-dimension</em> will get label value "0", "1" and so on.
+      This feature may be useful if there are several arrays populated in parallel, and the
+      array index of a label is needed in order to correlate with a different array.
+    </p>
+    <p>
+    Example: Given an attribute field <code>myField</code> containing the array value:
+    </p>
+<pre>
+[v1, v2, v3]
+</pre>
+    <p><em>tensorFromLabelsWithOffset(attribute(myField), dim, off)</em> produces:</p>
+<pre>
+tensor&lt;float&gt;(dim{},off{}):{ {dim:v1,off:0}:1.0, {dim:v2,off:1}:1.0, {dim:v3,off:2}:1.0 }
+</pre>
+  </td></tr>
 
 <tr><td colspan="3"></td></tr>
 <tr><td colspan="3"><h3 id="field-match-features-normalized">Field match features - normalized</h3></td></tr>


### PR DESCRIPTION
Adds a reference entry for the new tensorFromLabelsWithOffset rank feature in rank-features.html. The feature builds a tensor<float> with two mapped dimensions: one holding the labels from an array attribute, and one holding the array index (offset) of each label.

This lets ranking expressions correlate values across several arrays that are populated in parallel.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
