### PR TITLE
Add struct-field selection in document-summary blocks

### DIFF
--- a/en/reference/schemas/schemas.html
+++ b/en/reference/schemas/schemas.html
@@ -4473,6 +4473,32 @@ This is mainly useful for <a href="../../querying/text-matching.html#tokens-exam
 </p>
 </td>
 </tr>
+<tr><td>struct-field</td>
+  <td>Zero to many</td>
+  <td>
+    <p id="document-summary-struct-field">
+    Only valid inside a field of "array of struct" or "map of struct" type,
+    inside an explicit <a href="#document-summary">document-summary</a> block.
+    Selects struct sub-fields to include in this document summary:
+    </p>
+<pre>
+document-summary mysmallsum {
+  summary myarrayfield {
+    struct-field: a
+    struct-field: b, c
+  }
+  summary mymapfield {
+    struct-field: key, value.d
+  }
+}
+</pre>
+    <p>
+    If not specified all sub-fields will be included. For maps of structs the
+    "key" field must be included, and at least one of the "value.[name]"
+    subfields as well.
+    </p>
+  </td>
+</tr>
 </tbody>
 </table>
 <p>


### PR DESCRIPTION
Add reference documentation for the "struct-field" property, which lets a document-summary select a subset of a struct's sub-fields (for array-of-struct and map-of-struct fields) instead of returning them all, so users have a documented syntax and constraints (e.g. map summaries must include "key" and at least one "value.*" field) to follow when trimming summary payload size.
