### PR TITLE
Document zones with more than one availability zone

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -324,6 +324,8 @@ docs:
         url: /en/operations/environments.html
       - page: Zones
         url: /en/operations/zones.html
+      - page: Availability Zones
+        url: /en/operations/az.html
       - page: Production deployment
         url: /en/operations/production-deployment.html
       - page: Deployment variants

--- a/assets/img/az-multi-cluster.svg
+++ b/assets/img/az-multi-cluster.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="440" height="200">
+  <!-- Zone -->
+  <rect x="4" y="4" width="432" height="192" rx="6" fill="white" stroke="#aaaaaa" stroke-dasharray="5,3" stroke-width="1.5"/>
+  <text x="12" y="18" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#777777">prod.aws-us-east-1</text>
+  <!-- AZ1 box -->
+  <rect x="14" y="22" width="200" height="166" rx="6" fill="#b7e2f1" stroke="#3788a5" stroke-width="1"/>
+  <text x="22" y="37" font-family="Helvetica Neue, Arial, sans-serif" font-size="11" font-weight="bold" fill="#1b5878">use1-az1</text>
+  <!-- AZ2 box -->
+  <rect x="226" y="22" width="200" height="166" rx="6" fill="#b7e2f1" stroke="#3788a5" stroke-width="1"/>
+  <text x="234" y="37" font-family="Helvetica Neue, Arial, sans-serif" font-size="11" font-weight="bold" fill="#1b5878">use1-az2</text>
+  <!-- Container cluster (spans both AZs) -->
+  <rect x="24" y="42" width="392" height="56" rx="6" fill="#baedce" stroke="#4a9e72" stroke-width="1" stroke-opacity="0.4"/>
+  <text x="220" y="74" font-family="Helvetica Neue, Arial, sans-serif" font-size="12" font-weight="bold" fill="#1b6a3a" text-anchor="middle">Container cluster</text>
+  <!-- Content cluster (spans both AZs) -->
+  <rect x="24" y="108" width="392" height="72" rx="6" fill="#baedce" stroke="#4a9e72" stroke-width="1" stroke-opacity="0.4"/>
+  <text x="220" y="147" font-family="Helvetica Neue, Arial, sans-serif" font-size="12" font-weight="bold" fill="#1b6a3a" text-anchor="middle">Content cluster</text>
+</svg>

--- a/assets/img/az-multi-content.svg
+++ b/assets/img/az-multi-content.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="440" height="188">
+  <!-- Zone -->
+  <rect x="4" y="4" width="432" height="180" rx="6" fill="white" stroke="#aaaaaa" stroke-dasharray="5,3" stroke-width="1.5"/>
+  <text x="12" y="18" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#777777">prod.aws-us-east-1</text>
+  <!-- AZ1 box -->
+  <rect x="14" y="22" width="200" height="154" rx="6" fill="#b7e2f1" stroke="#3788a5" stroke-width="1"/>
+  <text x="22" y="37" font-family="Helvetica Neue, Arial, sans-serif" font-size="11" font-weight="bold" fill="#1b5878">use1-az1</text>
+  <!-- AZ2 box -->
+  <rect x="226" y="22" width="200" height="154" rx="6" fill="#b7e2f1" stroke="#3788a5" stroke-width="1"/>
+  <text x="234" y="37" font-family="Helvetica Neue, Arial, sans-serif" font-size="11" font-weight="bold" fill="#1b5878">use1-az2</text>
+  <!-- Content cluster (spans both AZs) -->
+  <rect x="24" y="42" width="392" height="126" rx="6" fill="#baedce" stroke="#4a9e72" stroke-width="1" stroke-opacity="0.4"/>
+  <text x="220" y="57" font-family="Helvetica Neue, Arial, sans-serif" font-size="12" font-weight="bold" fill="#1b6a3a" text-anchor="middle">Content cluster</text>
+  <!-- Group 0: x=70 (in AZ1) -->
+  <rect x="70" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="92" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 0</text>
+  <rect x="78" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="78" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="78" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <!-- Group 1: x=124 (in AZ1) -->
+  <rect x="124" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="146" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 1</text>
+  <rect x="132" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="132" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="132" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <!-- Group 2: x=272 (in AZ2) -->
+  <rect x="272" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="294" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 2</text>
+  <rect x="280" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="280" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="280" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <!-- Group 3: x=326 (in AZ2) -->
+  <rect x="326" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="348" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 3</text>
+  <rect x="334" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="334" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="334" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+</svg>

