### PR TITLE
Restructure autoscaling examples: recommended configs first, per cluster type

### DIFF
--- a/en/operations/autoscaling.html
+++ b/en/operations/autoscaling.html
@@ -142,24 +142,42 @@ or routed to a different cluster in the same Vespa application.
 
 <h2 id="examples">Examples</h2>
 <p>
-  Below is an example of node resources with autoscaling that would work
-  well for a container cluster:
+  The examples below show recommended starting points per cluster type.
+  As a rule of thumb, container clusters can autoscale on any dimension,
+  while content clusters work best with fixed node resources and a range
+  on the number of nodes or groups.
+</p>
+
+<h3 id="container-clusters">Container clusters</h3>
+<p>
+  Container clusters are stateless, so nodes can be added, removed or
+  replaced quickly, and no data needs to move.
+  Scaling the number of nodes is the simplest option and a good starting point:
 </p>
 <pre>{% highlight xml %}
   <nodes count="[2, 8]">
-    <resources vcpu="[2, 3]" memory="[8Gb, 16Gb]" disk="[50Gb, 100Gb]"/>
+    <resources vcpu="4" memory="8Gb"/>
+  </nodes>
+{% endhighlight xml %}</pre>
+<p>
+  You can also let autoscaling choose the node resources within ranges.
+  Changing node resources usually means replacing nodes,
+  but for a container cluster this causes little overhead:
+</p>
+<pre>{% highlight xml %}
+  <nodes count="[2, 8]">
+    <resources vcpu="[2, 4]" memory="[8Gb, 16Gb]"/>
   </nodes>
 {% endhighlight xml %}</pre>
 
+<h3 id="content-clusters">Content clusters</h3>
 <p>
-  The above would in general <strong>not be recommended for a content
-  cluster.</strong> Changing cpu, memory or disk usually leads to
-  allocating new nodes to fulfil the new node resources spec. When
-  that happens there will be redistribution of documents between the
-  old and new nodes and this might impact service quality to some
-  degree. For a content cluster it would usually be better to try to
-  stick to the same node resources and add or remove nodes, e.g
-  something like:
+  Content clusters hold data, so scaling them means redistributing documents.
+  Changing vcpu, memory or disk usually leads to allocating new nodes to
+  fulfil the new node resource spec, replacing all nodes in the cluster and
+  redistributing all documents.
+  Keep node resources fixed and autoscale the number of nodes instead -
+  then only the data on added or removed nodes has to move:
 </p>
 <pre>{% highlight xml %}
   <nodes count="[2, 8]">
@@ -167,24 +185,53 @@ or routed to a different cluster in the same Vespa application.
   </nodes>
 {% endhighlight xml %}</pre>
 <p>
-  If a content cluster is configured to autoscale based on node resources
-  (not just number of nodes or groups) this will work fine, but note
-  that using paged attributes or HNSW indexes will make it more expensive
-  and time-consuming to redistribute documents when scaling up or down.
-  When doing the initial feeding of a cluster it will be best to avoid
-  auto-scaling, as changing the topology will require redistribution of
-  documents, possibly several times.
-</p>
-<p>
-  When using groups in a content cluster it's possible to scale the
-  number of groups instead of the number of nodes, e.g. with a fixed
-  group size and a range for the number of groups:
+  For content clusters using
+  <a href="../reference/applications/services/services.html#nodes">groups</a>,
+  express the topology with <code>groups</code> and <code>group-size</code>
+  rather than a <code>count</code> range, and autoscale the number of groups:
 </p>
 <pre>{% highlight xml %}
   <nodes groups="[2, 4]" group-size="8">
     <resources vcpu="4" memory="16Gb" disk="500Gb"/>
   </nodes>
 {% endhighlight xml %}</pre>
