### PR TITLE
Relate labeled() to equivalent operators in other search engines

### DIFF
--- a/en/reference/querying/yql.html
+++ b/en/reference/querying/yql.html
@@ -791,6 +791,11 @@ where rank(title contains "running shoes",
 <pre>
   expression: bm25(title) + itemRawScore(memberDiscount) + 31.5 * itemRawScore(premiumOrFeaturedBrand)
 </pre>
+      <p>
+      This is similar to Lucene's <code>ConstantScoreQuery</code>,
+      often used in Elasticsearch/OpenSearch through
+      <code>function_score</code> or in Solr with <code>^=</code> query syntax.
+      </p>
     </td>
   </tr>
 


### PR DESCRIPTION
Add a short note to the labeled() reference documentation pointing out that it plays the same role as Lucene's ConstantScoreQuery, reached via function_score in Elasticsearch/OpenSearch and via the ^= syntax in Solr.

Why: users migrating from those engines look for a way to attach a fixed score contribution to a sub-query without letting it affect matching. Naming the operator they already know makes labeled() discoverable from that starting point, instead of leaving them to infer the mapping from the Vespa-specific description of labels and itemRawScore.