--- a/assets/img/az-single-cluster.svg
+++ b/assets/img/az-single-cluster.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="280" height="200">
+  <!-- Zone -->
+  <rect x="4" y="4" width="272" height="192" rx="6" fill="white" stroke="#aaaaaa" stroke-dasharray="5,3" stroke-width="1.5"/>
+  <text x="12" y="18" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#777777">prod.aws-us-east-1c</text>
+  <!-- AZ box -->
+  <rect x="14" y="22" width="252" height="166" rx="6" fill="#b7e2f1" stroke="#3788a5" stroke-width="1"/>
+  <text x="22" y="37" font-family="Helvetica Neue, Arial, sans-serif" font-size="11" font-weight="bold" fill="#1b5878">use1-az1</text>
+  <!-- Container cluster -->
+  <rect x="24" y="42" width="232" height="56" rx="6" fill="#baedce" stroke="#4a9e72" stroke-width="1" stroke-opacity="0.4"/>
+  <text x="140" y="74" font-family="Helvetica Neue, Arial, sans-serif" font-size="12" font-weight="bold" fill="#1b6a3a" text-anchor="middle">Container cluster</text>
+  <!-- Content cluster -->
+  <rect x="24" y="108" width="232" height="72" rx="6" fill="#baedce" stroke="#4a9e72" stroke-width="1" stroke-opacity="0.4"/>
+  <text x="140" y="147" font-family="Helvetica Neue, Arial, sans-serif" font-size="12" font-weight="bold" fill="#1b6a3a" text-anchor="middle">Content cluster</text>
+</svg>

--- a/assets/img/az-single-content.svg
+++ b/assets/img/az-single-content.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="280" height="188">
+  <!-- Zone -->
+  <rect x="4" y="4" width="272" height="180" rx="6" fill="white" stroke="#aaaaaa" stroke-dasharray="5,3" stroke-width="1.5"/>
+  <text x="12" y="18" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#777777">prod.aws-us-east-1c</text>
+  <!-- AZ box -->
+  <rect x="14" y="22" width="252" height="154" rx="6" fill="#b7e2f1" stroke="#3788a5" stroke-width="1"/>
+  <text x="22" y="37" font-family="Helvetica Neue, Arial, sans-serif" font-size="11" font-weight="bold" fill="#1b5878">use1-az1</text>
+  <!-- Content cluster (spans AZ) -->
+  <rect x="24" y="42" width="232" height="126" rx="6" fill="#baedce" stroke="#4a9e72" stroke-width="1" stroke-opacity="0.4"/>
+  <text x="140" y="57" font-family="Helvetica Neue, Arial, sans-serif" font-size="12" font-weight="bold" fill="#1b6a3a" text-anchor="middle">Content cluster</text>
+  <!-- Group 0: x=37 -->
+  <rect x="37" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="59" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 0</text>
+  <rect x="45" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="45" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="45" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <!-- Group 1: x=91 -->
+  <rect x="91" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="113" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 1</text>
+  <rect x="99" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="99" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="99" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <!-- Group 2: x=145 -->
+  <rect x="145" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="167" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 2</text>
+  <rect x="153" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="153" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="153" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <!-- Group 3: x=199 -->
+  <rect x="199" y="66" width="44" height="90" rx="4" fill="#daeef7" stroke="#93cee1" stroke-width="1"/>
+  <text x="221" y="79" font-family="Helvetica Neue, Arial, sans-serif" font-size="10" fill="#2e2f27" text-anchor="middle">Group 3</text>
+  <rect x="207" y="84" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="207" y="103" width="28" height="14" rx="3" fill="#1b6a3a"/>
+  <rect x="207" y="122" width="28" height="14" rx="3" fill="#1b6a3a"/>
+</svg>

