### PR TITLE
document bm25(field:field,label:label) and bm25_for_labels

### DIFF
--- a/en/ranking/bm25.html
+++ b/en/ranking/bm25.html
@@ -378,3 +378,78 @@ preparation is still ongoing:
 <pre>
 /state/v1/custom/component/documentdb/mydoctype/subdb/ready/index
 </pre>
+
+
+<h2 id="scoring-labeled-parts-of-the-query">Scoring labeled parts of the query</h2>
+<p>
+<code>bm25(content)</code> sums the contribution of every query term searching <em>content</em>.
+When a query is built from several parts, it is often useful to score those parts separately.
+This is done by attaching a
+<a href="multivalue-query-operators.html#raw-scores-and-query-item-labeling">label</a>
+to the query items, using the <a href="../reference/querying/yql.html#label">label</a> annotation in
+YQL, and referring to that label from the rank profile:
+</p>
+<pre>
+select * from example where
+    ({label:"must"}content contains "vespa") and
+    ({label:"nice"}(content contains "ranking" or content contains "relevance"))
+</pre>
+<p>
+A label set on an operator enclosing others, as on the <em>or</em> above, is inherited by every term
+inside it, so a label can be given per clause instead of per term.
+</p>
+<p>
+The <a href="../reference/ranking/rank-features.html#bm25">bm25(field: <em>fieldname</em>, label: <em>label</em>)</a>
+rank feature scores only the terms carrying the given label:
+</p>
+<pre>
+rank-profile labeled {
+  first-phase {
+    expression: bm25(field: content, label: must) + 0.5 * bm25(field: content, label: nice)
+  }
+}
+</pre>
+
+
+<h3 id="one-score-per-label">One score per label</h3>
+<p>
+With many labels, or when the labels are not known when the schema is written,
+use <a href="../reference/ranking/rank-features.html#bm25_for_labels">bm25_for_labels(field)</a> instead.
+It returns a <code>tensor&lt;float&gt;(label{})</code> with one cell per label that scores in the field,
+holding the sum of the BM25 scores of that label's terms:
+</p>
+<pre>
+rank-profile labels {
+  inputs {
+    query(label_weights) tensor&lt;float&gt;(label{})
+  }
+  first-phase {
+    expression: sum(bm25_for_labels(content) * query(label_weights))
+  }
+  match-features {
+    bm25_for_labels(content)
+  }
+}
+</pre>
+<p>
+For the query above, the match feature might be returned as:
+</p>
+<pre>
+"bm25_for_labels(content)": {
+  "type": "tensor&lt;float&gt;(label{})",
+  "cells": {
+    "must": 0.7568,
+    "nice": 0.3213
+  }
+}
+</pre>
+<p>
+Other typical uses are <code>reduce(bm25_for_labels(content), max, label)</code> to rank by the best
+scoring labeled part, or feeding the tensor to a machine-learned model.
+A label only gets a cell when it actually scores, and terms without a label are not included at all,
+so <code>reduce(bm25_for_labels(content), sum, label)</code> equals <code>bm25(content)</code> only when
+every scoring term carries exactly one label.
+</p>
+{% include note.html content="A single label can be picked out with
+<code>bm25_for_labels(content){label:must}</code>, but <code>bm25(field: content, label: must)</code>
+is faster, as it does not compute the full tensor." %}

--- a/en/reference/querying/yql.html
+++ b/en/reference/querying/yql.html
@@ -2090,9 +2090,25 @@ where myUrlField.hostname contains ({startAnchor: true}uri("vespa.ai"))
     <td>string</td>
     <td>
       <p id="label">
-      Used by <a href="#geolocation">geoLocation</a>
-      and <a href="#nearestneighbor">nearestNeighbor</a>. <!-- ToDo: and probably others ... -->
-      Label for referring to this term/operator during ranking.
+      Attaches a symbolic name to this query item so that it can be referred to from ranking,
+      see <a href="../../ranking/multivalue-query-operators.html#raw-scores-and-query-item-labeling">
+      query item labeling</a>.
+      </p>
+      <p>
+      The label is carried by single terms, or operators like <a href="#and">and</a>, <a href="#or">or</a> or
+      <a href="#nearestneighbor">nearestNeighbor</a>. Sub-clauses inherit the label of their parent, but
+      can override it.
+      </p>
+      <p>
+      The rank features taking a label are
+      <a href="../ranking/rank-features.html#itemRawScore(label)">itemRawScore(<em>label</em>)</a>,
+      <a href="../ranking/rank-features.html#closeness(dimension,name)">closeness(label,<em>name</em>)</a>,
+      <a href="../ranking/rank-features.html#distance(dimension,name)">distance(label,<em>name</em>)</a>,
+      <a href="../ranking/rank-features.html#closest(name,label)">closest(<em>field</em>,<em>label</em>)</a> and
+      <a href="../ranking/rank-features.html#bm25">bm25(field: <em>field</em>, label: <em>label</em>)</a>.
+      In addition,
+      <a href="../ranking/rank-features.html#bm25_for_labels">bm25_for_labels(<em>field</em>)</a>
+      returns one bm25 score per label.
       </p>
     </td>
   </tr>

--- a/en/reference/ranking/rank-feature-configuration.html
+++ b/en/reference/ranking/rank-feature-configuration.html
@@ -73,7 +73,13 @@ rank-profile my-profile inherits default {
   <td>5</td>
   <td><p id="term">The number of terms for which this is included in the rank features dump in the summary</p></td></tr>
 
-<tr><td rowspan="3"><a href="rank-features.html#bm25">bm25(<em>fieldname</em>)</a></td>
+<tr><td rowspan="3">
+    <a href="rank-features.html#bm25">bm25(<em>fieldname</em>)</a>
+    <p>
+      Also used by <a href="rank-features.html#bm25">bm25(field: <em>fieldname</em>, label: <em>label</em>)</a>
+      and <a href="rank-features.html#bm25_for_labels">bm25_for_labels(<em>fieldname</em>)</a>.
+    </p>
+  </td>
   <td>k1</td>
   <td>1.2</td>
   <td><p id="bm25">Used to limit how much a single query term can affect the score for a document.</p></td></tr>

--- a/en/reference/ranking/rank-features.html
+++ b/en/reference/ranking/rank-features.html
@@ -1228,6 +1228,54 @@ tensor&lt;float&gt;(dim{},off{}):{ {dim:v1,off:0}:1.0, {dim:v2,off:1}:1.0, {dim:
     </p>
   </td></tr>
 
+<tr><td>bm25(field: <em>name</em>, label: <em>label</em>)</td>
+  <td>0</td>
+  <td>
+    <p id="bm25(field,label)">
+    As <a href="#bm25">bm25(<em>name</em>)</a>, but only over the query terms carrying the given
+    <a href="../../ranking/multivalue-query-operators.html#raw-scores-and-query-item-labeling">query item label</a>.
+    Use it to score a labeled subset of the query.
+    </p>
+    <p>
+    A label which is not an identifier or an integer must be quoted:
+    </p>
+<pre>
+bm25(field: myfield, label: "title-terms")
+</pre>
+    <p>
+    Only terms which both carry the label and search <em>name</em> contribute; the feature is 0 when no
+    such term matches the document.
+    </p>
+  </td></tr>
+
+<tr><td>bm25_for_labels(<em>name</em>)</td>
+  <td><code>tensor&lt;double&gt;(label{}):{}</code></td>
+  <td>
+    <p id="bm25_for_labels">
+    A <code>tensor&lt;float&gt;(label{})</code> holding one
+    <a href="#bm25">bm25</a> score per
+    <a href="../../ranking/multivalue-query-operators.html#raw-scores-and-query-item-labeling">query item label</a>
+    in the <a href="../schemas/schemas.html#indexing-index">indexed string field</a> <em>name</em>,
+    which must have <em>enable-bm25</em> set.
+    Each cell is labeled with the query item label and holds the sum of the BM25 scores of that label's
+    terms in <em>name</em>. This makes it possible to rank on the labeled parts of the query individually
+    without adding one <a href="#bm25(field,label)">bm25(field, label)</a> feature per label:
+    </p>
+<pre>
+reduce(bm25_for_labels(myfield), max, label)          # score of the best scoring labeled clause
+sum(bm25_for_labels(myfield) * query(label_weights))  # weight the labels from the query
+</pre>
+    <p>
+    A label gets a cell only if it actually scores, that is when at least one term carrying it searches
+    <em>name</em> and matches the document. Terms without a label are never included, so
+    <code>reduce(bm25_for_labels(<em>name</em>), sum, label)</code> equals <code>bm25(<em>name</em>)</code>
+    only when every scoring term carries exactly one label.
+    </p>
+    {% include note.html content="A single label can be extracted with
+    <code>bm25_for_labels(myfield){label:mylabel}</code>, but
+    <code>bm25(field: myfield, label: mylabel)</code> is faster since it avoids computing the tensor." %}
+  </td></tr>
+
 <tr>
   <td>elementwise(bm25(field),dimension,cell_type)</td>
   <td><code>tensor&lt;cell_type&gt;(dimension{}):{}</code></td>


### PR DESCRIPTION
Corresponding docs to https://github.com/vespa-engine/vespa/pull/37488 and https://github.com/vespa-engine/vespa/pull/37498. Note that tensors changed from double to floats in the meantime (see https://github.com/vespa-engine/vespa/pull/37516).