### PR TITLE
Rewrite README for Mintlify and restore migration scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,69 +6,55 @@
   <img alt="#Vespa" width="200" src="https://assets.vespa.ai/logos/Vespa-logo-dark-RGB.svg" style="margin-bottom: 25px;">
 </picture>
 
-[![Vespa Documentation Search Feed](https://github.com/vespa-engine/documentation/actions/workflows/feed.yml/badge.svg)](https://github.com/vespa-engine/documentation/actions/workflows/feed.yml)
-[![/documentation link checker](https://cd.screwdriver.cd/pipelines/7021/link-checker-documentation/badge)](https://cd.screwdriver.cd/pipelines/7021/)
-
 # Creating Vespa documentation
 
 All Vespa features must be documented - this document explains how to add to the documentation.
 
 ## Practical information
 
-Vespa documentation is served using [AWS Amplify](https://aws.amazon.com/amplify/) with [Jekyll](https://jekyllrb.com/).
+Vespa documentation is served using [Mintlify](https://mintlify.com/docs).
 To edit documentation, check out and work off the master branch in this repository.
 
-Documentation is written in HTML or Markdown.
-Use a single Jekyll template [_layouts/default.html](_layouts/default.html) to add header, footer and layout.
+Documentation is written in [MDX](https://mintlify.com/docs/text) and lives under `en/` (and `ja/`).
+Navigation is defined in [docs.json](docs.json).
 
-You probably need to get the right Ruby version first, with
+### Local development
 
-    $ brew install rbenv
-    $ rbenv init
-    $ source ~/.zprofile
-    $ rbenv install 3.3.7
-    $ rbenv local 3.3.7
+Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview documentation changes locally:
 
-Prepend /opt/homebrew/opt/ruby/bin to your $PATH, e.g. in your .zshrc.
+    $ npm i -g mint
 
-Then you should be able to run:
+Run the following command at the root of the repository, where `docs.json` is located:
 
-    $ bundle install
-    $ bundle exec jekyll serve --incremental --drafts --trace
+    $ mint dev
 
-to set up a local server at localhost:4000 to see the pages as they will look when served.
-
+View the local preview at `http://localhost:3000`.
 The output will highlight rendering/other problems when starting serving.
 
-Alternatively, use the docker image `jekyll/jekyll` to run the local server on
-Mac
+Troubleshooting:
 
-    $ docker run -ti --rm --name doc \
-      --publish 4000:4000 -e JEKYLL_UID=$UID -v $(pwd):/srv/jekyll \
-      jekyll/jekyll jekyll serve --incremental --force_polling
+- If the dev environment isn't running: Run `mint update` to ensure you have the most recent version of the CLI.
+- If a page loads as a 404: Make sure you are running in a folder with a valid `docs.json`.
 
-or RHEL 8
+### Publishing changes
 
-    $ podman run -it --rm --name doc -p 4000:4000 -e JEKYLL_ROOTLESS=true \
-      -v "$PWD":/srv/jekyll:Z docker.io/jekyll/jekyll jekyll serve --incremental --force_polling
+Changes are deployed to production automatically after pushing to the default branch,
+via the [Mintlify GitHub app](https://dashboard.mintlify.com/settings/organization/github-app).
 
-The Jekyll server should normally rebuild HTML files automatically
-when a source files changes. If this does not happen, you can use
-`jekyll serve --force-polling` as a workaround.
+### Migration scripts
 
-The layout is written in [denali.design](https://denali.design/),
-see [_layouts/default.html](_layouts/default.html) for usage.
-Please do not add custom style sheets, as it is harder to maintain.
+[scripts/](scripts/) contains the helper scripts used to convert the Jekyll HTML/Markdown
+sources to MDX during the Mintlify migration, e.g. [scripts/html_to_mdx.py](scripts/html_to_mdx.py).
 
 ## Writing documentation
 
 This explains the style and considerations to follow before contributing documentation.
-See [contribute](https://docs.vespa.ai/en/learn/contributing.html) on the practicalities of
+See [contribute](https://docs.vespa.ai/en/learn/contributing) on the practicalities of
 submitting changes.
 
 ### Table of contents
 
-All documents must be listed in_data/sidebar.yml.
+All documents must be listed in the navigation in [docs.json](docs.json).
 
 ### Guides and references
 
@@ -84,25 +70,26 @@ Reference documents are those that are placed in reference/ subdirectory.
 
 The documents are categorized in a set of categories which are mostly the same for guides and references.
 
-The subdirectory and category used in the TOC (sidebar.yml) must always be the same.
+The subdirectory and the navigation group used in docs.json must always be the same.
 
 Place new documents in the most suitable category. Most times they can fit multiple ones; such is life.
 
 Be conscious of the category a document is in when editing it. If you're adding off-category information,
-maybe it should be split into another document? 
+maybe it should be split into another document?
 
 Be extra careful about what is added to the "basics" documents: They should be a clean, easy to understand
 introduction to only the most important concepts of Vespa.
 
-If you need to move a document, you can; just make sure to add a redirect header from the old location.
+If you need to move a document, you can; just make sure to add an entry in the `redirects`
+array in [docs.json](docs.json) from the old location.
 
 ### Applicability
 
-Some documentation only applies to Vespa Cloud ("cloud"), self-managed instances ("self-managed"), 
+Some documentation only applies to Vespa Cloud ("cloud"), self-managed instances ("self-managed"),
 and/or is only available commercially ("enterprise").
-Such documents *must* be marked by setting the appropriate applies_to tags in the document header. 
-See https://docs.vespa.ai/en/learn/about-documentation.html for more a more detailed description of the three applicability
-types.
+Make this clear in the document when applicable.
+See https://docs.vespa.ai/en/learn/about-documentation for a more detailed description of the three
+applicability types.
 
 ### Maintainability
 
@@ -129,50 +116,13 @@ Make the text as short, clear, and easy to read as possible:
 
 ### Linking
 
-Use relative internal links. All internal links will work with and without ".html" suffix, ".md" suffix does not work.
-Use the ".html" suffix when linking to pages where the source is html, and no suffix when linking to Markdown sources.
-That convention is helpful to determine whether a link marked as non-existing in your editor is due to it being a
-Markdown file (with suffix .md, which can't be used in the link), or due to it actually not existing.
+Use root-relative internal links without a file suffix, e.g. `/en/querying/query-api`.
 
-Add an *id* attribute to each heading such that it can be linked to: Use the exact same text as the heading as id, 
-lowercased and with spaces replaced by dashes such that references can be made without checking the source.
-Don't change headings/ids unless completely necessary as that breaks links.
+Don't change headings unless completely necessary, as heading anchors are derived from
+the heading text and changing them breaks links.
 
 ### Link to Javadoc
 
 * Link to javadoc for an artifact: https://javadoc.io/doc/com.yahoo.vespa/container-search
 * Link to javadoc for a package: https://javadoc.io/doc/com.yahoo.vespa/container-search/latest/com/yahoo/search/federation/vespa/package-summary.html
 * Link to javadoc for a class: https://javadoc.io/doc/com.yahoo.vespa/vespa-feed-client-api/latest/ai/vespa/feed/client/JsonFeeder.html
-
-## Appendix: Vespa Documentation Search
-
-See the [Vespa Documentation Search](https://github.com/vespa-cloud/vespa-documentation-search)
-sample application for architecture.
-
-Below is a description of the job for indexing this repository's documentation.
-File locations below refer to this repo's root.
-
-1. Build a Vespa feed from the source in this repo:
-    1. Use Jekyll to generate HTML from the content
-      (some files are in [Markdown](https://daringfireball.net/projects/markdown/))
-    1. Use [Nokogiri](https://nokogiri.org/) to extract text from HTML
-    1. Implement HTML-to-text in a Vespa feed file by using a
-      [Jekyll Generator](https://jekyllrb.com/docs/plugins/generators/),
-      see [_plugins-vespafeed/vespa_index_generator.rb](/_plugins-vespafeed/vespa_index_generator.rb)
-    1. The generated _open_index.json_ can then be
-      [fed to Vespa](https://docs.vespa.ai/en/reference/document-json-format.html)
-
-1. Feed changes to https://console.vespa-cloud.com/tenant/vespa-team/application/vespacloud-docsearch
-   using [feed_to_vespa.py](feed_to_vespa.py):
-    1. Visit all content on the Vespa instance to list all IDs
-    1. Determine whether or not to remove documents
-    1. Feed all content
-    
-1. Automate these steps using GitHub Actions
-    1. Store the keys required to feed data as secrets in Github
-    1. Find workflow at [.github/workflows/feed.yml](/.github/workflows/feed.yml)
-
-Local development:
-
-    $ bundle exec jekyll build
-    $ ./feed_to_vespa.py   # put data-plane-private/public-key.pem in this dir in advance

--- a/scripts/convert_query_tables.py
+++ b/scripts/convert_query_tables.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Convert query API reference HTML tables to Mintlify markdown tables."""
+
+from __future__ import annotations
+
+import html
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from html_to_mdx import Node, TreeBuilder, convert_href, preprocess_body  # noqa: E402
+
+SOURCE_DIR = Path(__file__).resolve().parent.parent / "en" / "reference" / "api"
+ROOT = SOURCE_DIR.parent.parent
+
+H2_RE = re.compile(r'<h2\s+id="([^"]*)"[^>]*>([^<]*)</h2>', re.I)
+TABLE_CLASS_RE = re.compile(r"<table\s+class=\"table\"", re.I)
+P_RE = re.compile(r"<p(?:\s[^>]*)?>(.*?)</p>", re.I | re.DOTALL)
+HR_RE = re.compile(r"<hr\s*/?>", re.I)
+
+
+def load_html_section() -> str:
+    raw = subprocess.check_output(
+        ["git", "show", "HEAD:en/reference/api/query.html"],
+        cwd=ROOT,
+        text=True,
+    )
+    idx = raw.find('<h2 id="query">')
+    if idx == -1:
+        raise SystemExit("query section not found in HTML")
+    return raw[idx:]
+
+
+def fix_short_td_rows(html: str) -> str:
+    """Fix rows like <tr><td>a<td>b</tr> missing </td> closers."""
+
+    def repl(m: re.Match) -> str:
+        row = m.group(0)
+        if "</td>" in row or "</th>" in row:
+            return row
+        pieces = re.split(r"(?=<t[dh]\b)", row)
+        out = [pieces[0]]
+        for piece in pieces[1:]:
+            tag_m = re.match(r"(<t[dh][^>]*>)([\s\S]*)", piece, re.I)
+            if not tag_m:
+                continue
+            tag, rest = tag_m.groups()
+            content = re.split(r"(?=</tr>)", rest, maxsplit=1)[0].strip()
+            close = "</th>" if tag.lower().startswith("<th") else "</td>"
+            out.append(f"{tag}{content}{close}")
+        if "</tr>" in row and not out[-1].endswith("</tr>"):
+            out.append("</tr>")
+        return "".join(out)
+
+    return re.sub(r"<tr[\s\S]*?</tr>", repl, html, flags=re.IGNORECASE)
+
+
+def fix_html_structure(body: str) -> str:
+    body = re.sub(
+        r"(<p(?:\s[^>]*)?>(?:(?!</p>)[\s\S])*?)(\s*</td>)",
+        r"\1</p>\2",
+        body,
+        flags=re.IGNORECASE,
+    )
+    body = re.sub(
+        r"(<li>(?:(?!</li>)[\s\S])*?)(\s*<li>)",
+        lambda m: m.group(1) + "</li>" + m.group(2),
+        body,
+    )
+    body = fix_short_td_rows(body)
+    body = re.sub(
+        r"<tr><th rowspan=\"2\">Value\s*<th colspan=\"3\">Results in</tr>\s*"
+        r"<tr>\s*(?:<th>)?composite</th><th>tokenization</th><th>syntax</th></tr>",
+        "<tr><th>Value</th><th>composite</th><th>tokenization</th><th>syntax</th></tr>",
+        body,
+        flags=re.IGNORECASE,
+    )
+    # Close table rows that end at </table> without </tr>
+    body = re.sub(
+        r"(<tr>(?:(?!</tr>)[\s\S])*?)(</table>)",
+        lambda m: m.group(1) + "</td></tr>" + m.group(2),
+        body,
+        flags=re.IGNORECASE,
+    )
+    return body
+
+
+def escape_cell(text: str) -> str:
+    text = text.replace("\n", " ").replace("\r", "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text.replace("|", "\\|")
+
+
+def emit_inline(node: Node | str, source_dir: Path) -> str:
+    if isinstance(node, str):
+        return html.unescape(node)
+    tag = node.tag or ""
+    inner = "".join(emit_inline(c, source_dir) for c in node.children)
+    if tag == "br":
+        return "<br />"
+    if tag == "a":
+        href = convert_href(node.attrs.get("href", ""), source_dir)
+        text = inner.strip() or href
+        return f"[{text}]({href})"
+    if tag == "code":
+        return f"`{inner}`"
+    if tag in ("em", "i"):
+        return f"*{inner}*"
+    if tag in ("strong", "b"):
+        return f"**{inner}**"
+    if tag == "mdx-warning":
+        return f"**Important:** {inner.strip()}"
+    if tag == "mdx-note":
+        return f"**Note:** {inner.strip()}"
+    return inner
+
+
+def nested_table_to_md(node: Node, source_dir: Path) -> str:
+    rows: list[list[str]] = []
+    for c in node.children:
+        if isinstance(c, Node) and c.tag == "tr":
+            cells = [
+                escape_cell(emit_inline(cell, source_dir))
+                for cell in c.children
+                if isinstance(cell, Node) and cell.tag in ("td", "th")
+            ]
+            if cells:
+                rows.append(cells)
+    if not rows:
+        return ""
+    if len(rows[0]) == 2:
+        return " ".join(f"`{r[0]}`: {r[1]}" for r in rows)
+    return " ".join(" — ".join(r) for r in rows)
+
+
+def emit_cell(node: Node, source_dir: Path) -> str:  # noqa: PLR0912
+    parts: list[str] = []
+    for c in node.children:
+        if isinstance(c, Node):
+            if c.tag == "table":
+                nested = nested_table_to_md(c, source_dir)
+                if nested:
+                    parts.append(nested)
+            elif c.tag in ("ul", "ol"):
+                for li in c.children:
+                    if isinstance(li, Node) and li.tag == "li":
+                        parts.append(emit_inline(li, source_dir).strip())
+            elif c.tag == "p":
+                text = emit_inline(c, source_dir).strip()
+                if text:
+                    parts.append(text)
+            elif c.tag in ("mdx-warning", "mdx-note"):
+                parts.append(emit_inline(c, source_dir).strip())
+            else:
+                text = emit_inline(c, source_dir).strip()
+                if text:
+                    parts.append(text)
+        else:
+            t = html.unescape(c).strip()
+            if t:
+                parts.append(t)
+    return " ".join(parts)
+
+
+def row_cells(tr: Node) -> list[Node]:
+    return [c for c in tr.children if isinstance(c, Node) and c.tag in ("th", "td")]
+
+
+def cell_text(cell: Node, source_dir: Path) -> str:
+    if cell.tag == "th":
+        return escape_cell(emit_inline(cell, source_dir))
+    return escape_cell(emit_cell(cell, source_dir))
+
+
+NESTED_TABLE_RE = re.compile(r"<table[^>]*>[\s\S]*?</table>", re.IGNORECASE)
+
+
+def table_end(html: str, start: int) -> int:
+    j = html.find(">", start) + 1
+    depth = 1
+    while j < len(html) and depth > 0:
+        next_open = html.find("<table", j)
+        next_close = html.find("</table>", j)
+        if next_close == -1:
+            return len(html)
+        if next_open != -1 and next_open < next_close:
+            depth += 1
+            j = html.find(">", next_open) + 1
+        else:
+            depth -= 1
+            j = next_close + len("</table>")
+    return j
+
+
+def isolate_nested_tables(table_html: str) -> tuple[str, list[str]]:
+    """Replace every nested <table> inside the outer table with placeholders."""
+    nested: list[str] = []
+    first = re.search(r"<table\b", table_html, re.I)
+    if not first:
+        return table_html, nested
+    pos = first.end()
+    while True:
+        m = re.search(r"<table\b", table_html[pos:], re.I)
+        if not m:
+            break
+        start = pos + m.start()
+        end = table_end(table_html, start)
+        nested.append(table_html[start:end])
+        placeholder = f"<!--NESTED{len(nested) - 1}-->"
+        table_html = table_html[:start] + placeholder + table_html[end:]
+        pos = start + len(placeholder)
+    return table_html, nested
+
+
+def restore_nested(fragment: str, nested: list[str]) -> str:
+    for i, table_html in enumerate(nested):
+        fragment = fragment.replace(f"<!--NESTED{i}-->", table_html)
+    return fragment
+
+
+def nested_table_to_md_html(table_html: str, source_dir: Path) -> str:
+    table_html = fix_short_td_rows(table_html)
+    rows: list[list[str]] = []
+    for tr in re.finditer(r"<tr[^>]*>([\s\S]*?)</tr>", table_html, re.I):
+        cells = tr_cells_from_inner(tr.group(1), [], source_dir)
+        if cells:
+            rows.append(cells)
+    if not rows:
+        return ""
+    if rows and all(len(r) == 2 for r in rows):
+        return " ".join(f"`{r[0]}`: {r[1]}" for r in rows)
+    if rows and all(len(r) >= 4 for r in rows):
+        header = rows[0]
+        parts = []
+        for row in rows[1:]:
+            parts.append(
+                f"`{row[0]}` → composite `{row[1]}`, tokenization `{row[2]}`, syntax `{row[3]}`"
+            )
+        return " ".join(parts)
+    if len(rows) >= 2 and len(rows[0]) >= 3:
+        parts = []
+        for row in rows[1:]:
+            if len(row) >= 4:
+                parts.append(
+                    f"`{row[0]}` → composite `{row[1]}`, tokenization `{row[2]}`, syntax `{row[3]}`"
+                )
+            elif len(row) >= 2:
+                parts.append(f"`{row[0]}`: {row[1]}")
+        return " ".join(parts)
+    return " ".join(" — ".join(r) for r in rows)
+
+
+def html_inline_to_md(fragment: str, source_dir: Path) -> str:
+    if not fragment.strip():
+        return ""
+    work = preprocess_body(fragment.strip())
+    builder = TreeBuilder()
+    builder.feed(f"<div>{work}</div>")
+    builder.close()
+    div = next(c for c in builder.root.children if isinstance(c, Node))
+    return emit_cell(div, source_dir)
+
+
+def emit_cell_node(node: Node, source_dir: Path, nested: list[str] | None = None) -> str:
+    parts: list[str] = []
+    for c in node.children:
+        if isinstance(c, str):
+            text = c.strip()
+            for m in re.finditer(r"<!--NESTED(\d+)-->", text):
+                if nested:
+                    parts.append(nested_table_to_md_html(nested[int(m.group(1))], source_dir))
+            text = re.sub(r"<!--NESTED\d+-->", "", text).strip()
+            if text:
+                parts.append(html.unescape(text))
+        elif isinstance(c, Node):
+            if c.tag == "table":
+                parts.append(nested_table_to_md_html(node_to_html_table(c), source_dir))
+            elif c.tag in ("ul", "ol"):
+                for li in c.children:
+                    if isinstance(li, Node) and li.tag == "li":
+                        parts.append(emit_inline(li, source_dir).strip())
+            elif c.tag == "p":
+                text = emit_inline(c, source_dir).strip()
+                if text:
+                    parts.append(text)
+            elif c.tag in ("mdx-warning", "mdx-note"):
+                parts.append(emit_inline(c, source_dir).strip())
+            else:
+                text = emit_inline(c, source_dir).strip()
+                if text:
+                    parts.append(text)
+        else:
+            t = html.unescape(c).strip()
+            if t:
+                parts.append(t)
+    return " ".join(parts)
+
+
+def node_to_html_table(node: Node) -> str:
+    return "".join(node_to_html_table_part(c) for c in [node])
+
+
+def node_to_html_table_part(node: Node | str) -> str:
+    if isinstance(node, str):
+        return html.unescape(node)
+    tag = node.tag or ""
+    inner = "".join(node_to_html_table_part(c) for c in node.children)
+    attrs = " ".join(f'{k}="{v}"' for k, v in node.attrs.items())
+    open_tag = f"<{tag} {attrs}>" if attrs else f"<{tag}>"
+    return f"{open_tag}{inner}</{tag}>"
+
+
+def tr_cells_from_inner(tr_inner: str, nested: list[str], source_dir: Path) -> list[str]:
+    inner = restore_nested(tr_inner, nested)
+    builder = TreeBuilder()
+    builder.feed(f"<tr>{inner}</tr>")
+    builder.close()
+    tr = next(c for c in builder.root.children if isinstance(c, Node) and c.tag == "tr")
+    cells: list[str] = []
+    for c in tr.children:
+        if isinstance(c, Node) and c.tag == "th":
+            cells.append(escape_cell(emit_inline(c, source_dir)))
+        elif isinstance(c, Node) and c.tag == "td":
+            cells.append(escape_cell(emit_cell_node(c, source_dir, nested)))
+    return cells
+
+
+def extract_rows_regex(table_html: str, source_dir: Path) -> tuple[list[str], list[list[str]]]:
+    header: list[str] = []
+    body_rows: list[list[str]] = []
+    isolated, nested = isolate_nested_tables(table_html)
+    thead = re.search(r"<thead>([\s\S]*?)</thead>", isolated, re.I)
+    if thead:
+        htr = re.search(r"<tr[^>]*>([\s\S]*?)</tr>", thead.group(1), re.I)
+        if htr:
+            header = tr_cells_from_inner(htr.group(1), [], source_dir)
+    tbody = re.search(r"<tbody>([\s\S]*?)</tbody>", isolated, re.I)
+    chunk = tbody.group(1) if tbody else isolated
+    for tr in re.finditer(r"<tr[^>]*>([\s\S]*?)</tr>", chunk, re.I):
+        cells = tr_cells_from_inner(tr.group(1), nested, source_dir)
+        if cells:
+            body_rows.append(cells)
+    return header, body_rows
+
+
+def html_table_to_markdown(table_html: str, source_dir: Path) -> str:
+    caption_m = re.search(r"<caption>([\s\S]*?)</caption>", table_html, re.I)
+    caption = html.unescape(caption_m.group(1)).strip() if caption_m else ""
+
+    header, body_rows = extract_rows_regex(table_html, source_dir)
+
+    if not header:
+        return ""
+
+    ncol = len(header)
+    lines: list[str] = []
+    if caption:
+        lines.extend([f"*{caption}*", ""])
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join("---" for _ in header) + " |")
+    for row in body_rows:
+        while len(row) < ncol:
+            row.append("")
+        lines.append("| " + " | ".join(row[:ncol]) + " |")
+    return "\n".join(lines) + "\n\n"
+
+
+def inline_html_to_md(fragment: str, source_dir: Path) -> str:
+    fragment = preprocess_body(fragment.strip())
+    builder = TreeBuilder()
+    builder.feed(f"<div>{fragment}</div>")
+    builder.close()
+    parts: list[str] = []
+    for c in builder.root.children:
+        if isinstance(c, Node) and c.tag == "div":
+            for cc in c.children:
+                if isinstance(cc, Node) and cc.tag == "p":
+                    text = emit_inline(cc, source_dir).strip()
+                    if text:
+                        parts.append(text)
+                elif isinstance(cc, Node) and cc.tag in ("ul", "ol"):
+                    for li in cc.children:
+                        if isinstance(li, Node) and li.tag == "li":
+                            parts.append(f"- {emit_inline(li, source_dir).strip()}")
+        elif isinstance(c, Node) and c.tag == "p":
+            text = emit_inline(c, source_dir).strip()
+            if text:
+                parts.append(text)
+    return "\n\n".join(parts) + ("\n\n" if parts else "")
+
+
+def convert_section(chunk: str, source_dir: Path) -> str:
+    out: list[str] = []
+    pos = 0
+    for m in H2_RE.finditer(chunk):
+        before = chunk[pos : m.start()]
+        if before.strip():
+            out.append(process_between(before, source_dir))
+        title = html.unescape(m.group(2)).strip()
+        out.append(f"## {title}\n\n")
+        pos = m.end()
+
+    tail = chunk[pos:]
+    if tail.strip():
+        out.append(process_between(tail, source_dir))
+    return "".join(out)
+
+
+def extract_main_tables(fragment: str) -> list[tuple[int, int, str]]:
+    tables: list[tuple[int, int, str]] = []
+    pos = 0
+    while True:
+        m = TABLE_CLASS_RE.search(fragment, pos)
+        if not m:
+            break
+        start = m.start()
+        j = fragment.find(">", m.end()) + 1
+        depth = 1
+        while j < len(fragment) and depth > 0:
+            next_open = fragment.find("<table", j)
+            next_close = fragment.find("</table>", j)
+            if next_close == -1:
+                break
+            if next_open != -1 and next_open < next_close:
+                depth += 1
+                j = fragment.find(">", next_open) + 1
+            else:
+                depth -= 1
+                j = next_close + len("</table>")
+        if depth == 0:
+            tables.append((start, j, fragment[start:j]))
+            pos = j
+        else:
+            break
+    return tables
+
+
+def process_between(fragment: str, source_dir: Path) -> str:
+    out: list[str] = []
+    pos = 0
+    for start, end, table_html in extract_main_tables(fragment):
+        before = fragment[pos:start]
+        if before.strip():
+            out.append(inline_html_to_md(before, source_dir))
+        out.append(html_table_to_markdown(table_html, source_dir))
+        pos = end
+    rest = fragment[pos:]
+    if rest.strip():
+        out.append(inline_html_to_md(rest, source_dir))
+    if HR_RE.search(fragment) and "---" not in "".join(out):
+        out.append("---\n\n")
+    return "".join(out)
+
+
+def convert() -> str:
+    body = fix_html_structure(load_html_section())
+    body = preprocess_body(body.strip())
+    text = convert_section(body, SOURCE_DIR)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip() + "\n"
+
+
+def main() -> None:
+    mdx_path = SOURCE_DIR / "query.mdx"
+    original = mdx_path.read_text(encoding="utf-8")
+    lines = original.split("\n")
+    cut = next(i for i, line in enumerate(lines) if line.strip() == "## Query" and i > 20)
+    head = "\n".join(lines[:cut])
+    new_body = convert()
+    mdx_path.write_text(f"{head}\n\n{new_body}", encoding="utf-8")
+    print(f"Wrote {mdx_path} ({len(mdx_path.read_text().splitlines())} lines)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_reference_api.py
+++ b/scripts/convert_reference_api.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Convert en/reference/api/*.html to Mintlify MDX."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from html_to_mdx import convert_file  # noqa: E402
+from fix_mdx_parse_errors import (  # noqa: E402
+    escape_mdx_curly_in_math,
+    fix_frontmatter,
+    generic_pre_to_fences,
+    jekyll_highlight_to_fences,
+    jekyll_note_to_mdx,
+)
+
+API_DIR = Path(__file__).resolve().parent.parent / "en" / "reference" / "api"
+
+
+def post_fix(path: Path) -> bool:
+    original = path.read_text(encoding="utf-8")
+    text = fix_frontmatter(original)
+    text = jekyll_note_to_mdx(text)
+    text = jekyll_highlight_to_fences(text)
+    text = generic_pre_to_fences(text)
+    text = escape_mdx_curly_in_math(text)
+    if text != original:
+        path.write_text(text, encoding="utf-8")
+        return True
+    return False
+
+
+def main() -> None:
+    for path in sorted(API_DIR.glob("*.html")):
+        convert_file(path)
+    for path in sorted(API_DIR.glob("*.mdx")):
+        if post_fix(path):
+            print(f"Post-fixed {path.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_reference_tables.py
+++ b/scripts/convert_reference_tables.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Convert HTML tables to markdown in all en/reference MDX files."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from mdx_html_tables import convert_tree  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent / "en" / "reference"
+
+
+SKIP = {"query.mdx"}
+
+
+def main() -> None:
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT
+    count = 0
+    for path in sorted(target.rglob("*.mdx")):
+        if path.name in SKIP:
+            continue
+        from mdx_html_tables import convert_mdx_file
+
+        if convert_mdx_file(path):
+            print(f"Converted tables in {path.name}")
+            count += 1
+    print(f"Updated {count} files")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_mdx_parse_errors.py
+++ b/scripts/fix_mdx_parse_errors.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Fix common MDX parse errors in Vespa docs (Jekyll/HTML leftovers)."""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent / "en"
+
+
+def fix_frontmatter(text: str) -> str:
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    meta, body = text[3:end], text[end + 4 :]
+
+    def quote_desc(m: re.Match) -> str:
+        val = m.group(1).strip()
+        if (val.startswith('"') and val.endswith('"')) or (
+            val.startswith("'") and val.endswith("'")
+        ):
+            return m.group(0)
+        escaped = val.replace("\\", "\\\\").replace('"', '\\"')
+        return f'description: "{escaped}"'
+
+    meta = re.sub(r"^description:\s*(.+)$", quote_desc, meta, flags=re.M)
+    return f"---{meta}\n---{body}"
+
+
+def jekyll_note_to_mdx(text: str) -> str:
+    def note_repl(m: re.Match) -> str:
+        content = html.unescape(m.group(2)).strip()
+        return f"\n<Note>\n**Note:**\n\n{content}\n</Note>\n"
+
+    def important_repl(m: re.Match) -> str:
+        content = html.unescape(m.group(2)).strip()
+        return f"\n<Warning>\n**Important:**\n\n{content}\n</Warning>\n"
+
+    def pre_req_repl(m: re.Match) -> str:
+        memory = m.group(1)
+        extra = m.group(2) or ""
+        extra = re.sub(r"<li>", "\n- ", extra)
+        extra = re.sub(r"</li>", "", extra)
+        extra = re.sub(r"<code>([^<]+)</code>", r"`\1`", extra)
+        return (
+            f"\n<Note>\n**Prerequisites:**\n\n"
+            f"Memory: {memory}.{extra.strip()}\n</Note>\n"
+        )
+
+    text = re.sub(
+        r"\{%\s*include\s+note\.html\s+content=(['\"])(.*?)\1\s*%\}",
+        note_repl,
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(
+        r"\{%\s*include\s+important\.html\s+content=(['\"])(.*?)\1\s*%\}",
+        important_repl,
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(
+        r"\{%\s*include\s+pre-req\.html\s+memory=(['\"])([^'\"]+)\1(?:\s+extra-reqs=(['\"])(.*?)\3)?\s*%\}",
+        pre_req_repl,
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(r"\{%\s*include\s+video-include\.html[^%]*%\}", "", text, flags=re.DOTALL)
+    text = re.sub(
+        r"\{%\s*include\s+warning\.html\s+content=(['\"])(.*?)\1\s*%\}",
+        important_repl,
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(
+        r"\{%\s*include\s+setup\.html\s+appname=['\"]([^'\"]+)['\"]\s*%\}",
+        lambda m: "",
+        text,
+    )
+    text = re.sub(
+        r"\{%\s*include\s+version\.html\s+version=[\"']([^\"']+)[\"']\s*%\}",
+        lambda m: f"Vespa {m.group(1)}+",
+        text,
+    )
+    return text
+
+
+def html_comments_to_mdx(text: str) -> str:
+    def repl(m: re.Match) -> str:
+        content = m.group(1).strip()
+        return f"{{/* {content} */}}"
+    return re.sub(r"<!--(.*?)-->", repl, text, flags=re.DOTALL)
+
+
+def pre_parent_to_fences(text: str) -> str:
+    pattern = re.compile(
+        r'<div class="pre-parent">\s*<button[^>]*></button>\s*'
+        r"<pre(?:\s[^>]*)?>(.*?)</pre>\s*</div>",
+        re.DOTALL | re.IGNORECASE,
+    )
+
+    def to_fence(m: re.Match) -> str:
+        code = html.unescape(m.group(1)).strip()
+        code = re.sub(r"<[^>]+>", "", code)
+        lang = "bash" if code.startswith("$") else "txt"
+        return f"\n```{lang}\n{code}\n```\n"
+
+    return pattern.sub(to_fence, text)
+
+
+def jekyll_highlight_to_fences(text: str) -> str:
+    def pre_highlight(m: re.Match) -> str:
+        lang = m.group(1) or "txt"
+        code = html.unescape(m.group(2)).strip("\n")
+        return f"\n```{lang}\n{code}\n```\n"
+
+    text = re.sub(
+        r"<pre>\s*\{%\s*highlight\s+(\w*)\s*%\}\s*(.*?)\s*\{%\s*endhighlight\s*%\}\s*</pre>",
+        pre_highlight,
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(
+        r"\{%\s*highlight\s+(\w*)\s*%\}\s*(.*?)\s*\{%\s*endhighlight\s*%\}",
+        pre_highlight,
+        text,
+        flags=re.DOTALL,
+    )
+    return text
+
+
+def escape_mdx_curly_in_math(text: str) -> str:
+    """Escape { in $$ math blocks so MDX does not parse as JSX."""
+
+    def fix_math(m: re.Match) -> str:
+        inner = m.group(1)
+        inner = inner.replace("{", "\\{").replace("}", "\\}")
+        return f"$$ {inner} $$"
+
+    return re.sub(r"\$\$\s*(.*?)\s*\$\$", fix_math, text, flags=re.DOTALL)
+
+
+def fix_angle_in_tables(text: str) -> str:
+    """Fix |<| table cells that break MDX."""
+    lines = []
+    for line in text.split("\n"):
+        if "|" in line and re.search(r"\|[<>≤≥]\|", line):
+            line = line.replace("|<|", "|`<`|").replace("|>|", "|`>`|")
+            line = line.replace("|≤|", "|`≤`|").replace("|≥|", "|`≥`|")
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def generic_pre_to_fences(text: str) -> str:
+    pattern = re.compile(r"<pre(?:\s[^>]*)?>(.*?)</pre>", re.DOTALL | re.IGNORECASE)
+
+    def to_fence(m: re.Match) -> str:
+        code = html.unescape(m.group(1)).strip()
+        # Only unwrap Jekyll/HTML wrappers; do not strip API placeholders like <namespace>.
+        code = re.sub(r"</?(?:code|span)(?:\s[^>]*)?>", "", code, flags=re.IGNORECASE)
+        if "{%" in code or "{% endhighlight" in code:
+            return m.group(0)
+        if code.startswith("$"):
+            lang = "bash"
+        elif code.startswith("{") or code.startswith("["):
+            lang = "json"
+        elif "schema " in code or "rank-profile" in code or "field " in code:
+            lang = "txt"
+        else:
+            lang = "txt"
+        return f"\n```{lang}\n{code}\n```\n"
+
+    return pattern.sub(to_fence, text)
+
+
+def fix_img_tags(text: str) -> str:
+    text = re.sub(
+        r'<img\s+src="([^"]+)"\s+alt="([^"]*)"\s*width="[^"]*"\s*height="[^"]*"\s*/?>',
+        r"\n<Frame>\n![\2](\1)\n</Frame>\n",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r'<img\s+src="([^"]+)"\s+alt="([^"]*)"\s*/?>',
+        r"\n<Frame>\n![\2](\1)\n</Frame>\n",
+        text,
+        flags=re.IGNORECASE,
+    )
+    return text
+
+
+def fix_angle_bracket_placeholders(text: str) -> str:
+    text = text.replace("<host:port>", "`host:port`")
+    return text
+
+
+def wrap_inline_field_defs(text: str) -> str:
+    def repl(m: re.Match) -> str:
+        return f"`{m.group(0).strip()}`"
+
+    return re.sub(
+        r"^field \w+ type \w+ \{ indexing:[^}]+\}",
+        repl,
+        text,
+        flags=re.MULTILINE,
+    )
+
+
+def html_tables_to_markdown(text: str) -> str:
+    """Convert simple HTML tables to markdown."""
+
+    def table_repl(m: re.Match) -> str:
+        rows = re.findall(r"<tr>(.*?)</tr>", m.group(1), re.DOTALL)
+        md_rows = []
+        for row in rows:
+            cells = re.findall(r"<t[dh]>(.*?)</t[dh]>", row, re.DOTALL)
+            cells = [re.sub(r"<[^>]+>", "", c).strip() for c in cells]
+            if not cells:
+                continue
+            cells = [
+                c.replace("|", "\\|")
+                .replace("<", "`<")
+                .replace(">", ">`")
+                if c in ("<", ">", "≤", "≥")
+                else c
+                for c in cells
+            ]
+            md_rows.append("| " + " | ".join(cells) + " |")
+        if len(md_rows) >= 1:
+            sep = "| " + " | ".join("---" for _ in md_rows[0].split("|")[1:-1]) + " |"
+            if len(md_rows) > 1:
+                return "\n" + md_rows[0] + "\n" + sep + "\n" + "\n".join(md_rows[1:]) + "\n"
+        return m.group(0)
+
+    return re.sub(
+        r"<table[^>]*>(.*?)</table>",
+        table_repl,
+        text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+
+
+def fix_bash_completion_redirect(text: str) -> str:
+    """Lines like source <(cmd) break MDX."""
+    if "vespa_completion" not in str(text):
+        return text
+    lines = []
+    in_fence = False
+    for line in text.split("\n"):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            lines.append(line)
+            continue
+        if not in_fence and "<(" in line:
+            lines.append("```bash")
+            lines.append(line.strip())
+            lines.append("```")
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def fix_tensor_pre_braces(text: str) -> str:
+    """Content in pre blocks with {category: ...} - ensure inside fences."""
+    return text  # handled by pre_parent_to_fences
+
+
+def process_file(path: Path) -> bool:
+    original = path.read_text(encoding="utf-8")
+    text = original
+    text = fix_frontmatter(text)
+    text = jekyll_note_to_mdx(text)
+    text = html_comments_to_mdx(text)
+    text = pre_parent_to_fences(text)
+    text = generic_pre_to_fences(text)
+    text = jekyll_highlight_to_fences(text)
+    text = escape_mdx_curly_in_math(text)
+    text = fix_angle_in_tables(text)
+    text = html_tables_to_markdown(text)
+    text = fix_img_tags(text)
+    text = fix_angle_bracket_placeholders(text)
+    text = wrap_inline_field_defs(text)
+    text = fix_bash_completion_redirect(text)
+    if text != original:
+        path.write_text(text, encoding="utf-8")
+        return True
+    return False
+
+
+def main() -> None:
+    files = sorted(ROOT.rglob("*.md")) + sorted(ROOT.rglob("*.mdx"))
+    count = 0
+    for path in files:
+        if process_file(path):
+            print(f"Fixed {path.relative_to(ROOT.parent)}")
+            count += 1
+    print(f"Updated {count} files")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/html_to_mdx.py
+++ b/scripts/html_to_mdx.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Convert Vespa Jekyll HTML docs to Mintlify MDX."""
+
+from __future__ import annotations
+
+import html
+import re
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from pathlib import Path
+
+APPS_DIR = Path(__file__).resolve().parent.parent / "en" / "applications"
+VOID_TAGS = frozenset({"br", "hr", "img", "input", "meta", "link"})
+
+
+@dataclass
+class Node:
+    tag: str | None = None
+    attrs: dict[str, str] = field(default_factory=dict)
+    children: list[Node | str] = field(default_factory=list)
+
+    def text_content(self) -> str:
+        parts: list[str] = []
+        for c in self.children:
+            if isinstance(c, str):
+                parts.append(c)
+            else:
+                parts.append(c.text_content())
+        return "".join(parts).strip()
+
+
+class TreeBuilder(HTMLParser):
+    def __init__(self) -> None:
+        # Keep &lt;...&gt; in <pre> and tables; avoid treating placeholders as tags.
+        super().__init__(convert_charrefs=False)
+        self.root = Node(tag="root")
+        self.stack: list[Node] = [self.root]
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in VOID_TAGS:
+            node = Node(tag=tag, attrs={k: v or "" for k, v in attrs})
+            self.stack[-1].children.append(node)
+            return
+        node = Node(tag=tag, attrs={k: v or "" for k, v in attrs})
+        self.stack[-1].children.append(node)
+        self.stack.append(node)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in VOID_TAGS:
+            return
+        if len(self.stack) > 1:
+            self.stack.pop()
+
+    def handle_data(self, data: str) -> None:
+        if data:
+            self.stack[-1].children.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        self.stack[-1].children.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        self.stack[-1].children.append(f"&#{name};")
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, text
+    fm = text[3:end].strip()
+    body = text[end + 4 :].lstrip("\n")
+    meta: dict[str, str] = {}
+    for line in fm.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        if ":" in line:
+            key, _, val = line.partition(":")
+            meta[key.strip()] = val.strip().strip('"')
+    return meta, body
+
+
+def convert_href(href: str, source_dir: Path) -> str:
+    if not href or href.startswith(("http://", "https://", "mailto:", "#")):
+        return href
+    if href.startswith("/"):
+        parts = href.split("#", 1)
+        path = parts[0].replace(".html", "")
+        anchor = f"#{parts[1]}" if len(parts) > 1 else ""
+        return path + anchor
+    parts = href.split("#", 1)
+    path = parts[0].replace(".html", "")
+    anchor = f"#{parts[1]}" if len(parts) > 1 else ""
+    resolved = (source_dir / path).resolve()
+    try:
+        rel = resolved.relative_to(APPS_DIR.parent.parent)
+        return "/" + str(rel).replace("\\", "/") + anchor
+    except ValueError:
+        return path + anchor
+
+
+def preprocess_body(body: str) -> str:
+    # Unclosed <p> wrapping lists or trailing content
+    body = re.sub(r"<p>((?:(?!</p>)[\s\S])*?)<ul>", r"<p>\1</p>\n<ul>", body, flags=re.IGNORECASE)
+    body = re.sub(r"<p>((?:(?!</p>)[\s\S])*?)<ol>", r"<p>\1</p>\n<ol>", body, flags=re.IGNORECASE)
+    body = re.sub(r"</ul>\s*</p>", "</ul>", body, flags=re.IGNORECASE)
+    body = re.sub(r"</ol>\s*</p>", "</ol>", body, flags=re.IGNORECASE)
+    body = re.sub(r"<p>\s*<ul>", "<ul>", body, flags=re.IGNORECASE)
+    body = re.sub(r"<p>\s*<ol>", "<ol>", body, flags=re.IGNORECASE)
+    body = re.sub(r"<i>", "<em>", body, flags=re.IGNORECASE)
+    body = re.sub(r"</i>", "</em>", body, flags=re.IGNORECASE)
+
+    def important_repl(m: re.Match) -> str:
+        content = html.unescape(m.group(2)).strip()
+        return f"<mdx-warning>{content}</mdx-warning>"
+
+    def note_repl(m: re.Match) -> str:
+        content = html.unescape(m.group(2)).strip()
+        return f"<mdx-note>{content}</mdx-note>"
+
+    body = re.sub(
+        r"\{%\s*include\s+important\.html\s+content=(['\"])(.*?)\1\s*%\}",
+        important_repl,
+        body,
+        flags=re.DOTALL,
+    )
+    body = re.sub(
+        r"\{%\s*include\s+note\.html\s+content=(['\"])(.*?)\1\s*%\}",
+        note_repl,
+        body,
+        flags=re.DOTALL,
+    )
+    body = re.sub(r"\{%\s*include\s+video-include\.html[^%]*%\}", "", body, flags=re.DOTALL)
+
+    def deprecated_repl(m: re.Match) -> str:
+        content = html.unescape(m.group(2)).strip()
+        return f"<mdx-warning>{content}</mdx-warning>"
+
+    body = re.sub(
+        r"\{%\s*include\s+deprecated\.html\s+content=(['\"])(.*?)\1\s*%\}",
+        deprecated_repl,
+        body,
+        flags=re.DOTALL,
+    )
+    body = re.sub(
+        r"\{%\s*include\s+version\.html\s+version=[\"']([^\"']+)[\"']\s*%\}",
+        lambda m: f"Vespa {m.group(1)}+",
+        body,
+    )
+    body = re.sub(
+        r'<span class="pre-hilite">(.*?)</span>',
+        lambda m: f"<code>{html.unescape(m.group(1))}</code>",
+        body,
+        flags=re.DOTALL,
+    )
+    # Jekyll sources sometimes omit </li> before the next <li>
+    body = re.sub(
+        r"(<li>(?:(?!</li>)[\s\S])*?)(\s*<li>)",
+        lambda m: m.group(1) + "</li>" + m.group(2),
+        body,
+    )
+
+    def escape_pre_content(m: re.Match) -> str:
+        inner = m.group(1)
+        if "{%" in inner or "data-lang=" in inner:
+            return m.group(0)
+        if "&lt;" in inner:
+            return m.group(0)
+        escaped = inner.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        return f"<pre>{escaped}</pre>"
+
+    body = re.sub(
+        r"<pre(?:\s[^>]*)?>(.*?)</pre>",
+        escape_pre_content,
+        body,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+
+    def pre_highlight(m: re.Match) -> str:
+        lang = m.group(1) or "txt"
+        code = html.unescape(m.group(2)).strip("\n")
+        escaped = html.escape(code, quote=False)
+        return f'<pre data-lang="{lang}">{escaped}</pre>'
+
+    body = re.sub(
+        r"<pre>\s*\{%\s*highlight\s+(\w*)\s*%\}\s*(.*?)\s*\{%\s*endhighlight\s*%\}\s*</pre>",
+        pre_highlight,
+        body,
+        flags=re.DOTALL,
+    )
+    body = re.sub(
+        r"\{%\s*highlight\s+(\w*)\s*%\}\s*(.*?)\s*\{%\s*endhighlight\s*%\}",
+        pre_highlight,
+        body,
+        flags=re.DOTALL,
+    )
+
+    def img_repl(m: re.Match) -> str:
+        alt = m.group(1) or ""
+        src = m.group(2)
+        return f'<mdx-frame><img src="{src}" alt="{alt}"/></mdx-frame>'
+
+    body = re.sub(
+        r'<img\s+[^>]*src=["\']([^"\']+)["\'][^>]*alt=["\']([^"\']*)["\'][^>]*/?>',
+        lambda m: f'<mdx-frame><img src="{m.group(1)}" alt="{m.group(2)}"/></mdx-frame>',
+        body,
+        flags=re.IGNORECASE,
+    )
+    body = re.sub(
+        r'<img\s+[^>]*alt=["\']([^"\']*)["\'][^>]*src=["\']([^"\']+)["\'][^>]*/?>',
+        lambda m: f'<mdx-frame><img src="{m.group(2)}" alt="{m.group(1)}"/></mdx-frame>',
+        body,
+        flags=re.IGNORECASE,
+    )
+    body = re.sub(
+        r'<img\s+[^>]*src=["\']([^"\']+)["\'][^>]*/?>',
+        lambda m: f'<mdx-frame><img src="{m.group(1)}" alt=""/></mdx-frame>',
+        body,
+        flags=re.IGNORECASE,
+    )
+    return body
+
+
+BLOCK_IN_CELL = frozenset({"p", "ul", "ol", "pre", "table", "dl", "h2", "h3", "h4"})
+
+
+def cell_has_blocks(node: Node) -> bool:
+    for c in node.children:
+        if isinstance(c, Node):
+            if c.tag in BLOCK_IN_CELL or cell_has_blocks(c):
+                return True
+    return False
+
+
+def table_has_rich_cells(node: Node) -> bool:
+    for c in node.children:
+        if isinstance(c, Node):
+            if c.tag in ("td", "th") and cell_has_blocks(c):
+                return True
+            if table_has_rich_cells(c):
+                return True
+    return False
+
+
+def attrs_str(attrs: dict[str, str]) -> str:
+    if not attrs:
+        return ""
+    return " " + " ".join(f'{k}="{html.escape(v, quote=True)}"' for k, v in attrs.items())
+
+
+def node_to_html(node: Node | str, source_dir: Path) -> str:
+    if isinstance(node, str):
+        return html.escape(html.unescape(node))
+    tag = node.tag or ""
+    if tag in VOID_TAGS:
+        return f"<{tag}{attrs_str(node.attrs)}/>"
+    inner = "".join(node_to_html(c, source_dir) for c in node.children)
+    if tag == "a":
+        href = convert_href(node.attrs.get("href", ""), source_dir)
+        return f'<a href="{html.escape(href, quote=True)}">{inner}</a>'
+    if tag == "code":
+        return f"<code>{inner}</code>"
+    if tag in ("em", "i"):
+        return f"<em>{inner}</em>"
+    if tag in ("strong", "b"):
+        return f"<strong>{inner}</strong>"
+    if tag == "br":
+        return "<br/>"
+    if tag == "pre":
+        code = node.text_content()
+        return f"<pre><code>{code}</code></pre>"
+    if tag == "mdx-warning":
+        return f"<Warning><strong>Important:</strong> {inner}</Warning>"
+    if tag == "mdx-note":
+        return f"<Note><strong>Note:</strong> {inner}</Note>"
+    if tag == "p":
+        text = "".join(
+            node_to_html(c, source_dir) if isinstance(c, Node) else html.escape(html.unescape(c))
+            for c in node.children
+        ).strip()
+        return f"<p>{text}</p>" if text else ""
+    if tag == "ul":
+        items = "".join(
+            f"<li>{node_to_html(c, source_dir)}</li>"
+            for c in node.children
+            if isinstance(c, Node) and c.tag == "li"
+        )
+        return f"<ul>{items}</ul>"
+    if tag == "li":
+        return inner
+    return f"<{tag}{attrs_str(node.attrs)}>{inner}</{tag}>"
+
+
+def inline_md(node: Node | str, source_dir: Path) -> str:
+    if isinstance(node, str):
+        return html.unescape(node)
+    tag = node.tag or ""
+    kids = "".join(inline_md(c, source_dir) for c in node.children)
+
+    if tag == "a":
+        href = convert_href(node.attrs.get("href", ""), source_dir)
+        text = kids.strip() or href
+        return f"[{text}]({href})"
+    if tag == "code":
+        return f"`{kids}`"
+    if tag in ("em", "i"):
+        return f"*{kids}*"
+    if tag in ("strong", "b"):
+        return f"**{kids}**"
+    if tag == "br":
+        return "\n"
+    if tag == "mdx-warning":
+        return f"\n<Warning>\n**Important:**\n\n{kids.strip()}\n</Warning>\n"
+    if tag == "mdx-note":
+        return f"\n<Note>\n**Note:**\n\n{kids.strip()}\n</Note>\n"
+    if tag == "mdx-frame":
+        img = next((c for c in node.children if isinstance(c, Node) and c.tag == "img"), None)
+        if img:
+            alt = img.attrs.get("alt", "")
+            src = img.attrs.get("src", "")
+            return f"\n<Frame>\n![{alt}]({src})\n</Frame>\n"
+    if tag == "img":
+        alt = node.attrs.get("alt", "")
+        src = node.attrs.get("src", "")
+        return f"\n<Frame>\n![{alt}]({src})\n</Frame>\n"
+    if tag in ("ul", "ol", "li", "p", "h1", "h2", "h3", "h4", "pre", "table", "tr", "td", "th"):
+        return kids
+    return kids
+
+
+def block_md(node: Node, source_dir: Path, depth: int = 0) -> str:
+    if isinstance(node, str):
+        return html.unescape(node)
+    tag = node.tag or ""
+    indent = "  " * depth
+
+    if tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+        level = int(tag[1])
+        text = inline_md(node, source_dir).strip()
+        return f"\n{'#' * level} {text}\n\n"
+
+    if tag == "p":
+        text = inline_md(node, source_dir).strip()
+        return f"{text}\n\n" if text else ""
+
+    if tag == "pre":
+        lang = node.attrs.get("data-lang", "txt") or "txt"
+        code = html.unescape(node.text_content())
+        return f"\n```{lang}\n{code}\n```\n\n"
+
+    if tag == "ul":
+        lines: list[str] = []
+        for c in node.children:
+            if isinstance(c, Node) and c.tag == "li":
+                item = block_md(c, source_dir, depth).strip()
+                item_lines = item.split("\n")
+                lines.append(f"{indent}- {item_lines[0]}")
+                for extra in item_lines[1:]:
+                    lines.append(f"{indent}  {extra}")
+        return "\n".join(lines) + "\n\n"
+
+    if tag == "ol":
+        lines = []
+        n = 0
+        for c in node.children:
+            if isinstance(c, Node) and c.tag == "li":
+                n += 1
+                item = block_md(c, source_dir, depth).strip()
+                item_lines = item.split("\n")
+                lines.append(f"{indent}{n}. {item_lines[0]}")
+                for extra in item_lines[1:]:
+                    lines.append(f"{indent}   {extra}")
+        return "\n".join(lines) + "\n\n"
+
+    if tag == "li":
+        parts: list[str] = []
+        for c in node.children:
+            if isinstance(c, Node) and c.tag in ("ul", "ol"):
+                parts.append("\n" + block_md(c, source_dir, depth + 1).rstrip())
+            elif isinstance(c, Node) and c.tag == "p":
+                parts.append(inline_md(c, source_dir).strip())
+            else:
+                parts.append(inline_md(c, source_dir))
+        return "".join(parts).strip()
+
+    if tag == "table":
+        if table_has_rich_cells(node):
+            return "\n" + node_to_html(node, source_dir) + "\n\n"
+        rows: list[list[str]] = []
+        for c in node.children:
+            if isinstance(c, Node) and c.tag in ("thead", "tbody", "tr"):
+                if c.tag == "tr":
+                    rows.append([inline_md(cell, source_dir).strip() for cell in c.children if isinstance(cell, Node) and cell.tag in ("td", "th")])
+                else:
+                    for row in c.children:
+                        if isinstance(row, Node) and row.tag == "tr":
+                            rows.append([inline_md(cell, source_dir).strip() for cell in row.children if isinstance(cell, Node) and cell.tag in ("td", "th")])
+        if not rows:
+            return ""
+        out = ["| " + " | ".join(rows[0]) + " |", "| " + " | ".join("---" for _ in rows[0]) + " |"]
+        for row in rows[1:]:
+            while len(row) < len(rows[0]):
+                row.append("")
+            out.append("| " + " | ".join(row[: len(rows[0])]) + " |")
+        return "\n".join(out) + "\n\n"
+
+    if tag == "dl":
+        parts: list[str] = []
+        for c in node.children:
+            if isinstance(c, Node) and c.tag == "dt":
+                parts.append(f"\n#### {inline_md(c, source_dir).strip()}\n\n")
+            elif isinstance(c, Node) and c.tag == "dd":
+                for child in c.children:
+                    if isinstance(child, Node):
+                        parts.append(block_md(child, source_dir, depth))
+                    else:
+                        t = html.unescape(child).strip()
+                        if t:
+                            parts.append(t + "\n\n")
+            elif isinstance(c, Node):
+                parts.append(block_md(c, source_dir, depth))
+        return "".join(parts)
+
+    if tag in ("dt", "dd"):
+        return ""
+
+    if tag in ("thead", "tbody", "tr", "td", "th"):
+        return ""
+
+    if tag in ("mdx-warning", "mdx-note", "mdx-frame"):
+        return inline_md(node, source_dir)
+
+    if tag == "root":
+        parts = []
+        for c in node.children:
+            if isinstance(c, Node):
+                parts.append(block_md(c, source_dir, depth))
+            else:
+                t = html.unescape(c).strip()
+                if t:
+                    parts.append(t + "\n\n")
+        result = "".join(parts)
+        result = re.sub(r"\n{3,}", "\n\n", result)
+        # Strip HTML-source indentation from prose lines
+        result = re.sub(r"(?m)^  +(?![\s`-])", "", result)
+        return result.strip() + "\n"
+
+    # default: render children
+    return "".join(
+        block_md(c, source_dir, depth) if isinstance(c, Node) else html.unescape(c)
+        for c in node.children
+    )
+
+
+def first_description(root: Node) -> str:
+    for c in root.children:
+        if isinstance(c, Node) and c.tag == "p":
+            text = c.text_content()
+            text = re.sub(r"\s+", " ", text).strip()
+            if len(text) > 200:
+                text = text[:197].rsplit(" ", 1)[0] + "..."
+            return text
+    return ""
+
+
+def convert_file(path: Path) -> None:
+    raw = path.read_text(encoding="utf-8")
+    meta, body = parse_frontmatter(raw)
+    title = meta.get("title", path.stem.replace("-", " ").title())
+
+    if path.suffix == ".md" and not body.strip().startswith("<"):
+        # Pure markdown source
+        mdx_body = body.strip() + "\n"
+        desc_m = re.search(r"^([^\n#].+?\.)", mdx_body, re.MULTILINE)
+        description = desc_m.group(1).strip() if desc_m else f"{title} in Vespa applications."
+        out_path = path.with_suffix(".mdx")
+        out_path.write_text(
+            f'---\ntitle: "{title}"\ndescription: {description}\n---\n\n{mdx_body}',
+            encoding="utf-8",
+        )
+        if path != out_path:
+            path.unlink()
+        print(f"Converted {path.name} -> {out_path.name}")
+        return
+
+    body = preprocess_body(body.strip())
+    builder = TreeBuilder()
+    builder.feed(f"<body>{body}</body>")
+    builder.close()
+    mdx_body = block_md(builder.root, path.parent)
+    description = first_description(builder.root) or f"{title} in Vespa applications."
+
+    out_path = path.with_suffix(".mdx")
+    out_path.write_text(
+        f'---\ntitle: "{title}"\ndescription: {description}\n---\n\n{mdx_body}',
+        encoding="utf-8",
+    )
+    if path.suffix == ".html":
+        path.unlink()
+    elif path.suffix == ".md":
+        path.unlink()
+    print(f"Converted {path.name} -> {out_path.name}")
+
+
+def main() -> None:
+    for mdx in APPS_DIR.glob("*.mdx"):
+        mdx.unlink()
+    # Restore HTML from git if missing
+    import subprocess
+
+    html_files = list(APPS_DIR.glob("*.html"))
+    if not html_files:
+        subprocess.run(
+            ["git", "checkout", "HEAD", "--", "en/applications/*.html"],
+            cwd=APPS_DIR.parent.parent,
+            check=False,
+        )
+    targets = sorted(APPS_DIR.glob("*.html"))
+    zk = APPS_DIR / "using-zookeeper.md"
+    if not zk.exists():
+        subprocess.run(
+            ["git", "show", "HEAD:en/applications/using-zookeeper.md"],
+            cwd=APPS_DIR.parent.parent,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    if zk.exists():
+        targets.append(zk)
+    for p in targets:
+        convert_file(p)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indent_code_blocks.py
+++ b/scripts/indent_code_blocks.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Indent content inside fenced code blocks in MDX files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+APPS_DIR = Path(__file__).resolve().parent.parent / "en" / "applications"
+PAD = "    "
+
+
+def looks_like_xml(code: str) -> bool:
+    s = code.strip()
+    return s.startswith("<") or "<services" in s or "<container" in s or "<chain" in s
+
+
+def looks_like_java(code: str) -> bool:
+    return (
+        "import " in code
+        or "public class" in code
+        or "public void" in code
+        or "@Override" in code
+        or "extends " in code
+    )
+
+
+def indent_xml(code: str) -> str:
+    lines = code.split("\n")
+    out: list[str] = []
+    level = 0
+    stack: list[str] = []
+    for raw in lines:
+        s = raw.strip()
+        if not s:
+            out.append("")
+            continue
+        if s.startswith("<?") or s.startswith("<!--"):
+            out.append(s)
+            continue
+        if s in ("...", "…"):
+            out.append(PAD * level + s)
+            continue
+        if s.startswith("</"):
+            tag = re.match(r"</(\w+)", s)
+            if tag and stack and stack[-1] == tag.group(1):
+                stack.pop()
+                level = max(0, level - 1)
+            elif level > 0:
+                level -= 1
+            out.append(PAD * level + s)
+            continue
+        if s.endswith("/>") or re.match(r"<[^>]+>.*</[^>]+>$", s):
+            out.append(PAD * level + s)
+            continue
+        if s.startswith("<"):
+            tag = re.match(r"<(\w+)", s)
+            out.append(PAD * level + s)
+            if tag and not s.endswith("/>") and "</" not in s[1:]:
+                stack.append(tag.group(1))
+                level += 1
+            continue
+        out.append(PAD * level + s)
+    return "\n".join(out)
+
+
+def indent_java(code: str) -> str:
+    """Basic Java brace-based indentation for flattened blocks."""
+    if "\n" in code and code.count("\n") > 3:
+        # Already multiline — normalize brace indent only
+        lines = code.split("\n")
+    else:
+        # Single line or few lines — split on common tokens
+        s = code.strip()
+        if "{" not in s and ";" not in s:
+            return code
+        # Split after ; and { } for readability
+        s = re.sub(r"\s*;\s*", ";\n", s)
+        s = re.sub(r"\s*\{\s*", " {\n", s)
+        s = re.sub(r"\s*\}\s*", "\n}\n", s)
+        lines = [ln.strip() for ln in s.split("\n") if ln.strip()]
+
+    out: list[str] = []
+    level = 0
+    for line in lines:
+        s = line.strip()
+        if not s:
+            continue
+        if s.startswith("}"):
+            level = max(0, level - 1)
+        out.append(PAD * level + s)
+        if s.endswith("{") and not s.startswith("}"):
+            level += 1
+    return "\n".join(out)
+
+
+def indent_shell(code: str) -> str:
+    lines = code.split("\n")
+    out = []
+    for line in lines:
+        s = line.strip()
+        if not s:
+            out.append("")
+            continue
+        if s.endswith("\\"):
+            out.append(s)
+        elif s.startswith("-D") or s.startswith("$"):
+            out.append(s)
+        else:
+            out.append(s)
+    return "\n".join(out)
+
+
+def indent_block(code: str, lang: str) -> str:
+    lang = (lang or "").lower()
+    if lang in ("xml", "txt", "yaml", "yml") and looks_like_xml(code):
+        return indent_xml(code)
+    if lang in ("java",) or looks_like_java(code):
+        return indent_java(code)
+    if lang in ("bash", "shell", "sh") and code.strip().startswith("$"):
+        return indent_shell(code)
+    if looks_like_xml(code):
+        return indent_xml(code)
+    return code
+
+
+def process_file(path: Path) -> bool:
+    text = path.read_text(encoding="utf-8")
+    parts = re.split(r"(^```[\w-]*\n)(.*?)(^```\s*$)", text, flags=re.MULTILINE | re.DOTALL)
+    if len(parts) < 2:
+        return False
+
+    changed = False
+    new_parts = [parts[0]]
+    i = 1
+    while i < len(parts):
+        if i + 2 < len(parts) and parts[i].startswith("```"):
+            fence_open = parts[i]
+            body = parts[i + 1]
+            fence_close = parts[i + 2]
+            lang_match = re.match(r"^```([\w-]*)", fence_open)
+            lang = lang_match.group(1) if lang_match else ""
+            new_body = indent_block(body.rstrip("\n"), lang)
+            if new_body != body.rstrip("\n"):
+                changed = True
+            new_parts.append(fence_open)
+            new_parts.append(new_body + "\n")
+            new_parts.append(fence_close)
+            i += 3
+        else:
+            new_parts.append(parts[i])
+            i += 1
+
+    if changed:
+        path.write_text("".join(new_parts), encoding="utf-8")
+    return changed
+
+
+def main() -> None:
+    for path in sorted(APPS_DIR.glob("*.mdx")):
+        if process_file(path):
+            print(f"Updated {path.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/join_paragraphs.py
+++ b/scripts/join_paragraphs.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Join wrapped prose lines into single lines in MDX files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def is_fence(line: str) -> bool:
+    return line.strip().startswith("```")
+
+
+def is_structural(line: str) -> bool:
+    s = line.strip()
+    if not s:
+        return False
+    if re.match(r"^#{1,6}\s", s):
+        return True
+    if re.match(
+        r"^</?(Accordion|AccordionGroup|Warning|Note|Frame|Steps|Step|Card|Tabs|Tab|Info|Tip|Check|Callout|Danger)\b",
+        s,
+    ):
+        return True
+    if re.match(r"^</?(table|tbody|thead|tr|th|td|caption|dl|dt|dd)\b", s, re.I):
+        return True
+    if s == "---":
+        return True
+    if re.match(r"^(title|sidebarTitle|description):", s):
+        return True
+    if s.startswith("{/*") or s.endswith("*/}") or s == "*/}":
+        return True
+    if re.match(r"^\|", s):
+        return True
+    if re.match(r"^!\[", s):
+        return True
+    if s.startswith("{`") or (s.startswith("{") and "$$" in s):
+        return True
+    if re.match(r"^####\s", s):
+        return True
+    return False
+
+
+def is_list_item(line: str) -> bool:
+    return bool(re.match(r"^\s*[-*]\s+", line)) or bool(re.match(r"^\s*\d+\.\s+", line))
+
+
+def join_lines(group: list[str]) -> str:
+    return " ".join(l.strip() for l in group)
+
+
+def join_p_block(lines: list[str]) -> str:
+    """Join a multi-line <p>...</p> block into one line."""
+    text = " ".join(l.strip() for l in lines)
+    return re.sub(r"\s+", " ", text)
+
+
+def process_block(block: list[str]) -> list[str]:
+    result: list[str] = []
+    i = 0
+    while i < len(block):
+        line = block[i]
+        s = line.strip()
+        if s.startswith("<p") and "</p>" not in s:
+            group = [line]
+            i += 1
+            while i < len(block) and "</p>" not in block[i]:
+                group.append(block[i])
+                i += 1
+            if i < len(block):
+                group.append(block[i])
+                i += 1
+            result.append(join_p_block(group))
+            continue
+        if is_structural(line):
+            result.append(line)
+            i += 1
+            continue
+        if is_list_item(line):
+            group = [line]
+            i += 1
+            while i < len(block) and not is_list_item(block[i]) and not is_structural(block[i]):
+                if block[i].strip().startswith("<p"):
+                    break
+                group.append(block[i])
+                i += 1
+            result.append(join_lines(group))
+            continue
+        group = [line]
+        i += 1
+        while i < len(block) and not is_list_item(block[i]) and not is_structural(block[i]):
+            if block[i].strip().startswith("<p"):
+                break
+            group.append(block[i])
+            i += 1
+        result.append(join_lines(group))
+    return result
+
+
+def process_file(path: Path) -> tuple[int, int]:
+    lines = path.read_text(encoding="utf-8").split("\n")
+    output: list[str] = []
+    i = 0
+    in_code = False
+    in_frontmatter = False
+    fm_count = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        if i == 0 and line.strip() == "---":
+            in_frontmatter = True
+            fm_count = 1
+
+        if in_frontmatter:
+            output.append(line)
+            if line.strip() == "---" and fm_count > 0 and i > 0:
+                fm_count += 1
+                if fm_count >= 2:
+                    in_frontmatter = False
+            i += 1
+            continue
+
+        if is_fence(line):
+            in_code = not in_code
+            output.append(line)
+            i += 1
+            continue
+        if in_code:
+            output.append(line)
+            i += 1
+            continue
+        if not line.strip():
+            output.append(line)
+            i += 1
+            continue
+
+        block: list[str] = []
+        while i < len(lines) and lines[i].strip() and not is_fence(lines[i]):
+            block.append(lines[i])
+            i += 1
+        output.extend(process_block(block))
+
+    before = len(lines)
+    after = len(output)
+    path.write_text("\n".join(output), encoding="utf-8")
+    return before, after
+
+
+def main() -> None:
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / "en" / "reference" / "api"
+    if target.is_file():
+        paths = [target]
+    else:
+        paths = sorted(target.glob("*.mdx"))
+    for path in paths:
+        before, after = process_file(path)
+        print(f"{path.name}: {before} -> {after} lines")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mdx_html_tables.py
+++ b/scripts/mdx_html_tables.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Convert HTML tables in MDX files to Mintlify markdown tables."""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+from html_to_mdx import Node, TreeBuilder, convert_href, preprocess_body
+
+TABLE_TAG_RE = re.compile(r"<table\b", re.IGNORECASE)
+H2_HTML_RE = re.compile(r'<h2\s+id="[^"]*">\s*([^<]+?)\s*</h2>', re.IGNORECASE)
+HR_RE = re.compile(r"<hr\s*/?>", re.IGNORECASE)
+
+
+def fix_short_td_rows(html_text: str) -> str:
+    def repl(m: re.Match) -> str:
+        row = m.group(0)
+        if "</td>" in row or "</th>" in row:
+            return row
+        pieces = re.split(r"(?=<t[dh]\b)", row)
+        out = [pieces[0]]
+        for piece in pieces[1:]:
+            tag_m = re.match(r"(<t[dh][^>]*>)([\s\S]*)", piece, re.I)
+            if not tag_m:
+                continue
+            tag, rest = tag_m.groups()
+            content = re.split(r"(?=</tr>)", rest, maxsplit=1)[0].strip()
+            close = "</th>" if tag.lower().startswith("<th") else "</td>"
+            out.append(f"{tag}{content}{close}")
+        if "</tr>" in row and not out[-1].endswith("</tr>"):
+            out.append("</tr>")
+        return "".join(out)
+
+    return re.sub(r"<tr[\s\S]*?</tr>", repl, html_text, flags=re.IGNORECASE)
+
+
+def fix_html_structure(body: str) -> str:
+    body = re.sub(
+        r"(<p(?:\s[^>]*)?>(?:(?!</p>)[\s\S])*?)(\s*</td>)",
+        r"\1</p>\2",
+        body,
+        flags=re.IGNORECASE,
+    )
+    body = re.sub(
+        r"(<li>(?:(?!</li>)[\s\S])*?)(\s*<li>)",
+        lambda m: m.group(1) + "</li>" + m.group(2),
+        body,
+    )
+    body = fix_short_td_rows(body)
+    body = re.sub(
+        r"<tr><th rowspan=\"2\">Value\s*<th colspan=\"3\">Results in</tr>\s*"
+        r"<tr>\s*(?:<th>)?composite</th><th>tokenization</th><th>syntax</th></tr>",
+        "<tr><th>Value</th><th>composite</th><th>tokenization</th><th>syntax</th></tr>",
+        body,
+        flags=re.IGNORECASE,
+    )
+    body = re.sub(
+        r"(<tr>(?:(?!</tr>)[\s\S])*?)(</table>)",
+        lambda m: m.group(1) + "</td></tr>" + m.group(2),
+        body,
+        flags=re.IGNORECASE,
+    )
+    return body
+
+
+def escape_cell(text: str) -> str:
+    text = text.replace("\n", " ").replace("\r", "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text.replace("|", "\\|")
+
+
+def emit_inline(node: Node | str, source_dir: Path) -> str:
+    if isinstance(node, str):
+        return html.unescape(node)
+    tag = node.tag or ""
+    inner = "".join(emit_inline(c, source_dir) for c in node.children)
+    if tag == "br":
+        return "<br />"
+    if tag == "a":
+        href = convert_href(node.attrs.get("href", ""), source_dir)
+        text = inner.strip() or href
+        return f"[{text}]({href})"
+    if tag == "code":
+        return f"`{inner}`"
+    if tag == "pre":
+        code = html.unescape(node.text_content()).strip()
+        if "\n" in code:
+            return " ".join(f"`{line.strip()}`" for line in code.split("\n") if line.strip())
+        return f"`{code}`"
+    if tag in ("em", "i"):
+        return f"*{inner}*"
+    if tag in ("strong", "b"):
+        return f"**{inner}**"
+    if tag == "mdx-warning":
+        return f"**Important:** {inner.strip()}"
+    if tag == "mdx-note":
+        return f"**Note:** {inner.strip()}"
+    return inner
+
+
+def table_end(html_text: str, start: int) -> int:
+    j = html_text.find(">", start) + 1
+    depth = 1
+    while j < len(html_text) and depth > 0:
+        next_open = html_text.find("<table", j)
+        next_close = html_text.find("</table>", j)
+        if next_close == -1:
+            return len(html_text)
+        if next_open != -1 and next_open < next_close:
+            depth += 1
+            j = html_text.find(">", next_open) + 1
+        else:
+            depth -= 1
+            j = next_close + len("</table>")
+    return j
+
+
+def isolate_nested_tables(table_html: str) -> tuple[str, list[str]]:
+    nested: list[str] = []
+    first = TABLE_TAG_RE.search(table_html)
+    if not first:
+        return table_html, nested
+    pos = first.end()
+    while True:
+        m = TABLE_TAG_RE.search(table_html[pos:])
+        if not m:
+            break
+        start = pos + m.start()
+        end = table_end(table_html, start)
+        nested.append(table_html[start:end])
+        placeholder = f"<!--NESTED{len(nested) - 1}-->"
+        table_html = table_html[:start] + placeholder + table_html[end:]
+        pos = start + len(placeholder)
+    return table_html, nested
+
+
+def restore_nested(fragment: str, nested: list[str]) -> str:
+    for i, table_html in enumerate(nested):
+        fragment = fragment.replace(f"<!--NESTED{i}-->", table_html)
+    return fragment
+
+
+def normalize_table_html(table_html: str) -> str:
+    def fence_sub(m: re.Match) -> str:
+        lang = m.group(1) or "txt"
+        code = html.escape(m.group(2).strip("\n"))
+        return f'<pre data-lang="{lang}">{code}</pre>'
+
+    table_html = re.sub(r"```(\w*)\n([\s\S]*?)```", fence_sub, table_html)
+    return preprocess_body(fix_html_structure(table_html))
+
+
+def nested_table_to_md_html(table_html: str, source_dir: Path) -> str:
+    header, body_rows = extract_rows(table_html, source_dir)
+    if not header or not body_rows:
+        return ""
+    if len(header) == 4 and all(len(r) >= 4 for r in body_rows):
+        return " ".join(
+            f"`{row[0]}` → composite `{row[1]}`, tokenization `{row[2]}`, syntax `{row[3]}`"
+            for row in body_rows
+        )
+    lines: list[str] = []
+    for row in body_rows:
+        while len(row) < len(header):
+            row.append("")
+        parts = [f"**{h}:** {v}" for h, v in zip(header, row) if v.strip()]
+        if parts:
+            lines.append("; ".join(parts))
+    return "<br />".join(lines)
+
+
+def emit_cell_node(node: Node, source_dir: Path, nested: list[str] | None = None) -> str:
+    parts: list[str] = []
+    for c in node.children:
+        if isinstance(c, str):
+            text = c.strip()
+            for m in re.finditer(r"<!--NESTED(\d+)-->", text):
+                if nested:
+                    parts.append(nested_table_to_md_html(nested[int(m.group(1))], source_dir))
+            text = re.sub(r"<!--NESTED\d+-->", "", text).strip()
+            if text:
+                parts.append(html.unescape(text))
+        elif isinstance(c, Node):
+            if c.tag == "table":
+                parts.append(nested_table_to_md_html(node_to_html_table(node), source_dir))
+            elif c.tag in ("ul", "ol"):
+                for li in c.children:
+                    if isinstance(li, Node) and li.tag == "li":
+                        parts.append(emit_inline(li, source_dir).strip())
+            elif c.tag == "p":
+                text = emit_inline(c, source_dir).strip()
+                if text:
+                    parts.append(text)
+            elif c.tag == "pre":
+                text = emit_inline(c, source_dir).strip()
+                if text:
+                    parts.append(text)
+            elif c.tag in ("mdx-warning", "mdx-note"):
+                parts.append(emit_inline(c, source_dir).strip())
+            else:
+                text = emit_inline(c, source_dir).strip()
+                if text:
+                    parts.append(text)
+    return " ".join(parts)
+
+
+def node_to_html_table(node: Node) -> str:
+    tag = node.tag or ""
+    inner = "".join(node_to_html_table_part(c) for c in node.children)
+    attrs = " ".join(f'{k}="{html.escape(v, quote=True)}"' for k, v in node.attrs.items())
+    open_tag = f"<{tag} {attrs}>" if attrs else f"<{tag}>"
+    return f"{open_tag}{inner}</{tag}>"
+
+
+def node_to_html_table_part(node: Node | str) -> str:
+    if isinstance(node, str):
+        return html.unescape(node)
+    tag = node.tag or ""
+    inner = "".join(node_to_html_table_part(c) for c in node.children)
+    attrs = " ".join(f'{k}="{html.escape(v, quote=True)}"' for k, v in node.attrs.items())
+    open_tag = f"<{tag} {attrs}>" if attrs else f"<{tag}>"
+    return f"{open_tag}{inner}</{tag}>"
+
+
+def tr_cells_from_inner(tr_inner: str, nested: list[str], source_dir: Path) -> list[str]:
+    inner = restore_nested(tr_inner, nested)
+    builder = TreeBuilder()
+    builder.feed(f"<tr>{inner}</tr>")
+    builder.close()
+    tr = next(c for c in builder.root.children if isinstance(c, Node) and c.tag == "tr")
+    cells: list[str] = []
+    for c in tr.children:
+        if isinstance(c, Node) and c.tag == "th":
+            cells.append(escape_cell(emit_inline(c, source_dir)))
+        elif isinstance(c, Node) and c.tag == "td":
+            cells.append(escape_cell(emit_cell_node(c, source_dir, nested)))
+    return cells
+
+
+def infer_header(first_row: list[str]) -> list[str]:
+    n = len(first_row)
+    if n == 2:
+        return ["Term", "Description"]
+    if n == 3:
+        return ["Name", "Default", "Description"]
+    if n == 4:
+        return ["Name", "Type", "Default", "Description"]
+    return [f"Column {i + 1}" for i in range(n)]
+
+
+def extract_rows(table_html: str, source_dir: Path) -> tuple[list[str], list[list[str]]]:
+    table_html = normalize_table_html(table_html)
+    header: list[str] = []
+    body_rows: list[list[str]] = []
+    isolated, nested = isolate_nested_tables(table_html)
+    thead = re.search(r"<thead>([\s\S]*?)</thead>", isolated, re.I)
+    if thead:
+        htr = re.search(r"<tr[^>]*>([\s\S]*?)</tr>", thead.group(1), re.I)
+        if htr:
+            header = tr_cells_from_inner(htr.group(1), [], source_dir)
+    tbody = re.search(r"<tbody>([\s\S]*?)</tbody>", isolated, re.I)
+    chunk = tbody.group(1) if tbody else isolated
+    for tr in re.finditer(r"<tr[^>]*>([\s\S]*?)</tr>", chunk, re.I):
+        cells = tr_cells_from_inner(tr.group(1), nested, source_dir)
+        if cells and any(c.strip() for c in cells):
+            body_rows.append(cells)
+    if not header and body_rows:
+        header = infer_header(body_rows[0])
+    return header, body_rows
+
+
+def html_table_to_markdown(table_html: str, source_dir: Path) -> str:
+    caption_m = re.search(r"<caption>([\s\S]*?)</caption>", table_html, re.I)
+    caption = html.unescape(caption_m.group(1)).strip() if caption_m else ""
+    header, body_rows = extract_rows(table_html, source_dir)
+    if not header:
+        return table_html
+    ncol = len(header)
+    lines: list[str] = []
+    if caption:
+        lines.extend([f"*{caption}*", ""])
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join("---" for _ in header) + " |")
+    for row in body_rows:
+        while len(row) < ncol:
+            row.append("")
+        lines.append("| " + " | ".join(row[:ncol]) + " |")
+    return "\n".join(lines) + "\n\n"
+
+
+def inline_html_to_md(fragment: str, source_dir: Path) -> str:
+    if not fragment.strip():
+        return ""
+    work = preprocess_body(fragment.strip())
+    builder = TreeBuilder()
+    builder.feed(f"<div>{work}</div>")
+    builder.close()
+    parts: list[str] = []
+    for c in builder.root.children:
+        if not isinstance(c, Node):
+            continue
+        if c.tag == "div":
+            for cc in c.children:
+                if isinstance(cc, Node) and cc.tag == "p":
+                    text = emit_inline(cc, source_dir).strip()
+                    if text:
+                        parts.append(text)
+                elif isinstance(cc, Node) and cc.tag in ("ul", "ol"):
+                    for li in cc.children:
+                        if isinstance(li, Node) and li.tag == "li":
+                            parts.append(f"- {emit_inline(li, source_dir).strip()}")
+        elif c.tag == "p":
+            text = emit_inline(c, source_dir).strip()
+            if text:
+                parts.append(text)
+    return "\n\n".join(parts) + ("\n\n" if parts else "")
+
+
+def extract_all_tables(fragment: str) -> list[tuple[int, int, str]]:
+    tables: list[tuple[int, int, str]] = []
+    pos = 0
+    while True:
+        m = TABLE_TAG_RE.search(fragment[pos:])
+        if not m:
+            break
+        start = pos + m.start()
+        end = table_end(fragment, start)
+        tables.append((start, end, fragment[start:end]))
+        pos = end
+    return tables
+
+
+def convert_html_fragment(fragment: str, source_dir: Path) -> str:
+    fragment = H2_HTML_RE.sub(r"## \1\n\n", fragment)
+    out: list[str] = []
+    pos = 0
+    for start, end, table_html in extract_all_tables(fragment):
+        before = fragment[pos:start]
+        if before.strip():
+            out.append(inline_html_to_md(before, source_dir))
+        md = html_table_to_markdown(table_html, source_dir)
+        if md and not md.startswith("<table"):
+            out.append(md)
+        else:
+            out.append(table_html)
+        pos = end
+    rest = fragment[pos:]
+    if rest.strip():
+        out.append(inline_html_to_md(rest, source_dir))
+    text = "".join(out)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    if not text.startswith("---"):
+        return "", text
+    m = re.match(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", text, re.DOTALL)
+    if not m:
+        return "", text
+    return text[: m.end()], text[m.end() :]
+
+
+def convert_mdx_file(path: Path) -> bool:
+    original = path.read_text(encoding="utf-8")
+    if "<table" not in original.lower():
+        return False
+    fm, body = split_frontmatter(original)
+    converted = convert_html_fragment(body, path.parent)
+    if converted == body:
+        return False
+    fm_out = fm.rstrip("\n") + "\n"
+    body_out = converted.lstrip("\n")
+    path.write_text(fm_out + body_out, encoding="utf-8")
+    return True
+
+
+def convert_tree(root: Path) -> int:
+    count = 0
+    for path in sorted(root.rglob("*.mdx")):
+        if convert_mdx_file(path):
+            print(f"Converted tables in {path.relative_to(root.parent.parent)}")
+            count += 1
+    return count

--- a/scripts/unescape-mdx-code.ps1
+++ b/scripts/unescape-mdx-code.ps1
@@ -1,0 +1,104 @@
+# Remove unnecessary markdown escape backslashes inside ``` fences and inline `code`
+$root = Resolve-Path (Join-Path $PSScriptRoot "..")
+$dirs = @("en\querying", "en\writing", "en\schemas")
+
+function Unescape-CodeText([string]$text) {
+    if ([string]::IsNullOrEmpty($text)) { return $text }
+
+    $lines = $text -split "`n", -1
+    $result = New-Object System.Collections.Generic.List[string]
+
+    foreach ($line in $lines) {
+        $trimmed = $line.TrimEnd()
+        $trail = $line.Substring($trimmed.Length)
+        $hasLineCont = $trimmed -match '\\$'
+
+        if ($hasLineCont) {
+            $work = $trimmed.Substring(0, $trimmed.Length - 1)
+        } else {
+            $work = $trimmed
+        }
+
+        $placeholder = @{}
+        $i = 0
+        $work = [regex]::Replace($work, '\\{2,}', {
+            param($m)
+            $key = "___BS$($i)___"
+            $placeholder[$key] = $m.Value
+            $script:i++
+            return $key
+        })
+        $work = [regex]::Replace($work, '\\["'']', {
+            param($m)
+            $key = "___QS$($i)___"
+            $placeholder[$key] = $m.Value
+            $script:i++
+            return $key
+        })
+
+        $work = $work -replace '\\([*_\[\]{}|.+#&?-])', '$1'
+
+        foreach ($kv in $placeholder.GetEnumerator()) {
+            $work = $work.Replace($kv.Key, $kv.Value)
+        }
+
+        if ($hasLineCont) { $work += '\' }
+        $result.Add($work + $trail)
+    }
+
+    return ($result -join "`n")
+}
+
+function Process-InlineCode([string]$segment) {
+    $parts = [regex]::Split($segment, '(`[^`]+`)')
+    for ($j = 0; $j -lt $parts.Length; $j++) {
+        if ($j % 2 -eq 1) {
+            $inner = $parts[$j].Substring(1, $parts[$j].Length - 2)
+            $parts[$j] = '`' + (Unescape-CodeText $inner) + '`'
+        }
+    }
+    return ($parts -join '')
+}
+
+function Process-FenceBody([string]$body) {
+    if ($body -match '^(?m)^') {
+        $nl = $body.IndexOf("`n")
+        if ($nl -lt 0) { return $body }
+        $langLine = $body.Substring(0, $nl + 1)
+        $code = $body.Substring($nl + 1)
+        return $langLine + (Unescape-CodeText $code)
+    }
+    return (Unescape-CodeText $body)
+}
+
+$files = foreach ($d in $dirs) {
+    Get-ChildItem (Join-Path $root $d) -Recurse -Filter "*.mdx"
+}
+
+foreach ($file in $files) {
+    $content = [IO.File]::ReadAllText($file.FullName)
+    $original = $content
+    $parts = [regex]::Split($content, '(```)')
+    $inFence = $false
+
+    for ($i = 0; $i -lt $parts.Length; $i++) {
+        $part = $parts[$i]
+        if ($part -eq '```') {
+            $inFence = -not $inFence
+            continue
+        }
+        if ($inFence) {
+            $parts[$i] = Process-FenceBody $part
+        } else {
+            $parts[$i] = Process-InlineCode $part
+        }
+    }
+
+    $newContent = ($parts -join '')
+    if ($newContent -ne $original) {
+        [IO.File]::WriteAllText($file.FullName, $newContent)
+        Write-Output "updated: $($file.Name)"
+    }
+}
+
+Write-Output "done. $($files.Count) files scanned."

--- a/scripts/wrap_steps.py
+++ b/scripts/wrap_steps.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Wrap sequential numbered lists in Mintlify Steps/Step components."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+APPS_DIR = Path(__file__).resolve().parent.parent / "en" / "applications"
+STEP_START = re.compile(r"^(\d+)\.\s+(.*)$")
+HEADING = re.compile(r"^#{1,6}\s")
+STRUCTURAL = re.compile(
+    r"^</?(Steps|Step|Frame|Warning|Note|Accordion|AccordionGroup)\b"
+)
+
+
+def is_fence(line: str) -> bool:
+    return line.strip().startswith("```")
+
+
+def collect_numbered_block(lines: list[str], start: int) -> tuple[list[list[str]], int] | None:
+    """Collect a sequential 1..n numbered list starting at `start`. Returns steps, end index."""
+    if start >= len(lines):
+        return None
+    m = STEP_START.match(lines[start])
+    if not m or m.group(1) != "1":
+        return None
+
+    steps: list[list[str]] = []
+    current: list[str] = [m.group(2)]
+    expected = 2
+    i = start + 1
+    in_fence = False
+
+    while i < len(lines):
+        line = lines[i]
+
+        if is_fence(line):
+            in_fence = not in_fence
+            current.append(line)
+            i += 1
+            continue
+
+        if in_fence:
+            current.append(line)
+            i += 1
+            continue
+
+        if HEADING.match(line) or STRUCTURAL.match(line):
+            break
+
+        sm = STEP_START.match(line)
+        if sm:
+            num = int(sm.group(1))
+            if num == expected:
+                steps.append(current)
+                current = [sm.group(2)]
+                expected += 1
+                i += 1
+                continue
+            if num == 1 and expected > 2:
+                # Nested sub-list restart — keep inside current step
+                current.append(line)
+                i += 1
+                continue
+            break
+
+        # Continuation of current step (blank lines, indented text, code-adjacent prose)
+        if line.strip() == "" or not STEP_START.match(line):
+            current.append(line)
+            i += 1
+            continue
+
+        break
+
+    if len(current) > 0 or not steps:
+        steps.append(current)
+
+    if len(steps) < 2:
+        return None
+
+    return steps, i
+
+
+def steps_to_mdx(steps: list[list[str]]) -> list[str]:
+    out = ["<Steps>"]
+    for step_lines in steps:
+        out.append("  <Step>")
+        body = "\n".join(step_lines).strip("\n")
+        if body:
+            for bl in body.split("\n"):
+                out.append(f"  {bl}" if bl else "")
+        out.append("  </Step>")
+        out.append("")
+    out.append("</Steps>")
+    return out
+
+
+def process_file(path: Path) -> bool:
+    lines = path.read_text(encoding="utf-8").split("\n")
+    out: list[str] = []
+    i = 0
+    in_frontmatter = False
+    fm_done = 0
+    changed = False
+
+    while i < len(lines):
+        line = lines[i]
+
+        if i == 0 and line.strip() == "---":
+            in_frontmatter = True
+            fm_done = 1
+        if in_frontmatter:
+            out.append(line)
+            if line.strip() == "---" and fm_done > 0 and i > 0:
+                fm_done += 1
+                if fm_done >= 2:
+                    in_frontmatter = False
+            i += 1
+            continue
+
+        if line.strip().startswith("<Steps>"):
+            # Already wrapped — copy until </Steps>
+            out.append(line)
+            i += 1
+            while i < len(lines) and lines[i].strip() != "</Steps>":
+                out.append(lines[i])
+                i += 1
+            if i < len(lines):
+                out.append(lines[i])
+                i += 1
+            continue
+
+        block = collect_numbered_block(lines, i)
+        if block:
+            steps, end = block
+            out.extend(steps_to_mdx(steps))
+            out.append("")
+            i = end
+            changed = True
+            continue
+
+        out.append(line)
+        i += 1
+
+    if changed:
+        text = "\n".join(out)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        path.write_text(text.rstrip() + "\n", encoding="utf-8")
+    return changed
+
+
+def main() -> None:
+    for path in sorted(APPS_DIR.glob("*.mdx")):
+        if process_file(path):
+            print(f"Updated {path.name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The mintlify-docs directory removal (#4833) dropped two things that existed nowhere else: the Mintlify dev workflow documented in its README, and the Jekyll-to-MDX conversion scripts.

- Rewrite the root README: replace the stale Jekyll/Ruby build instructions, sidebar.yml references and feed-pipeline appendix (infra no longer on this branch) with the Mintlify workflow (mint dev, GitHub-app publishing, docs.json navigation/redirects), keeping the still-relevant writing guidance (guides vs references, categorization, maintainability, style, Javadoc links) with linking conventions updated for MDX.
- Restore the conversion helpers to scripts/ (html_to_mdx.py etc.) for future syncs from master.

The deleted mintlify-docs/LICENSE was the Mintlify starter-kit MIT license, not a Vespa license, and is intentionally not restored.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