--- a/en/operations/az.html
+++ b/en/operations/az.html
@@ -17,6 +17,18 @@ redirect_from:
   <code>&lt;availability-zone&gt;</code> elements in the <code>&lt;region&gt;</code>
   element, see <a href="../reference/applications/deployment.html#availability-zone">deployment.xml</a>.
 </p>
+<table>
+  <tr>
+    <td style="padding-right:24px">
+      <p style="text-align:center;font-size:0.9em;color:#555">Single-AZ zone</p>
+      <img src="/assets/img/az-single-cluster.svg" width="280" height="auto" alt="Single-AZ zone with container and content cluster"/>
+    </td>
+    <td>
+      <p style="text-align:center;font-size:0.9em;color:#555">Multi-AZ zone</p>
+      <img src="/assets/img/az-multi-cluster.svg" width="440" height="auto" alt="Multi-AZ zone with clusters spread across two availability zones"/>
+    </td>
+  </tr>
+</table>
 <p>
   It is an error to deploy to a multi-AZ zone and not specifying at least one AZ.
   If you specify exactly one AZ, it is identical to deploying to a traditional zone tied to that AZ.
@@ -33,6 +45,18 @@ redirect_from:
   Each group contains 3 nodes.  This means 2 groups will be placed in <code>use1-az1</code>,
   and 2 groups will be placed in <code>use1-az2</code>.
 </p>
+<table>
+  <tr>
+    <td style="padding-right:24px">
+      <p style="text-align:center;font-size:0.9em;color:#555">Single-AZ zone</p>
+      <img src="/assets/img/az-single-content.svg" width="280" height="auto" alt="Content cluster with 4 groups in a single AZ"/>
+    </td>
+    <td>
+      <p style="text-align:center;font-size:0.9em;color:#555">Multi-AZ zone</p>
+      <img src="/assets/img/az-multi-content.svg" width="440" height="auto" alt="Content cluster with 4 groups spread across two AZs"/>
+    </td>
+  </tr>
+</table>
 
 <h2 id="benefits">Benefits to multi-AZ applications</h2>
 
@@ -41,7 +65,12 @@ redirect_from:
   deploying multiple application instances to each of those availability zones, has several benefits:
 </p>
 <ol>
-  <li>When an availability zone comes up after being offline, those content groups will automatically
-  be reconciled with the other groups, to get any documents they missed while being down.</li>
-  <li>Indexing is only done once, instead of once for each AZ.</li>
+  <li>A single load balancer spanning backends across AZs is more reliable than a DNS-based global endpoint wrapping the zonal endpoints.</li>
+  <li>Document embedding is cheaper, as it needs to be done once instead of once per AZ.</li>
+  <li>Feeding to a single endpoint is simpler and more robust than feeding to one endpoint for each AZ.
+  For instance, if an entire AZ goes down, then feeding to a multi-AZ application instance still works.
+  And once the AZ comes back online, the nodes in that AZ will automatically have their documents
+  updated from the nodes in the other AZs.</li>
+  <li>Deploying two instances of the same application to two AZs in the same region, with <code>redundancy=1</code>,
+    is prone to data loss.  Instead, one application instance can be deployed to those two AZs.</li>
 </ol>

