### PR TITLE
News: Vespa cloud instead of local. HF dataset fix

### DIFF
--- a/en/learn/tutorials/news-1-deploy-an-application.md
+++ b/en/learn/tutorials/news-1-deploy-an-application.md
@@ -257,7 +257,7 @@ Well done!
 Application instances in the [dev zone](../operations/environments.html#dev) will by default keep running for 14 days after the last deployment.
 You can control this in the [console](https://console.vespa-cloud.com/).
 
-The [Vespa Cloud console](https://console.vespa-cloud.com) can also be used to delte the application instance.
+The [Vespa Cloud console](https://console.vespa-cloud.com) can also be used to delete the application instance.
 
 
 ## Conclusion

--- a/en/learn/tutorials/news-1-deploy-an-application.md
+++ b/en/learn/tutorials/news-1-deploy-an-application.md
@@ -63,7 +63,9 @@ Vespa CLI configuration mode for configuration variables. Using
 local configuration mode is generally recommended when working 
 with multiple distinct Vespa applications, but most parts of 
 this tutorial uses the same configuration values which makes 
-it easier to use global configuration mode:
+it easier to use global configuration mode. The global
+configuration mode is useful because you don't have to reapply 
+the same Vespa configurations for each part of this tutorial series:
 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>

--- a/en/learn/tutorials/news-1-deploy-an-application.md
+++ b/en/learn/tutorials/news-1-deploy-an-application.md
@@ -1,6 +1,6 @@
 ---
 # Copyright Vespa.ai. All rights reserved.
-title: "News search and recommendation tutorial - getting started on Docker"
+title: "News search and recommendation tutorial - getting started on Vespa Cloud"
 redirect_from:
 - /en/tutorials/news-1-getting-started.html
 - /en/tutorials/news-1-deploy-an-application
@@ -8,7 +8,7 @@ redirect_from:
 
 
 Our goal with this series is to set up a Vespa application for personalized
-news recommendations. We will do this in stages, starting with a simple news
+news recommendations on Vespa Cloud. We will do this in stages, starting with a simple news
 search system and gradually adding functionality as we go through the
 tutorial parts.
 
@@ -22,32 +22,33 @@ The parts are:
 6. [News recommendation with searchers](news-6-recommendation-with-searchers.html) - custom searchers, doc processors
 7. [News recommendation with parent-child](news-7-recommendation-with-parent-child.html) - parent-child, tensor ranking
 
-There are different entry points to this tutorial. This one is describing how to get
-started using Docker on your local machine. You can also deploy the application we are creating on
-[Vespa Cloud](https://cloud.vespa.ai).
-
-In this part, we will start with a minimal Vespa application to
-get used to some basic operations for running the application on Docker.
+In this part, we will start with a minimal Vespa application to get used to some basic
+operations for deploying and running an application on Vespa Cloud.
 In the next part of the tutorial, we'll start developing our application.
 
-{% include pre-req.html memory="4 GB" extra-reqs='
-<li>Python3 for converting the dataset to Vespa JSON.</li>
-<li><code>curl</code> to download the dataset and run the Vespa health-checks.</li>
-<li><a href="https://openjdk.org/projects/jdk/17/" data-proofer-ignore>Java 17</a> in part 6.</li>
-<li><a href="https://maven.apache.org/install.html">Apache Maven</a> in part 6.</li>' %}
-
-{% include note.html content='4 GB Docker memory is sufficient for the demo dataset in part 2.
-The <span style="text-decoration: underline;">full</span> MIND dataset requires more, use 10 GB.' %}
+<div class="vespa-notification vespa-notification-prereqs" role="alert">
+  <p><strong>Prerequisites:</strong></p>
+  <ul>
+    <li>A Vespa Cloud account - create a <a href="https://console.vespa-cloud.com/">tenant</a>
+        if you do not have one.</li>
+    <li><a href="https://brew.sh/">Homebrew</a> to install the <a href="../../clients/vespa-cli.html">Vespa CLI</a>,
+        or download the Vespa CLI from <a href="https://github.com/vespa-engine/vespa/releases">Github releases</a>.</li>
+    <li>Python3 for converting the dataset to Vespa JSON.</li>
+    <li><code>curl</code> to download the dataset.</li>
+    <li><a href="https://openjdk.org/projects/jdk/17/" data-proofer-ignore>Java 17</a> in part 6.</li>
+    <li><a href="https://maven.apache.org/install.html">Apache Maven</a> in part 6.</li>
+  </ul>
+</div>
 
 In upcoming parts of this series, we will have some additional Python dependencies -
 we use [PyTorch](https://pytorch.org/) to train vector representations for news and users
 and train machine learning models for use in ranking.
 
 
-## Installing vespa-cli 
+## Installing Vespa CLI
 
 This tutorial uses [Vespa-CLI](../../clients/vespa-cli.html),
-Vespa CLI is the official command-line client for Vespa.ai. 
+Vespa CLI is the official command-line client for Vespa.ai.
 It is a single binary without any runtime dependencies and is available for Linux, macOS, and Windows.
 
 <div class="pre-parent">
@@ -57,16 +58,19 @@ $ brew install vespa-cli
 </pre>
 </div>
 
-For the rest of this tutorial, you will be using localhost, so you need to configure your Vespa CLI to connect to localhost.
-Run the following to use endpoints on localhost:
+In this tutorial it is possible to use either a local or global 
+Vespa CLI configuration mode for configuration variables. Using 
+local configuration mode is generally recommended when working 
+with multiple distinct Vespa applications, but most parts of 
+this tutorial uses the same configuration values which makes 
+it easier to use global configuration mode:
 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre>
-$ vespa config set target local
+$ vespa config set default_config_scope global
 </pre>
 </div>
-
 
 
 ## A minimal Vespa application
@@ -105,58 +109,69 @@ There are two files there:
 We will revisit these files in the next part of the tutorial.
 
 
-## Starting Vespa
+## Configuring Vespa CLI for Vespa Cloud
+Configure the Vespa CLI to use Vespa Cloud, and set the application name.
+Replace `tenant-name` with your tenant name from [console.vespa-cloud.com](https://console.vespa-cloud.com):
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre>
+$ vespa config set target cloud
+$ vespa config set application tenant-name.news
+</pre>
+</div>
+
+Usually its better to use local configuration for each application, 
+but this tutorial uses global configuration to avoid having to set the 
+configuration values for each part of the tutorial.
+
+Authenticate with Vespa Cloud:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre>
+$ vespa auth login
+</pre>
+</div>
+
+Follow the browser instructions to complete authentication.
+
+Next, add a certificate for [data plane access](/en/security/guide#data-plane) to the application:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre>
+$ vespa auth cert app-1-getting-started
+</pre>
+</div>
+
+
+
+
+## Deploying to Vespa Cloud
 
 This application doesn't contain much at the moment,
-let's start up the application anyway by starting a Docker container to run it:
+but let's deploy it to Vespa Cloud anyway to get used to the basic operations.
+The first deployment may take a few minutes while nodes are provisioned:
 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ docker pull vespaengine/vespa
-$ docker run --detach --name vespa --hostname vespa-tutorial \
-  --publish 8080:8080 --publish 19071:19071 --publish 19092:19092 \
-  vespaengine/vespa
-</pre>
-</div>
-
-First, we pull the latest [vespa-image](https://hub.docker.com/r/vespaengine/vespa/)
-from the Docker hub, then we
-start it with the name `vespa`. This starts the Docker container and the
-initial Vespa services to be able to deploy an application.
-
-Starting the container can take a short while. Before continuing, make sure
-that the configuration service is running by using `vespa status`. 
-
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre data-test="exec">
-$ vespa status deploy --wait 300 
-</pre>
-</div>
-
-With the config server up and running, deploy the application using vespa-cli:
-
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre data-test="exec">
-$ vespa deploy --wait 300 app-1-getting-started 
+$ vespa deploy --wait 600 app-1-getting-started 
 </pre>
 </div>
 
 The command uploads the application and verifies the content.
 If anything is wrong with the application, this step will fail with a failure description;
-Otherwise, this switches the application to a live status.
+otherwise, this switches the application to a live status.
 
-Whenever you have a new version of your application, 
+Whenever you have a new version of your application,
 run the same command to deploy the application.
 In most cases, there is no need to restart services.
 Vespa takes care of reconfiguring the system.
-If a restart of services is required in some rare case, however, the output will notify 
-which services need restart to make the change effective. 
 
-In the upcoming parts of the tutorials, we'll frequently deploy the 
-application changes in this manner. 
+In the upcoming parts of the tutorials, we'll frequently deploy the
+application changes in this manner.
 
 
 ## Feeding to Vespa
@@ -167,7 +182,7 @@ For now, to test that everything is up and running, we'll feed in a single test 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec" >
-$ vespa feed -t http://localhost:8080 doc.json
+$ vespa feed doc.json
 </pre>
 </div>
 
@@ -237,57 +252,12 @@ $ vespa document -v remove id:news:news::1
 Well done!
 
 
-## Stopping and starting Vespa
+## Managing the Vespa Cloud application
 
-Keep Vespa running to continue with the next steps in this tutorial set (skip the below).
+Application instances in the [dev zone](../operations/environments.html#dev) will by default keep running for 14 days after the last deployment.
+You can control this in the [console](https://console.vespa-cloud.com/).
 
-To stop Vespa, we can run the following commands:
-
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre>
-$ docker exec vespa vespa-stop-services
-$ docker exec vespa vespa-stop-configserver
-</pre>
-</div>
-
-Likewise, to start the Vespa services:
-
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre>
-$ docker exec vespa vespa-start-configserver
-$ docker exec vespa vespa-start-services
-</pre>
-</div>
-
-If a [restart is required](../../reference/schemas/schemas.html#changes-that-require-restart-but-not-re-feed)
-due to changes in the application package,
-these two steps are what you need to do.
-
-To wipe the index and restart:
-
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre>
-$ docker exec vespa sh -c ' \
-  vespa-stop-services && \
-  vespa-remove-index -force && \
-  vespa-start-services'
-</pre>
-</div>
-
-You can stop and kill the Vespa container application like this:
-
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre data-test="after">
-$ docker stop vespa; docker rm -f vespa
-</pre>
-</div>
-
-This will delete the Vespa application, including all data and configuration. See 
-[container tuning for production](../../operations/self-managed/docker-containers.html). 
+The [Vespa Cloud console](https://console.vespa-cloud.com) can also be used to delte the application instance.
 
 
 ## Conclusion

--- a/en/learn/tutorials/news-2-basic-feeding-and-query.md
+++ b/en/learn/tutorials/news-2-basic-feeding-and-query.md
@@ -56,7 +56,33 @@ news content at first. We'll use the impression data as we begin building
 the recommendation system later in this series.
 
 Let's start by downloading the data. The `news` sample app directory will 
-be our starting point. We've included a script to download the data for us:
+be our starting point. The MIND dataset is hosted on
+[Hugging Face](https://huggingface.co/datasets/yjw1029/MIND) and requires
+a free account and acceptance of the dataset's terms of use.
+
+### Accept the dataset terms
+
+1. Log in at [huggingface.co](https://huggingface.co)
+2. Go to the [MIND dataset page](https://huggingface.co/datasets/yjw1029/MIND)
+3. Click **Agree and access repository** to accept the terms
+
+### Create a Hugging Face access token
+
+1. Go to [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
+2. Click **New token**, give it a name, select **Read** role, and copy the token
+
+### Download the dataset
+
+Set your token as an environment variable:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre>
+$ export HF_TOKEN=hf_your_token_here
+</pre>
+</div>
+
+Then run the download script from the **news** sample app directory:
 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
@@ -110,12 +136,6 @@ ranking will be done and how data will be processed during feeding and indexing.
 The schema, e.g., `news.sd`, is a required part of an
 application package — the other file needed is `services.xml`.
 
-For self-hosted multi-node deployments, a `hosts.xml` file is also needed. 
-For multi-node self-hosted deployments using `hosts.xml`, see
-the [multinode high 
-availability](https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA)
-sample application. 
-
 We mentioned these files in the previous part but didn't really explain them at the time.
 We'll go through them here, starting with the specification of services.
 
@@ -135,9 +155,7 @@ service. Write the following to `news/my-app/services.xml`:
     &lt;container id="default" version="1.0"&gt;
         &lt;search /&gt;
         &lt;document-api /&gt;
-        &lt;nodes&gt;
-            &lt;node hostalias="node1" /&gt;
-        &lt;/nodes&gt;
+        &lt;nodes count="1" /&gt;
     &lt;/container&gt;
 
     &lt;content id="mind" version="1.0"&gt;
@@ -145,9 +163,7 @@ service. Write the following to `news/my-app/services.xml`:
         &lt;documents&gt;
             &lt;document type="news" mode="index" /&gt;
         &lt;/documents&gt;
-        &lt;nodes&gt;
-            &lt;node hostalias="node1" distribution-key="0" /&gt;
-        &lt;/nodes&gt;
+        &lt;nodes count="1" /&gt;
     &lt;/content&gt;
 
 &lt;/services&gt;
@@ -163,13 +179,13 @@ Quite a lot is set up here:
   for how to use mTLS with Vespa.
 - `<document-api>` sets up the [document
   endpoint](../../reference/api/document-v1.html) for feeding and visiting.
-- `<nodes>` defines the nodes required per service.  (See the
+- `<nodes count="1" />` defines the number of nodes for the service. (See the
   [reference](../../reference/applications/services/container.html) for more on container
   cluster setup).
 - `<content>` The stateful content cluster
 - `<redundancy>` denotes how many copies to store of each document.
 - `<documents>` assigns the document types in the _schema_ — the content
-  cluster capacity can be increased by adding node elements — see [elasticity](../../content/elasticity.html). (See also the
+  cluster capacity can be increased by raising the node count — see [elasticity](../../content/elasticity.html). (See also the
   [reference](../../reference/applications/services/content.html) for more on content cluster
   setup.)
 
@@ -278,10 +294,40 @@ my-app/
 └── services.xml
 </pre>
 
+If not already done from the previous [news tutorial](news-1-deploy-an-application.html), set Vespa configuration variables. Use your tenant name from the [Vespa Cloud console](https://console.vespa-cloud.com/) instead of `tenant-name`:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre>
+$ vespa config set target cloud
+$ vespa config set application tenant-name.news
+</pre>
+</div>
+
+Log in to Vespa Cloud:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre data-test="exec">
+$ vespa auth login
+</pre>
+</div>
+
+Add security credentials to the application package for data plane access:
+
+<div class="pre-parent">
+  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
+<pre data-test="exec">
+$ vespa auth cert my-app -f
+</pre>
+</div>
+
+Finally, deploy the application package to Vespa Cloud:
+
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec" data-test-assert-contains="Success">
-$ vespa deploy --wait 300 my-app
+$ vespa deploy --wait 600 my-app
 </pre>
 </div>
 
@@ -307,7 +353,7 @@ file can now be fed to Vespa. Use the method described in the previous part:
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa feed mind/vespa.json --target http://localhost:8080
+$ vespa feed mind/vespa.json
 </pre>
 </div>
 
@@ -364,14 +410,19 @@ $ vespa query -v 'yql=select * from news where default contains "music"'
 </pre>
 </div>
 
-or a POST JSON query (Notice the *Content-Type* header specification):
+or a POST JSON query. The values can be found by using the previous `vespa query -v` command. 
+The content type should be changed to `application/json`.
+It's also possible to use `vespa status` to find the url of your cloud instance.
+:
 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec" data-test-assert-contains='"coverage": 100'>
-$ curl -s -H "Content-Type: application/json" \
-  --data '{"yql" : "select * from sources * where default contains \"music\""}' \
-  http://localhost:8080/search/ | python3 -m json.tool
+$ curl --key /path/to/key \
+     --cert /path/to/cert \
+     -H 'Content-Type: application/json' \
+     --data '{"yql" : "select * from sources * where default contains \"music\""}' \
+     'https://your-vespa-url.vespa-app.cloud/search/' | python3 -m json.tool
 </pre>
 </div>
 

--- a/en/learn/tutorials/news-3-searching.md
+++ b/en/learn/tutorials/news-3-searching.md
@@ -532,7 +532,7 @@ Deploy the _popularity_ rank profile:
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300 my-app
+$ vespa deploy --wait 600 my-app
 </pre>
 </div>
 

--- a/en/learn/tutorials/news-5-recommendation.md
+++ b/en/learn/tutorials/news-5-recommendation.md
@@ -177,9 +177,7 @@ so we modify `services.xml` and add it under `documents` in the `content` sectio
     &lt;container id="default" version="1.0"&gt;
         &lt;search /&gt;
         &lt;document-api /&gt;
-        &lt;nodes&gt;
-            &lt;node hostalias="node1" /&gt;
-        &lt;/nodes&gt;
+        &lt;nodes count="1" /&gt;
     &lt;/container&gt;
 
     &lt;content id="mind" version="1.0"&gt;
@@ -188,9 +186,7 @@ so we modify `services.xml` and add it under `documents` in the `content` sectio
             &lt;document type="news" mode="index" /&gt;
             &lt;document type="user" mode="index" /&gt;
         &lt;/documents&gt;
-        &lt;nodes&gt;
-            &lt;node hostalias="node1" distribution-key="0" /&gt;
-        &lt;/nodes&gt;
+        &lt;nodes count="1" /&gt;
     &lt;/content&gt;
 
 &lt;/services&gt;
@@ -200,7 +196,7 @@ so we modify `services.xml` and add it under `documents` in the `content` sectio
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300 my-app 
+$ vespa deploy --wait 600 my-app 
 </pre>
 </div>
 
@@ -215,8 +211,8 @@ feed `mind/vespa_user_embeddings.json` and `mind/vespa_news_embeddings.json`:
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec" >
-$ vespa feed mind/vespa_user_embeddings.json --target http://localhost:8080
-$ vespa feed mind/vespa_news_embeddings.json --target http://localhost:8080
+$ vespa feed mind/vespa_user_embeddings.json
+$ vespa feed mind/vespa_news_embeddings.json
 </pre>
 </div>
 
@@ -292,7 +288,7 @@ Deploy the updates to query profiles:
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300 my-app
+$ vespa deploy --wait 600 my-app
 </pre>
 </div>
 
@@ -528,27 +524,20 @@ restart is required so that the index can be built:
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300 my-app
+$ vespa deploy --wait 600 my-app
 </pre>
 </div>
 
-Introducing the HNSW `index` requires a content node restart, in this case we restart all services:
+Introducing the HNSW `index` requires a content node restart.
+On Vespa Cloud, this is handled automatically after deployment —
+wait for the deployment to complete and the application to become ready:
 
-<div class="pre-parent">
-  <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
-<pre data-test="exec">
-$ docker exec vespa /usr/bin/sh -c \
-  '/opt/vespa/bin/vespa-stop-services &amp;&amp; /opt/vespa/bin/vespa-start-services'
-</pre>
-</div>
-
-<!-- Give the container some time to reindex -->
 <pre data-test="exec" style="display:none">
 $ vespa status --wait 300 
 </pre>
 
 
-After doing this and waiting a bit for Vespa to start, we can query Vespa again:
+After the deployment completes, we can query Vespa again:
 
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>

--- a/en/learn/tutorials/news-6-recommendation-with-searchers.md
+++ b/en/learn/tutorials/news-6-recommendation-with-searchers.md
@@ -275,7 +275,7 @@ This contains the full Vespa application, with Java components - deploy it:
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300 app-6-recommendation-with-searchers
+$ vespa deploy --wait 600 app-6-recommendation-with-searchers
 </pre>
 </div>
 

--- a/en/learn/tutorials/news-7-recommendation-with-parent-child.md
+++ b/en/learn/tutorials/news-7-recommendation-with-parent-child.md
@@ -287,7 +287,7 @@ $ (cd app-7-parent-child && mvn package)
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa deploy --wait 300 app-7-parent-child
+$ vespa deploy --wait 600 app-7-parent-child
 </pre>
 </div>
 
@@ -320,8 +320,8 @@ Feed the created feed files:
 <div class="pre-parent">
   <button class="d-icon d-duplicate pre-copy-button" onclick="copyPreContent(this)"></button>
 <pre data-test="exec">
-$ vespa feed mind/global_category_ctr.json --target http://localhost:8080
-$ vespa feed mind/news_category_ctr_update.json --target http://localhost:8080
+$ vespa feed mind/global_category_ctr.json
+$ vespa feed mind/news_category_ctr_update.json
 </pre>
 </div>
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

News tutorial now use Vespa Cloud instead of local vespa instance. The HuggingFace dataset also got some updated instructions as it is now needed to accept terms and conditions. Relevant [PR](https://github.com/vespa-engine/sample-apps/pull/1986)