### PR TITLE
Add missing fieldTermMatch outputs

### DIFF
--- a/en/reference/ranking/rank-features.html
+++ b/en/reference/ranking/rank-features.html
@@ -729,11 +729,37 @@ tensor&lt;float&gt;(dim{},off{}):{ {dim:v1,off:0}:1.0, {dim:v2,off:1}:1.0, {dim:
     </p>
   </td></tr>
 
-<tr><td>fieldTermMatch(<em>name</em>,<em>n</em>).occurrences</td>
+<tr><td>fieldTermMatch(<em>name</em>,<em>n</em>).lastPosition</td>
+  <td>1000000</td>
+  <td>
+    <p id="fieldTermMatch(name,n).lastPosition">
+      The position of the last occurrence of this query term in this index field.
+      <a href="rank-feature-configuration.html#fieldTermMatch">numTerms</a> configuration
+    </p>
+  </td></tr>
+
+ <tr><td>fieldTermMatch(<em>name</em>,<em>n</em>).occurrences</td>
   <td>0</td>
   <td>
     <p id="fieldTermMatch(name,n).occurrences">
-      The number of occurrences of this query term in this index field
+      The number of occurrences of this query term in this index field.
+    </p>
+  </td></tr>
+
+<tr><td>fieldTermMatch(<em>name</em>,<em>n</em>).firstPosition</td>
+  <td>0</td>
+  <td>
+    <p id="fieldTermMatch(name,n).weight">
+      The sum of occurrence weights of this term in this index field.
+    </p>
+  </td></tr>
+
+<tr><td>fieldTermMatch(<em>name</em>,<em>n</em>).exactness</td>
+  <td>0</td>
+  <td>
+    <p id="fieldTermMatch(name,n).exactness">
+      The average match exactness this term in this index field.
+      <a href="rank-feature-configuration.html#fieldTermMatch">numTerms</a> configuration
     </p>
   </td></tr>
 


### PR DESCRIPTION
@arnej27959 to make WordAlternative exactness generally useful I think we need to use it in various other rank features and create a few new ones. If you agree i can create a ticket on that.

@kkraune @radu-gheorghe fyi