--- a/en/operations/az.html
+++ b/en/operations/az.html
@@ -1,0 +1,47 @@
+---
+# Copyright Vespa.ai. All rights reserved.
+title: "Availability zones"
+applies_to: cloud
+redirect_from:
+- /en/cloud/az.html
+---
+
+<p>
+  A traditional zone in Vespa Cloud is tied to a single availability zone (AZ).  Deploying to such a single-AZ
+  zone results in the application running in that AZ.
+</p>
+<p>
+  Vespa Cloud also has zones like <code>prod.aws-us-east-1</code> that support multiple availability zones,
+  aka <em>multi-AZ</em> zones.
+  To deploy to a multi-AZ zone, you <em>must</em> specify a list of availability zones, using the
+  <code>&lt;availability-zone&gt;</code> elements in the <code>&lt;region&gt;</code>
+  element, see <a href="../reference/applications/deployment.html#availability-zone">deployment.xml</a>.
+</p>
+<p>
+  It is an error to deploy to a multi-AZ zone and not specifying at least one AZ.
+  If you specify exactly one AZ, it is identical to deploying to a traditional zone tied to that AZ.
+</p>
+<p>
+  Specifying more than one AZ means your application instance will spread evenly across those AZ.
+  This means the number of nodes in each cluster must be a multiple of the number of AZs.
+  For content clusters, the number of groups must also be a multiple of the number of AZs.
+</p>
+<p>
+  For example, let's say an application instance has been configured in deployment.xml with 2 availability zones
+  <code>use1-az1</code> and <code>use1-az2</code>, and a content cluster in services.xml specifies
+  4 groups and a total of 12 nodes.
+  Each group contains 3 nodes.  This means 2 groups will be placed in <code>use1-az1</code>,
+  and 2 groups will be placed in <code>use1-az2</code>.
+</p>
+
+<h2 id="benefits">Benefits to multi-AZ applications</h2>
+
+<p>
+  Deploying a single application instance to multiple availability zones, instead of
+  deploying multiple application instances to each of those availability zones, has several benefits:
+</p>
+<ol>
+  <li>When an availability zone comes up after being offline, those content groups will automatically
+  be reconciled with the other groups, to get any documents they missed while being down.</li>
+  <li>Indexing is only done once, instead of once for each AZ.</li>
+</ol>

--- a/en/operations/zones.html
+++ b/en/operations/zones.html
@@ -7,9 +7,17 @@ redirect_from:
 ---
 
 <p>
-  An application is deployed to a <em>zone</em>,
-  which is a combination of an <a href="environments.html">environment</a> and a <em>region</em>,
-  like <code>vespa deploy -z dev.aws-us-east-1c</code>.
+  An application instance can be deployed to one or more <em>zones</em>.  A zone in this documentation
+  refers to a Vespa zone, the basic target location for the deployment of an application instance.  A zone is
+  identified by an <a href="environments.html">environment</a> and a <em>region</em> identifier, for example
+  <code>prod.aws-us-east-1c</code>. This zone can be found in the below list of zones in Vespa Cloud.
+</p>
+<p>
+  A zone supports one or more availability zones.
+  The <code>prod.aws-us-east-1c</code> zone is in the AWS availability zone with AZ ID <code>use1-az6</code>.
+  Zones in Azure and GCP support the availability zone given by the region identifier, for example
+  <code>prod.gcp-europe-west3-b</code> is in the GCP availability zone europe-west3-b.
+  You can read more about zones supporting more than one availability zones in <a href="az.html">regional zones</a>.
 </p>
 <p>
   If an application requires zone-specific configuration (e.g., different capacity requirements per zone),
@@ -20,7 +28,7 @@ redirect_from:
 <p><code>dev</code> zones for development and performance testing:</p>
 <table class="table">
   <thead>
-  <tr><th style="width:80px">Environment</th><th>Default</th><th>Region</th><th>AWS Zone ID</th></tr>
+  <tr><th style="width:80px">Environment</th><th>Default</th><th>Region</th><th>Availability Zones</th></tr>
   </thead>
   <tbody>
   <tr><td><a href="environments.html#dev">dev</a></td><td>Yes</td><td>aws-us-east-1c</td><td>use1-az6</td></tr>
@@ -38,15 +46,17 @@ redirect_from:
 
 <table class="table">
   <thead>
-    <tr><th style="width:80px">Environment</th><th>Region</th><th>AWS Zone ID</th></tr>
+    <tr><th style="width:80px">Environment</th><th>Region</th><th>Availability Zones</th></tr>
   </thead>
   <tbody>
+    <tr><td><a href="environments.html#prod">prod</a><td>aws-us-east-1</td><td>use1-az1 to use1-az6, except use1-az3</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-us-east-1c</td><td>use1-az6</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-use1-az4</td><td>use1-az4</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-use2-az1</td><td>use2-az1</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-use2-az3</td><td>use2-az3</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-us-west-2a</td><td>usw2-az1</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-usw2-az3</td><td>usw2-az3</td></tr>
+    <tr><td><a href="environments.html#prod">prod</a><td>aws-eu-west-1</td><td>euw1-az1 to euw1-az3</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-eu-west-1a</td><td>euw1-az2</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-euw1-az1</td><td>euw1-az1</td></tr>
     <tr><td><a href="environments.html#prod">prod</a><td>aws-euc1-az1</td><td>euc1-az1</td></tr>
