### PR TITLE
Feed to vespacloud-docsearch.cloud-enclave in prod.aws-us-east-1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,6 +109,10 @@ search:
     # - url: https://ab1f72fd.b68a8c0d.z.vespa-app.cloud/
     #   indexes:
     #     - open_index.json
+    # vespacloud-docsearch.cloud-enclave | prod.aws-us-east-1
+    - url: https://ab1642f7.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - open_index.json
 
 defaults:
   - scope:

--- a/_paragraphs_config.yml
+++ b/_paragraphs_config.yml
@@ -46,3 +46,7 @@ search:
     - url: https://b4f1a714.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
+    # vespacloud-docsearch.cloud-enclave | prod.aws-us-east-1
+    - url: https://ab1642f7.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json

--- a/_suggestions_config.yml
+++ b/_suggestions_config.yml
@@ -46,3 +46,7 @@ search:
     - url: https://b4f1a714.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
+    # vespacloud-docsearch.cloud-enclave | prod.aws-us-east-1
+    - url: https://ab1642f7.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json

--- a/_suggestions_reference_config.yml
+++ b/_suggestions_reference_config.yml
@@ -46,3 +46,7 @@ search:
     - url: https://b4f1a714.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_reference_index.json
+    # vespacloud-docsearch.cloud-enclave | prod.aws-us-east-1
+    - url: https://ab1642f7.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_reference_index.json


### PR DESCRIPTION
Extend feed endpoints so docsearch data is also fed to `vespacloud-docsearch.cloud-enclave` in zone `prod.aws-us-east-1` (cluster `ab1642f7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)