### PR TITLE
chunk indexing expression outputs an Array<String> not a tensor

### DIFF
--- a/en/reference/writing/indexing-language.html
+++ b/en/reference/writing/indexing-language.html
@@ -244,8 +244,8 @@ The supported arithmetic operators are:
 <tr>
   <td><code>chunk id [args]</code></td>
   <td>String</td>
-  <td>A tensor</td>
-  <td><p id="chunk">Invokes a which convert a string into an array of strings.
+  <td>Array&lt;String&gt;</td>
+  <td><p id="chunk">Invokes a <code>Chunker</code> which converts a string into an array of strings.
       Arguments are given space separated, as in <code>chunk fixed-length 512</code>.
       The id of the chunker to use is required and can be a chunker bundled with Vespa,
       or any chunker component added in the services.xml, see the


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Spotted a mistake.