### PR TITLE
Document the YQL labeled() query operator

### DIFF
--- a/en/reference/querying/yql.html
+++ b/en/reference/querying/yql.html
@@ -771,6 +771,30 @@ where rank(nearestNeighbor(field, queryVector), a contains "A", b contains "B", 
   </tr>
 
   <tr>
+    <th>labeled</th>
+    <td>
+      <p id="labeled">
+      Using <em>labeled(subQuery, "mylabel", 4.25)</em> wraps an arbitrary sub-query with a label
+      "mylabel" and score. If the sub-query matches a document, the score (4.25 in this example)
+      can be picked up by ranking expressions using the
+      <a href="../ranking/rank-features.html#itemRawScore(label)">itemRawScore</a>
+      rank feature.
+      Available since {% include version.html version="8.743.16" %}.
+      Typically used together with the <a href="#rank">rank</a> operator, like this:
+      </p>
+<pre>
+where rank(title contains "running shoes",
+           labeled(memberDiscountPercent >= 20 AND inStock > 0, "memberDiscount", 2.0),
+           labeled(premiumBrand = true OR todaysFeaturedBrand = true, "premiumOrFeaturedBrand", 1.0))
+</pre>
+      <p>And a ranking profile could use</p>
+<pre>
+  expression: bm25(title) + itemRawScore(memberDiscount) + 31.5 * itemRawScore(premiumOrFeaturedBrand)
+</pre>
+    </td>
+  </tr>
+
+  <tr>
     <th>in</th>
     <td>
       <p id="in">


### PR DESCRIPTION
Vespa 8.743.16 adds labeled(subQuery, "label", score), which wraps an arbitrary sub-query in a labeled item carrying a raw score. Until now labels could only be attached with the {label: "..."} annotation, and there was no way to give a sub-query an explicit score for ranking.

Add a reference entry for the operator in the YQL query operator table, next to rank(), explaining that the score is exposed to ranking expressions through itemRawScore(label). The example shows the intended use: retrieve on the main query with rank(), then let labeled() clauses contribute boosts without affecting matching, combined them in a rank profile expression.
