### PR TITLE
Document minTargetHits resolution formula and grouped topology interaction

### DIFF
--- a/en/reference/querying/yql.html
+++ b/en/reference/querying/yql.html
@@ -2277,6 +2277,19 @@ where myUrlField.hostname contains ({startAnchor: true}uri("vespa.ai"))
       and this parameter protects against that when totalTargetHits leads to some node with
       little content otherwise getting a low targetHits.
       </p>
+      <p>
+      Each content node resolves its per-node target hits as
+      <code>max(minTargetHits, ceil(totalTargetHits &times; share))</code>, where <code>share</code>
+      is the node's share of the active documents in the
+      <a href="../applications/services/content.html#group">group</a> serving the query - not across
+      the whole cluster, since a query is dispatched to a single group. A node that has just joined
+      the cluster, or is still receiving documents after a topology change, temporarily holds little
+      content and would get too few hits from <code>totalTargetHits</code> alone without this floor.
+      </p>
+      {% include note.html content="Setting minTargetHits higher than a node's expected share of
+      totalTargetHits makes minTargetHits the effective value, and totalTargetHits has no further
+      effect until it exceeds the floor. This is easy to hit when moving from a flat to a grouped
+      topology, since a group typically has fewer nodes than the full cluster."%}
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## What
Adds an explanation to the `minTargetHits` reference entry in `yql.html` covering the exact per-node resolution formula (`max(minTargetHits, ceil(totalTargetHits × share))`), that `share` is relative to the node's group rather than the whole cluster, and a note on the common pitfall where `minTargetHits` silently overrides `totalTargetHits` after moving to a grouped topology.

## Why
Customers migrating to grouped content clusters had to ask twice, and needed direct engineering input, to understand how `totalTargetHits` and `minTargetHits` resolve to a per-node value and why the denominator is the group's node count, not the cluster's. The reference page did not state the formula or the topology-dependent pitfall, so support had to explain it ad hoc each time.