### PR TITLE
queryTermDocumentFrequency rank feature docs

### DIFF
--- a/en/reference/ranking/rank-features.html
+++ b/en/reference/ranking/rank-features.html
@@ -146,6 +146,44 @@ Notes:
     <a href='rank-feature-configuration.html#bm25'>bm25(field).averageFieldLength</a> rank-property override." %}
   </td></tr>
 
+<tr><td>queryTermDocumentFrequency(<em>name</em>)</td>
+  <td>empty tensor</td>
+  <td>
+    <p id="queryTermDocumentFrequency(name)">
+    A <code>tensor&lt;double&gt;(term{})</code> holding the document frequency that
+    <a href="../../ranking/bm25.html">BM25</a> would use for each query term that searches the
+    <a href="../schemas/schemas.html#indexing-index">index</a> field <em>name</em>.
+    The document frequency is the number of documents that contain the term; it is the input to the
+    inverse document frequency (IDF) component of BM25. This feature is exposed for debugging and for use
+    in custom text ranking formulas such as <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/bm25f">BM25F</a> or <a href="https://github.com/vespa-engine/sample-apps/tree/master/examples/bayesian_bm25">Bayesian BM25</a>.
+    </p>
+    <p>
+    The tensor has one cell per query term that searches <em>name</em>; terms that do not search the field
+    are not included. Each cell is labeled with the index of the term in the query (as a string, starting at 0),
+    and the labels keep their original query-term index rather than being renumbered.
+    For a term that searches several fields, the cell holds the frequency for the specific field (here, <code>name</code>).
+    </p>
+    <p>
+    Example: for a query where term 0 and term 2 search the <code>content</code> field (term 1 searches a different field), <code>queryTermDocumentFrequency(content)</code> is:
+    </p>
+<pre>
+tensor&lt;double&gt;(term{}):{ {term:0}:1200.0, {term:2}:57.0 }
+</pre>
+    <p>
+    Each value is a query-provided override from the
+    <a href="../../ranking/significance.html">significance model</a> if one is present, otherwise the local
+    content node index statistic — the same value BM25 uses. See also
+    <a href="#term(n).significance">term(n).significance</a>, which is derived from this document frequency.
+    </p>
+    <p>
+    <em>name</em> must be a configured index field; referencing an unknown or non-index field is a configuration
+    error, and the tensor is empty when no query term searches the field.
+    </p>
+    {% include note.html content="The value is a per-content-node statistic unless overridden by the
+    significance model, so it may differ between nodes. In <a href='../../performance/streaming-search.html'>streaming
+    search</a>, non-overridden values are 0." %}
+  </td></tr>
+
 <tr><td>attribute(<em>name</em>)</td>
   <td>null</td>
   <td>


### PR DESCRIPTION
Docs corresponding to https://github.com/vespa-engine/vespa/pull/37373