### PR TITLE
Add revision/version attributes to delay reference

### DIFF
--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -799,6 +799,56 @@ or to gather higher-level metrics for a production deployment for a while, befor
 The maximum total delay for the whole deployment spec is 48 hours.
 The delay is specified by any combination of the <code>hours</code>, <code>minutes</code> and <code>seconds</code> attributes.
 </p>
+<p>
+By default, a delay applies to both application revision changes and Vespa platform
+upgrades. It is possible to restrict the delay to just one kind of change
+using the <code>revision</code> and <code>version</code> attributes, with the same
+semantics as on <a href="#block-change">block-change</a>. When a delay applies only to one
+kind of change, the other kind passes through the step with no delay.
+</p>
+<table class="table">
+  <thead>
+  <tr>
+    <th style="width:150px">Attribute</th>
+    <th style="width:100px">Mandatory</th>
+    <th>Values</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>hours
+    <td>No, default <code>0</code>
+    <td>The number of hours to delay.
+  </tr>
+  <tr>
+    <td>minutes
+    <td>No, default <code>0</code>
+    <td>The number of minutes to delay.
+  </tr>
+  <tr>
+    <td>seconds
+    <td>No, default <code>0</code>
+    <td>The number of seconds to delay.
+  </tr>
+  <tr>
+    <td>revision
+    <td>No, default <code>true</code>
+    <td>Set to <code>false</code> to let application revision deployments proceed without this delay.
+  </tr>
+  <tr>
+    <td>version
+    <td>No, default <code>true</code>
+    <td>Set to <code>false</code> to let Vespa platform upgrades proceed without this delay.
+  </tr>
+  </tbody>
+</table>
+<p>
+  The below example delays Vespa platform upgrades by 1 hour between the surrounding
+  steps, while application revision deployments proceed with no delay:
+</p>
+<pre>{% highlight xml %}
+<delay hours="1" revision="false" version="true"/>
+{% endhighlight %}</pre>
 
 
 


### PR DESCRIPTION
Do not merge, feature is not yet released.