### PR TITLE
Add maintenance-only block-change example

### DIFF
--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -237,6 +237,19 @@ and before <code>&lt;prod&gt;</code>. It can be declared multiple times.
               hours="0-8,16-23"
               time-zone="America/Los_Angeles"/>
 {% endhighlight %}</pre>
+<p>
+  To block <em>only</em> maintenance operations, <code>revision</code> and <code>version</code>
+  must be explicitly set to <code>false</code>, since they default to <code>true</code>.
+  The below example blocks maintenance during working hours,
+  while still allowing application deployments and platform upgrades at any time:
+</p>
+<pre>{% highlight xml %}
+<block-change maintenance="true"
+              revision="false"
+              version="false"
+              hours="8-15"
+              time-zone="America/Los_Angeles"/>
+{% endhighlight %}</pre>
 <p>The below example blocks:</p>
   <ul>
     <li>all changes on Sundays starting on 2022-03-01</li>


### PR DESCRIPTION
Adds an example to the `block-change` reference showing how to configure a maintenance-only block window.

A customer wrote `<block-change maintenance="true"/>` expecting to block only maintenance, but since `revision` and `version` default to `true` when omitted, that line also blocked application deployments and platform upgrades during the window. The attribute table documents the defaults, but there is no example combining them, so the mistake is easy to make. The new example spells out that a maintenance-only window needs `revision="false" version="false"`, and shows a config that keeps the maintenance window open well beyond the required 17 hours per week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)