### PR TITLE
Shorten and remove some 'advanced' details

### DIFF
--- a/en/basics/schemas.html
+++ b/en/basics/schemas.html
@@ -9,9 +9,11 @@ redirect_from:
 <p>This is an introduction to schemas in Vespa. You can find all the details in the
 <a href="../reference/schemas/schemas.html">schema reference</a>.</p>
 
-<p>A schema defines a type of data and what we want to compute over it.
-An application package can contain multiple schemas for different kinds of data.
-Each content cluster specified in services.xml refers to the schemas that should be stored an indexed
+<p>A schema defines a <a href="../schemas/documents.html">type of data</a>
+and what we want to compute over it.
+An application package can contain many schemas for different kinds of data.
+Each <a href="../learn/overview.html#content-clusters">content cluster</a> specified in services.xml
+refers to the schemas that should be stored an indexed
 in that cluster. Schemas can inherit other schemas to avoid repeating common content.</p>
 
 <p>Schemas are placed in files named the same as the schema, with the ending ".sd" (for schema definition),
@@ -142,26 +144,6 @@ completions and navigation - see <a href="../applications/ide-support.html">IDE 
 </ul>
 
 <p>You can find the details in <a href="../reference/schemas/schemas.html#modifying-schemas">modifying schemas</a>.</p>
-
-
-<h3 id="multiple-schemas">Multiple schemas</h3>
-<p>
-  An application package has one or more schemas.
-  There is no hard limit to number of schemas, the largest application have hundreds.
-</p>
-<p>
-  A schema defines how data is stored in a <a href="../learn/overview.html#content-clusters">content cluster</a>.
-  The most common approach is storing all schemas in a single content cluster.
-  Use more content clusters to isolate load or scale the clusters differently.
-</p>
-<p>
-  A schema defines a <a href="../schemas/documents.html">document type</a>.
-  One can store documents with the same document type in different content clusters.
-  Use cases are A/B testing and hot/cold variations of data.
-  Vespa will update documents in all content clusters with the same document type,
-  the mapping is set in <a href="../reference/applications/services/content.html#document">services.xml</a>
-  using <em>type</em>.
-</p>
 
 
 <br/>


### PR DESCRIPTION
I want to keep the documents in basics/ short and simple.

Does this cover what you needed to add? We may need a content-clusters doc under content/.