@@ -72,7 +82,7 @@ redirect_from:
 </p>
 <table class="table">
   <thead>
-  <tr><th style="width:80px">Environment</th><th>Region</th><th>AWS Zone ID</th></tr>
+  <tr><th style="width:80px">Environment</th><th>Region</th><th>Availability Zones</th></tr>
   </thead>
   <tbody>
   <tr><td><a href="environments.html#test">test</a></td><td>aws-us-east-1c</td><td>use1-az6</td></tr>

--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -22,8 +22,8 @@ redirect_from:
 <pre>{% highlight xml %}
 <deployment version="1.0">
     <prod>
-        <region>aws-us-east-1c</region>
-        <region>aws-us-west-2a</region>
+        <region name="aws-us-east-1c"/>
+        <region name="aws-us-west-2a"/>
     </prod>
 </deployment>
 {% endhighlight %}</pre>
@@ -32,7 +32,7 @@ redirect_from:
 <deployment version="1.0">
     <instance id="beta">
         <prod>
-            <region>aws-us-east-1c</region>
+            <region name="aws-us-east-1c"/>
         </prod>
     </instance>
     <instance id="default">
@@ -42,12 +42,12 @@ redirect_from:
                       time-zone="UTC" />
         <backup frequency="7d" granularity="cluster" />
         <prod>
-            <region>aws-us-east-1c</region>
+            <region name="aws-us-east-1c"/>
             <delay hours="3" minutes="7" seconds="13" />
             <parallel>
-                <region>aws-us-west-1c</region>
+                <region name="aws-us-west-1c"/>
                 <steps>
-                    <region>aws-eu-west-1a</region>
+                    <region name="aws-eu-west-1a"/>
                     <delay hours="3" />
                     <test>aws-us-west-2a</test>
                 </steps>
@@ -55,7 +55,7 @@ redirect_from:
         </prod>
         <endpoints>
             <endpoint container-id="my-container-service">
-                <region>aws-us-east-1c</region>
+                <region name="aws-us-east-1c"/>
             </endpoint>
         </endpoints>
     </instance>
@@ -343,7 +343,7 @@ instance-level value wins.
             <tag key="cost-center" value="search-team"/>
         </resource-tags>
         <prod>
-            <region>aws-us-east-1c</region>
+            <region name="aws-us-east-1c"/>
         </prod>
     </instance>
 </deployment>
@@ -732,7 +732,7 @@ after deployments and tests in the <code>test</code> and <code>staging</code> en
 <p>
 In <code>&lt;prod&gt;</code>, <code>&lt;parallel&gt;</code>, <code>&lt;steps&gt;</code>, or <code>&lt;group&gt;</code>.
 The application is deployed to the production
-<a href="../../operations/zones.html">region</a> with id contained in this element.
+<a href="../../operations/zones.html">region</a> identified by the <code>name</code> attribute.
 </p>
 <table class="table">
 <thead>
@@ -743,6 +743,15 @@ The application is deployed to the production
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>name</td>
+<td>Yes</td>
+<td>
+  The region identifier, e.g. <code>aws-us-east-1c</code>. See <a href="../../operations/zones.html">zones</a>
+  for the list of available regions.
+  Mandatory <em>unless</em> the region name is specified in the element body, but this is not compatible with
+  specifying <a href="#availability-zone"><code>&lt;availability-zone&gt;</code></a> children.</td>
+</tr>
 <tr>
 <td>fraction</td>
 <td>No</td>
@@ -758,6 +767,24 @@ Only when this region is inside a group: The fractional membership in the group.
 </tbody>
 </table>
 
