### PR TITLE
Add guidance on aggregating over large result sets

### DIFF
--- a/en/learn/faq.md
+++ b/en/learn/faq.md
@@ -298,6 +298,16 @@ Pass [ranking.profile=unranked](../reference/api/query.html#ranking.profile)
 to make the query less expensive to run.
 If an _estimate_ is good enough, use [hitcountestimate=true](../reference/api/query.html#hitcountestimate).
 
+### How to make grouping over many documents, like category counts, less expensive?
+Grouping is evaluated over every matched document on every content node,
+so a query like `where true | all(group(category) each(output(count())))` touches the full corpus on every query.
+Request no hits, use the `unranked` rank profile and set `max` on the grouping to reduce the work.
+
+If approximate counts are acceptable, group over a random 1% sample of the documents and scale the counts.
+
+If the same counts are requested by many users, compute them once and cache them in a Searcher.
+See [aggregating over large result sets](../querying/grouping.html#aggregating-over-large-result-sets).
+
 ### Must all fields in a fieldset have compatible type and matching settings?
 Yes - a deployment warning with _This may lead to recall and ranking issues_ is emitted
 when fields with conflicting tokenization are put in the same

--- a/en/performance/feature-tuning.html
+++ b/en/performance/feature-tuning.html
@@ -481,6 +481,15 @@ For most use cases, the time spent on dictionary traversal is negligible compare
 query evaluation (matching and ranking). If the query is very selective, for example, using
 vespa as a key-value lookup store with ranking support, the dictionary traversal time can be significant.'%}
 
+<h2 id="grouping-and-aggregation">Grouping and aggregation</h2>
+<p>
+  <a href="../querying/grouping.html">Grouping</a> is evaluated over every matched document on every content node,
+  so aggregating over a large result set is expensive.
+  See <a href="../querying/grouping.html#aggregating-over-large-result-sets">aggregating over large result sets</a>
+  for how to reduce the work per query and how to compute approximate counts from a corpus sample.
+</p>
+
+
 <h2 id="document-summaries-hits">Document summaries - hits</h2>
 <p>
   If queries request many (thousands) of hits from a content cluster with few content nodes,

--- a/en/performance/sizing-search.html
+++ b/en/performance/sizing-search.html
@@ -217,7 +217,9 @@ Components Involved in query execution:
   <li>Calculating the score (which might be a text ranking relevancy score or
       the inferred score of a Machine Learned model) of each hit,
       using the chosen rank-profile. See <a href="../basics/ranking.html">ranking with Vespa</a>.</li>
-  <li>Aggregating information over all the generated hits using <a href="../querying/grouping.html">result grouping</a>.</li>
+  <li>Aggregating information over all the generated hits using <a href="../querying/grouping.html">result grouping</a>.
+      The cost is proportional to the number of hits, see
+      <a href="../querying/grouping.html#aggregating-over-large-result-sets">aggregating over large result sets</a>.</li>
   <li>Sorting hits on relevancy score (text ranking) or inference score (e.g. ML model serving),
       or on attribute(s).
       See <em>max-hits-per-partition</em> and <em>top-k-probability</em> in

--- a/en/querying/grouping.html
+++ b/en/querying/grouping.html
@@ -819,6 +819,96 @@ all(
   The default precision may not achieve the required correctness for your use case.
 </p>
 
+<h2 id="aggregating-over-large-result-sets">Aggregating over large result sets</h2>
+<p>
+  Grouping is evaluated on every content node, over every document matching the query.
+  A query like
+</p>
+<pre class="no-transform">select * from product where true | all(group(category) each(output(count())))</pre>
+<p>
+  matches every document and feeds every match through the grouping engine, on every query.
+  The cost is proportional to the number of matched documents,
+  not to the number of groups returned.
+  Category counts for navigation in an e-commerce application is a typical example.
+</p>
+
+<h3 id="reduce-the-work-per-query">Reduce the work per query</h3>
+<ul>
+  <li>
+    Set <a href="../reference/api/query.html#hits">hits=0</a> (<code>limit 0</code> in YQL)
+    when only the aggregates are needed, so no document summaries are fetched.
+  </li>
+  <li>
+    Use the built-in <a href="../basics/ranking.html">unranked</a> rank profile
+    (<code>ranking.profile=unranked</code>) when the grouping does not use relevance,
+    so no rank score is computed for the matched documents.
+  </li>
+  <li>
+    Use <a href="#ordering-and-limiting-groups">max</a> on every grouping level and set
+    <a href="#global-limit">globalMaxGroups</a>.
+    This bounds the result size and the merge cost,
+    but does not reduce the number of documents evaluated.
+  </li>
+</ul>
+
+<h3 id="approximate-counts-from-a-corpus-sample">Approximate counts from a corpus sample</h3>
+<p>
+  When approximate counts are acceptable, aggregate over a random sample of the documents and scale the result.
+  Assign each document to one of 100 sample buckets in a synthetic field, using
+  <a href="../reference/writing/indexing-language.html#random">random</a>:
+</p>
+<pre class="no-transform">
+schema product {
+    document product {
+        field category type string {
+            indexing: attribute | summary
+        }
+    }
+    field sample_bucket type int {
+        indexing: random 100 | attribute
+        attribute: fast-search
+        rank: filter
+    }
+}
+</pre>
+<p>
+  <code>random 100</code> draws a uniformly distributed integer in the range [0, 100) when the document is put,
+  independent of the document content.
+  A partial update of other fields keeps the value; a new put of the document draws a new value.
+  Add the bucket as a filter to the query:
+</p>
+<pre class="no-transform">select * from product where sample_bucket = 0 limit 0 | all(group(category) each(output(count())))</pre>
+<p>
+  Multiply each count by 100 to estimate the count over the full corpus.
+  With <code>fast-search</code>, the filter is evaluated using the attribute's index instead of scanning all documents,
+  so both matching and grouping process only the sampled 1% of the corpus.
+  The filter combines with any other query terms, e.g. <code>where userQuery() and sample_bucket = 0</code>;
+  since the bucket is independent of the query, the matched set is sampled at the same rate.
+</p>
+<p>
+  The estimate for a group with <em>k</em> sampled documents is 100<em>k</em>,
+  with a relative standard error of approximately 1/&radic;<em>k</em>.
+  A group with 1000 sampled documents has a standard error of about 3%,
+  a group with 100 sampled documents about 10%.
+  Choose the sampling fraction from the smallest group that must be estimated with acceptable precision,
+  and use an exact query for groups with too few sampled documents.
+</p>
+<p>
+  Hits and grouping are computed over the same matched set,
+  so the sample filter also applies to the returned hits and to <code>totalCount</code>.
+  Use a separate query without the filter for the hits shown to the user.
+</p>
+
+<h3 id="caching-aggregates">Caching aggregates</h3>
+<p>
+  If the same aggregation is requested frequently and the result does not depend on the user,
+  such as category counts for a navigation menu, compute it once and serve it from a cache in a
+  <a href="../applications/searchers.html">Searcher</a>.
+  The FAQ has an example of a
+  <a href="../learn/faq.html#how-to-create-a-cache-that-refreshes-itself-regularly">component that refreshes a cache on a schedule</a>
+  by issuing the query itself, so the cost is paid at a fixed rate instead of per user query.
+</p>
+
 <h2 id="nested-groups">Nested Groups</h2>
 <p>
 Groups can be nested. This offers great drilling capabilities,


### PR DESCRIPTION
Grouping over a large matched set, such as category counts over the full corpus, is a common thing users want to do, causing issues if done frequently.

Adds a section to the grouping guide describing how to reduce the work per query, how to compute approximate counts from a random 1% sample using a synthetic random field, and when to cache aggregates in a Searcher. Link to it from the FAQ and the performance docs.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