+<p>
+  This scales between 2 and 4 groups of 8 nodes each, 16 to 32 nodes in total.
+  Since each query is handled by a single group, query capacity scales with
+  the number of groups, and adding a group populates the new group without
+  redistributing documents between the existing nodes.
+</p>
+{% include important.html content='Autoscaling node resources (vcpu, memory, disk)
+in a content cluster is supported, but each resource change replaces all nodes
+and redistributes all documents, which might impact service quality to some degree.
+Using <a href="../content/attributes.html#paged-attributes">paged attributes</a> or
+HNSW indexes makes redistribution more expensive and time-consuming.' %}
+{% include note.html content='Avoid autoscaling during the initial feeding of a
+cluster, as changing the topology will require redistribution of documents,
+possibly several times - see
+<a href="../writing/initial-batch-feed.html">initial batch feed</a>.' %}
+
+<h3 id="avoid-ranges-on-every-dimension">Avoid ranges on every dimension</h3>
+<p>
+  For completeness, this is a configuration to avoid, in particular for content clusters:
+</p>
+<pre>{% highlight xml %}
+  <nodes count="[2, 8]">
+    <resources vcpu="[2, 8]" memory="[8Gb, 32Gb]" disk="[50Gb, 200Gb]"/>
+  </nodes>
+{% endhighlight xml %}</pre>
+<p>
+  As node resources often come in increments of x2, these ranges span
+  7 node counts x 3 vcpu x 3 memory x 3 disk steps -
+  around 190 configurations the autoscaler can choose between.
+  For a content cluster, every move between configurations with different
+  node resources replaces all nodes and redistributes all documents.
+  Wide ranges on many dimensions mostly give the autoscaler more expensive
+  ways to reach the same utilization - prefer scaling a single dimension,
+  and see <a href="#resource-tradeoffs">resource tradeoffs</a>.
+</p>
+
+<h3 id="gpu-resources">GPU resources</h3>
 <p>
   Note that at the moment it is not possible to autoscale GPU
   resources per node, but you can scale the number of nodes
@@ -197,6 +244,24 @@ or routed to a different cluster in the same Vespa application.
     </resources>
   </nodes>
 {% endhighlight xml %}</pre>
+
+<h3 id="notes">Notes</h3>
+<ul>
+<li>
+  Autoscaling requires a cluster of at least two nodes -
+  single-node clusters are not autoscaled.
+</li>
+<li>
+  Ranges only take effect in production zones.
+  The <a href="environments.html#dev">dev environment</a> ignores
+  <code>nodes</code> and <code>resources</code> settings by default.
+</li>
+<li>
+  Set the lower bound of a range close to your normal baseline load -
+  a very wide range lets the autoscaler shed many nodes in quiet periods,
+  making the swing back on the next load peak larger and slower.
+</li>
+</ul>
 
 
 <h2>Related reading</h2>


### PR DESCRIPTION
### What

Restructure the Examples section of `en/operations/autoscaling.html` to lead with recommended configurations, split by cluster type:

- **Container clusters**: node-count range with fixed resources first, then resource ranges as an additional option (little overhead for stateless clusters).
- **Content clusters**: fixed resources + node-count range as the recommendation, and `groups`/`group-size` for grouped topologies, with the rationale (resource changes replace all nodes and redistribute all documents). The existing paged-attributes/HNSW and initial-feeding caveats become callouts next to the configs they qualify.
- New "Avoid ranges on every dimension" example showing how multi-dimension ranges multiply into ~190 configurations.
- New short notes: minimum two nodes, ranges only apply in production zones, and choosing a sensible lower bound.

### Why

The section previously opened with an example ranging every dimension, immediately followed by "not recommended for a content cluster" — **readers saw the discouraged pattern first,** and the content-cluster guidance was only stated as a negation. Subheadings per cluster type make the recommendations scannable, and users with grouped content clusters previously had no guidance on whether to range `count` or `groups`.

### References

- https://docs.vespa.ai/en/operations/autoscaling.html#examples

### How to test

Preview the rendered page; all links point to existing anchors (`content/attributes.html#paged-attributes`, `writing/initial-batch-feed.html`, `operations/environments.html#dev`, `reference/applications/services/services.html#nodes`).