+
+<h3 id="availability-zone">availability-zone</h3>
+<p>
+In <code>&lt;region&gt;</code>.  The element body must be one of the availability zone identifiers listed in
+<a href="../../operations/zones.html">zones</a>.
+At least one availability zone <em>must</em> be specified when deploying to a production region that supports
+more than one availability zone.  The application instance will be spread out evenly across these availability zones
+for resiliency.
+See <a href="../../operations/az.html">availability zones</a> for more.
+</p>
+<p>Example:</p>
+<pre>
+{% highlight xml %}
+<region name="aws-us-east-1">
+    <availability-zone>use1-az1</availability-zone>
+    <availability-zone>use1-az2</availability-zone>
+</region>
+{% endhighlight %}</pre>
 
 
 <h2 id="dev">dev</h2>
@@ -863,12 +890,12 @@ simultaneously, and, finally to <code>eu-west-1</code>, once both parallel deplo
 have completed:
 </p>
 <pre>{% highlight xml %}
-<region>us-west-1</region>
+<region name="us-west-1"/>
 <parallel>
-    <region>us-east-3</region>
-    <region>us-central-1</region>
+    <region name="us-east-3"/>
+    <region name="us-central-1"/>
 </parallel>
-<region>eu-west-1</region>
+<region name="eu-west-1"/>
 {% endhighlight %}</pre>
 
 
@@ -889,9 +916,9 @@ the second deployment, and at least two hours have passed since the block began 
 </p>
 <pre>{% highlight xml %}
 <parallel>
-    <region>us-east-3</region>
+    <region name="us-east-3"/>
     <steps>
-        <region>us-west-1</region>
+        <region name="us-west-1"/>
         <delay hours="1" />
         <test>us-west-1</test>
     </steps>
@@ -957,8 +984,8 @@ and a <em>us</em> endpoint pointing only to US regions.
 <endpoints>
     <endpoint container-id="my-container-service"/>
     <endpoint id="us" container-id="my-container-service">
-        <region>aws-us-east-1c</region>
-        <region>aws-us-west-2a</region>
+        <region name="aws-us-east-1c"/>
+        <region name="aws-us-west-2a"/>
     </endpoint>
 </endpoints>
 {% endhighlight %}</pre>
@@ -1009,7 +1036,7 @@ Changing endpoint visibility will make the service unavailable for a short perio
 <endpoints>
     <endpoint type='zone' container-id='my-container' enabled='false' />
     <endpoint type='zone' container-id='my-container' enabled='true'>
-        <region>region-1</region>
+        <region name="region-1"/>
     </endpoint>
 </endpoints>
 {% endhighlight %}</pre>
@@ -1059,11 +1086,11 @@ The following example creates a private endpoint in two specific regions.
 <pre>{% highlight xml %}
 <endpoints>
     <endpoint type='private' container-id='my-container'>
-        <region>aws-us-east-1c</region>
+        <region name="aws-us-east-1c"/>
         <allow with='aws-private-link' arn='arn:aws:iam::123123123123:root' />
     </endpoint>
     <endpoint type='private' container-id='my-container'>
-        <region>gcp-us-central1-f</region>
+        <region name="gcp-us-central1-f"/>
         <allow with='gcp-service-connect' project='user-project' />
     </endpoint>
 </endpoints>
@@ -1213,14 +1240,14 @@ of the instance in which it is used.
 <bcp>
     <group deadline="15m">
         <endpoint id="foo" container-id="bar"/>
-        <region>us-east1</region>
-        <region>us-east2</region>
-        <region fraction="0.5">us-central1</region>
+        <region name="us-east1"/>
+        <region name="us-east2"/>
+        <region name="us-central1" fraction="0.5"/>
     </group>
     <group>
-        <region>us-west1</region>
-        <region>us-west2</region>
-        <region fraction="0.5">us-central1</region>
+        <region name="us-west1"/>
+        <region name="us-west2"/>
+        <region name="us-central1" fraction="0.5"/>
     </group>
 </bcp>
 {% endhighlight %}</pre>


### PR DESCRIPTION
Documents...
* deployment.xml syntax to specify availability zones
* availability zones in our zones page. Also adds 2 multi-AZ zones (the one in prod.aws-eu-west-1 is expected to come online before the end of the month)
* Adds a separate page on availability zones, and the semantics of multi-AZ deployments.

The new availability zone page:
<img width="1609" height="1250" alt="image" src="https://github.com/user-attachments/assets/7f84ad74-d1a9-4708-929d-ec4940394ea5" />
