### PR TITLE
Clarify when the first automated backup runs

### DIFF
--- a/en/operations/data-management.html
+++ b/en/operations/data-management.html
@@ -28,6 +28,14 @@ redirect_from:
 </instance>
 {% endhighlight %}</pre>
 <p>
+  The first backup of a cluster is not created immediately when backups are enabled. A cluster
+  becomes eligible for its first backup only once a content node has been running for at least one
+  full backup interval &mdash; for example, 7 days for a <code>7d</code> frequency, measured from when
+  the node was first allocated. Subsequent backups then follow at the configured frequency. Backup
+  eligibility is evaluated approximately once per hour, so the first backup may appear up to an hour
+  after the cluster becomes eligible.
+</p>
+<p>
   Backups are retained for three backup intervals (e.g. 21 days for a 7-day frequency).
   The most recent fully completed backup is always retained regardless of age.
   See <a href="#restore">Restore from Backup</a> for how to request a restore.

--- a/en/reference/applications/deployment.html
+++ b/en/reference/applications/deployment.html
@@ -277,6 +277,12 @@ Configures scheduled backups of production content clusters. When present, backu
 be created at the specified frequency. Must be placed after any <code>&lt;test&gt;</code> and <code>&lt;staging&gt;</code> tags,
 and before <code>&lt;prod&gt;</code>.
 </p>
+<p>
+Note that the first backup is not created immediately when this element is added. A cluster becomes
+eligible for its first backup only once a content node has been running for at least one full
+<code>frequency</code> interval; subsequent backups then follow at the configured frequency.
+See <a href="../../operations/data-management.html#backup">Automated Backups</a> for details.
+</p>
 <table class="table">
   <thead>
   <tr>
@@ -290,7 +296,7 @@ and before <code>&lt;prod&gt;</code>.
     <td>frequency</td>
     <td>Yes</td>
     <td>A positive integer with a suffix <code>h</code> (hours) or <code>d</code> (days),
-    e.g. <code>12h</code> or <code>7d</code>. Minimum 1h.</td>
+    e.g. <code>24h</code> or <code>7d</code>. Minimum 24h.</td>
   </tr>
   <tr>
     <td>granularity</td>


### PR DESCRIPTION
## What

Clarifies backup timing in the docs, prompted by SUPPORT-786 where a customer enabled `<backup frequency="7d" />` and was surprised to see nothing in the bucket the next day.

The docs stated backups run "at the configured frequency" but did not mention that the **first** backup is not created until a content node has been running for one full `frequency` interval (measured from node allocation), and that eligibility is evaluated ~hourly. This is the behavior in `BackupMaintainer.clusterIsReadyForBackup`.

## Changes

- `en/operations/data-management.html` — add a paragraph explaining the first-backup node-age gate and the hourly evaluation cadence.
- `en/reference/applications/deployment.html` — add a matching first-backup note to the `<backup>` reference section, cross-referencing the data-management page.
- `en/reference/applications/deployment.html` — correct the `frequency` minimum from `1h` to `24h` to match the deployment.xml validation (the example is updated from `12h` to `24h` accordingly).

Ref: SUPPORT-786

🤖 Generated with [Claude Code](https://claude.com/claude-code)